### PR TITLE
use gemini-2.5-pro model

### DIFF
--- a/goose-container/goose-config.yaml
+++ b/goose-container/goose-config.yaml
@@ -1,5 +1,5 @@
 GOOSE_PROVIDER: google
-GOOSE_MODEL: gemini-2.5-pro-preview-06-05
+GOOSE_MODEL: gemini-2.5-pro
 GOOSE_RECIPE_GITHUB_REPO: packit/ai-workflows
 extensions:
   developer:


### PR DESCRIPTION
Let's ditch the preview as 2.5 pro is already available now.