### PR TITLE
reverse-dependencies: Compute indirect dependents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 .PHONY: rebase-package
 .PHONY: reverse-dependencies
 .PHONY: test-package
+.PHONY: test-reverse-dependencies
 .PHONY: triage-issue
 .PHONY: backport-fix
 
@@ -42,6 +43,13 @@ test-package: PACKAGE ?= podman
 test-package: DIST_GIT_BRANCH ?= c10s
 test-package: GIT_URL ?= https://gitlab.com/redhat/centos-stream/rpms
 test-package: RPM_COMPOSE ?= CentOS-Stream-10
+
+test-reverse-dependencies: ARCH ?= x86_64
+test-reverse-dependencies: PACKAGE ?= podman
+test-reverse-dependencies: CHANGE ?=
+test-reverse-dependencies: DIST_GIT_BRANCH ?= c10s
+test-reverse-dependencies: GIT_URL ?= https://gitlab.com/redhat/centos-stream/rpms
+test-reverse-dependencies: RPM_COMPOSE ?= CentOS-Stream-10
 
 triage-issue: ISSUE ?= RHEL-78418
 
@@ -145,6 +153,17 @@ test-package:
 			--params dist_git_branch=$(DIST_GIT_BRANCH) \
 			--params compose=$(RPM_COMPOSE)"
 
+test-reverse-dependencies:
+	$(COMPOSE) run --rm \
+		--entrypoint /bin/sh goose \
+		-c "/usr/local/bin/goose run --recipe recipes/test-reverse-dependencies.yaml \
+			--params arch=$(ARCH) \
+			--params package=$(PACKAGE) \
+			--params change='$(CHANGE)' \
+			--params git_url=$(GIT_URL) \
+			--params dist_git_branch=$(DIST_GIT_BRANCH) \
+			--params compose=$(RPM_COMPOSE)"
+
 config: GLOBAL_TEMPLATE = templates/compose.env
 config: SECRET_TEMPLATES = $(filter-out $(GLOBAL_TEMPLATE), $(wildcard templates/*))
 config:
@@ -170,5 +189,6 @@ help:
 	@echo "  run-goose                   - Run goose interactively"
 	@echo "  run-goose-bash              - Run goose with bash shell"
 	@echo "  test-package                - Submit package testing request to testing farm"
+	@echo "  test-reverse-dependencies   - Test all reverse dependencies of a package"
 	@echo "  <recipe>                    - To run the recipes/<recipe>.yaml"
 	@echo "  clean                       - Stop all services and clean volumes"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: help
 .PHONY:
 .PHONY: # Manage container image
-.PHONY: clean build config
+.PHONY: clean build debug-build config
 .PHONY:
 .PHONY: # Manage MCP server for JIRA
 .PHONY: stop-mcp-atlassian run-mcp-atlassian logs-mcp-atlassian
@@ -47,6 +47,9 @@ triage-issue: ISSUE ?= RHEL-78418
 ## Operations
 build:
 	$(COMPOSE) build
+
+debug-build:
+	BUILD_TARGET=debug $(COMPOSE) build
 
 run-mcp-atlassian:
 	$(COMPOSE) up -d mcp-atlassian
@@ -155,6 +158,7 @@ help:
 	@echo "Available targets:"
 	@echo "  config                      - Copy config templates to .secrets/ and .env"
 	@echo "  build                       - Build all images"
+	@echo "  debug-build                 - Build all images and rebuild goose from source"
 	@echo "  run-mcp-atlassian           - Start Atlassian MCP server in background"
 	@echo "  stop-mcp-atlassian          - Stop Atlassian MCP server"
 	@echo "  logs-mcp-atlassian          - Show Atlassian MCP server logs"

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ rebase-package: PACKAGE ?= cockpit
 rebase-package: VERSION ?= 339
 rebase-package: JIRA_ISSUES ?= "RHEL-123"
 
+reverse-dependencies: ARCH ?= x86_64
 reverse-dependencies: PACKAGE ?= podman
 
 test-package: PACKAGE ?= podman
@@ -132,6 +133,7 @@ reverse-dependencies:
 	$(COMPOSE) run --rm \
 		--entrypoint /bin/sh goose \
 		-c "/usr/local/bin/goose run --recipe recipes/reverse-dependencies.yaml \
+			--params arch=$(ARCH) \
 			--params package=$(PACKAGE)"
 
 test-package:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@
 .PHONY: test-reverse-dependencies
 .PHONY: triage-issue
 .PHONY: backport-fix
+.PHONY:
+.PHONY: # Development and testing
+.PHONY: check check-find-package-dependents-script
 
 ## Defaults
 COMPOSE ?= podman compose
@@ -175,6 +178,11 @@ clean:
 	$(COMPOSE) down
 	podman volume prune -f
 
+check: check-find-package-dependents-script
+
+check-find-package-dependents-script:
+	cd scripts && python tests/test-find-package-dependents.py
+
 help:
 	@echo "Available targets:"
 	@echo "  config                      - Copy config templates to .secrets/ and .env"
@@ -191,4 +199,5 @@ help:
 	@echo "  test-package                - Submit package testing request to testing farm"
 	@echo "  test-reverse-dependencies   - Test all reverse dependencies of a package"
 	@echo "  <recipe>                    - To run the recipes/<recipe>.yaml"
+	@echo "  check                       - Run all development tests"
 	@echo "  clean                       - Stop all services and clean volumes"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ If you need to change the llm provider and model, they are stored in the Goose c
 
 ## Build
 
-`make build`
-
+- `make build` This builds the goose image using an officially released goose binaries
+- `make debug-build` This builds the goose image using a rebuild of goose from git. `*.patch` in `goose-container/` are applied to the git tree before building.
 ## Run Goose - interactively - with the MCP Atlassian server
 
 To run goose interactively, don't be tempted to run `podman compose up` or similar, because input from your terminal might not be directed to the Goose container. Instead use:

--- a/compose.yaml
+++ b/compose.yaml
@@ -42,6 +42,7 @@ services:
       target: ${BUILD_TARGET:-production}
       args:
         BASE_IMAGE: registry.fedoraproject.org/fedora@sha256:3b94b23378c64850f5e2a83d0da4471fab0716d35a2662a794cfeb63b5e6fccd
+        GOOSE_VERSION: v1.1.3
     env_file:
       - .secrets/goose.env
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -37,8 +37,11 @@ services:
       mcp-testing-farm: { condition: service_healthy }
     image: goose-container
     build:
-      context: ./goose-container
-      dockerfile: Containerfile
+      context: .
+      dockerfile: ./goose-container/Containerfile
+      target: ${BUILD_TARGET:-production}
+      args:
+        BASE_IMAGE: registry.fedoraproject.org/fedora@sha256:3b94b23378c64850f5e2a83d0da4471fab0716d35a2662a794cfeb63b5e6fccd
     env_file:
       - .secrets/goose.env
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -49,6 +49,7 @@ services:
       - home-goose-persistent:/home/goose
       - ./goose-recipes:/home/goose/recipes:ro,z
       - ./goose-container/goose-config.yaml:/home/goose/.config/goose/config.yaml:ro,z
+      - ./scripts:/home/goose/scripts:ro,z
     stdin_open: true
     tty: true
     restart: "no"

--- a/goose-container/Containerfile
+++ b/goose-container/Containerfile
@@ -30,7 +30,8 @@ RUN dnf install -y \
         rpmbuild \
         spectool \
         rpmlint \
-        centpkg
+        centpkg \
+        wget
 
 RUN useradd -m -G wheel goose \
  && echo '%wheel ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel-nopasswd \

--- a/goose-container/Containerfile
+++ b/goose-container/Containerfile
@@ -1,17 +1,27 @@
-# This Containerfile contains two stages:
+# This Containerfile contains several stages:
 #
 #     runtime-platform: Fedora base image with the required dependencies
 #     added on top to run goose.
 #
 #     production: Official goose builds installed on top of runtime-platform
+#
+#     source-build: Fedora base image with goose built from
+#     git on top. It applies all the patches in goose-container
+#     as well. This is useful for instrumenting goose with
+#     extra debug logging, etc.
+#
+#     debug: Custom built Goose installed on top of runtime-platform
+#     This is useful for trying out the instrumented goose builds.
 
 ARG BASE_IMAGE=registry.fedoraproject.org/fedora:42
+ARG GOOSE_VERSION=v1.1.3
 
 #
 # runtime-platform: Fedora base image with the required dependencies to added to
 # run goose.
 #
 FROM ${BASE_IMAGE} AS runtime-platform
+
 RUN dnf install -y \
         libxcb \
         python3 \
@@ -47,10 +57,50 @@ FROM runtime-platform AS production
 
 USER root
 
-RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | \
+RUN curl -fsSL https://github.com/block/goose/releases/download/${GOOSE_VERSION}/download_cli.sh | \
     GOOSE_BIN_DIR=/usr/local/bin CONFIGURE=false bash
 
 USER goose
+
+ENTRYPOINT ["/usr/local/bin/goose"]
+
+FROM ${BASE_IMAGE} AS source-build
+
+RUN dnf install -y \
+        git \
+        rust \
+        cargo \
+        protobuf-compiler \
+        protobuf-devel \
+        libxcb-devel
+
+ARG GOOSE_REPO=https://github.com/block/goose.git
+ARG GOOSE_VERSION
+
+WORKDIR /usr/src
+RUN git clone --depth 1 \
+    --branch "${GOOSE_VERSION}" \
+    "${GOOSE_REPO}" \
+    goose-src
+
+WORKDIR /usr/src/goose-src
+COPY goose-container/*.patch patches/
+
+RUN cargo fetch --locked
+
+RUN git config --global user.email "rhel-packaging-agent@redhat.com" \
+ && git config --global user.name "RHEL Packaging Agent"
+
+RUN cargo build --release -p goose-cli
+
+RUN git am patches/*.patch \
+ && cargo build --release -p goose-cli
+
+#
+# debug: Custom built Goose installed on top of runtime-platform
+#
+FROM runtime-platform AS debug
+COPY --from=source-build /usr/src/goose-src/target/release/goose /usr/local/bin/goose
 
 ENTRYPOINT ["/usr/bin/bash"]
 CMD ["-c", ". ~/.bashrc; /usr/local/bin/goose"]

--- a/goose-container/Containerfile
+++ b/goose-container/Containerfile
@@ -1,17 +1,56 @@
-FROM fedora:42
+# This Containerfile contains two stages:
+#
+#     runtime-platform: Fedora base image with the required dependencies
+#     added on top to run goose.
+#
+#     production: Official goose builds installed on top of runtime-platform
 
-RUN dnf install -y libxcb python3 gh glab rpmbuild spectool rpmlint centpkg
+ARG BASE_IMAGE=registry.fedoraproject.org/fedora:42
 
-RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | GOOSE_BIN_DIR=/usr/local/bin CONFIGURE=false bash
+#
+# runtime-platform: Fedora base image with the required dependencies to added to
+# run goose.
+#
+FROM ${BASE_IMAGE} AS runtime-platform
+RUN dnf install -y \
+        libxcb \
+        python3 \
+        gh \
+        glab \
+        rpmbuild \
+        spectool \
+        rpmlint \
+        centpkg
 
-RUN useradd -m -G wheel goose && echo '%wheel ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel-nopasswd
+RUN useradd -m -G wheel goose \
+ && echo '%wheel ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel-nopasswd \
+ && mkdir -p /home/goose/.config/goose /home/goose/recipes /home/goose/scripts \
+ && chown -R goose:goose /home/goose
 
-RUN mkdir -p /home/goose/.config/goose /home/goose/recipes
-COPY ./goose-config.yaml /home/goose/.config/goose/config.yaml
-RUN chown -R goose:goose /home/goose/.config
+COPY --chown=goose:goose \
+     goose-container/goose-config.yaml \
+     /home/goose/.config/goose/config.yaml
+COPY --chown=goose:goose \
+     goose-recipes/ \
+     /home/goose/recipes/
+COPY --chown=goose:goose \
+     scripts/ \
+     /home/goose/scripts/
 
 USER goose
 WORKDIR /home/goose
+
+#
+# production: Official goose builds installed on top of runtime-platform
+#
+FROM runtime-platform AS production
+
+USER root
+
+RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | \
+    GOOSE_BIN_DIR=/usr/local/bin CONFIGURE=false bash
+
+USER goose
 
 ENTRYPOINT ["/usr/bin/bash"]
 CMD ["-c", ". ~/.bashrc; /usr/local/bin/goose"]

--- a/goose-recipes/reverse-dependencies.yaml
+++ b/goose-recipes/reverse-dependencies.yaml
@@ -1,30 +1,49 @@
 version: 0.1.0
 title: "Find reverse dependencies of an RPM package"
-description: "Find the reverse dependencies of the {{ package }} package.  That is all packages that directly or transitively depend on the {{ package }} package."
+description: "Find the reverse dependencies of the {{ package }} package for the architecture {{ arch }}. That is all packages that directly or transitively depend on the {{ package }} package on the architecture {{ arch }}."
 
 instructions: |
-  A couple of rules that you must follow and useful information for you:
-    * Work only in a temporary directory that you can create with the mktemp tool.
-    * Run `dnf repoquery --whatdepends` to determine the direct reverse dependencies of a package.
-    * Download the RPM .repo files with curl and make sure to ignore certificates.
-    * Before executing any command, print the plan and the steps you want to take.
+  * Before starting, create a temporary directory via mktemp that will be your working directory.
+  * For clarity, always use full, absolute paths for file I/O.
+  * Run all steps in a single shell command, so they share an environment
 
 parameters:
+- key: arch
+  input_type: string
+  requirement: required
+  description: The architecture of the platform to look for dependencies in
 - key: package
   input_type: string
   requirement: required
   description: The package for which to find reverse dependencies.
 
 prompt: |
-  You are an AI agent to list all direct and transitive reverse dependencies of a given RPM package.  As input you will receive the name of the package.  A reverse dependency package is one that depends on the input package.  As output you must print one list for the direct reverse dependencies, and another list for the transitive reverse dependencies.  Follow the below steps in the given order:
+  You are an AI agent to list direct and transitive reverse dependencies of a given RPM package. As input, receive the package name and target architecture. Output two files and print their contents: `{{ package }}-reverse-deps.txt` and `{{ package }}-all-reverse-deps.json`.
 
-  1. First, remove all other .repo files in /etc/yum.repos.d/.  That will implicitly disable all of them.
+  Steps:
 
-  2. Then download the RPM .repo file from the following source: https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10/repofile.repo
-    * Use curl and the -k flag to ignore certificates.
-    * If you face errors during the download, print them and exit.
-    * Do not attempt to download any other file.
-    * Copy the file to the /etc/yum/repos.d directory.
+  1. Save the location of the `scripts/` directory for later use in an environment variable, and then create and enter a unique working directory:
+     ```bash
+     scriptsdir=$(pwd)/scripts
+     workingdir=$(realpath $(mktemp -d "{{ package }}.XXXXX"))
+     cd "$workingdir"
+     ```
 
-  # TODO: experiment with this first and then tackle transitive dependencies later
-  2. Find the direct reverse dependencies of {{ package }} and print them in a pretty list.
+  2. Define the repository URL:
+     ```bash
+     baseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10/
+     ```
+
+  3. Query direct-only reverse dependencies as a flat list by running the helper script:
+     ```bash
+     $scriptsdir/find-package-dependents.py --base-url $baseurl --format plain '{{ package }}' \
+     --output-file "$workingdir/{{ package }}-reverse-deps.txt"
+     ```
+
+  4. Query all direct and indirect reverse dependencies as JSON by running the helper script:
+     ```bash
+     $scriptsdir/find-package-dependents.py --base-url $baseurl --all --format=json '{{ package }}' \
+     --output-file "$workingdir/{{ package }}-all-reverse-deps.json"
+     ```
+
+  5. Read the output files "$workingdir/{{ package }}-reverse-deps.txt" and "$workingdir/{{ package }}-all-reverse-deps.json" and read them back to me.

--- a/goose-recipes/test-reverse-dependencies.yaml
+++ b/goose-recipes/test-reverse-dependencies.yaml
@@ -1,0 +1,81 @@
+version: 0.1.0
+title: "Test reverse dependencies of an RPM package"
+description: >-
+  Find all reverse dependencies of the {{ package }} package for architecture {{ arch }},
+  convert them to source packages, and run Testing Farm tests for each source package
+  on branch {{ dist_git_branch }} against compose {{ compose }}.
+
+instructions: |
+  * Before starting, create a temporary directory via mktemp that will be your working directory.
+  * For clarity, always use full, absolute paths for file I/O.
+  * Run all steps that need to share an environment in a single shell command session.
+  * First find all reverse dependencies and convert them to source packages.
+  * Then submit Testing Farm requests for the selected subset of those source packages.
+
+parameters:
+  - key: arch
+    input_type: string
+    requirement: required
+    description: The architecture of the platform to look for dependencies in
+  - key: package
+    input_type: string
+    requirement: required
+    description: The package for which to find reverse dependencies and test them
+  - key: git_url
+    input_type: string
+    requirement: required
+    description: Base URL of the dist-git project
+  - key: baseurl
+    input_type: string
+    requirement: optional
+    default: http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10/
+    description: Location of repos to query for dependencies
+  - key: dist_git_branch
+    input_type: string
+    requirement: required
+    description: Branch in the dist-git repository
+  - key: compose
+    input_type: string
+    requirement: required
+    description: Testing Farm compose to use
+  - key: max_results
+    input_type: string
+    requirement: optional
+    default: 50
+    description: Maximum number of reverse dependencies to fetch from repeated dnf queries
+  - key: number_of_requests
+    input_type: string
+    requirement: optional
+    default: 10
+    description: The number of testing farm requests to initiate
+  - key: change
+    input_type: string
+    requirement: optional
+    default: (no relevant changes)
+    description: A pertinent change to the package relevant to which dependent tests should run
+
+prompt: |
+  You are an AI agent to find reverse dependencies of a given RPM package and test each source package. Please follow the following steps:
+
+  1. Query the first {{ max_results }} direct and indirect reverse dependencies as source packages along with their descriptions by running the helper script:
+     ```bash
+       workingdir=$(mktemp "$PWD/{{ package }}.reverse-deps-tests.XXXXXX")
+       $(pwd)/scripts/find-package-dependents.py --base-url {{ baseurl }} --all --describe --max-results {{ max_results }} --source-packages --format=plain '{{ package }}' \
+       --filter-command 'wget --spider -q https://gitlab.com/redhat/centos-stream/rpms/$PACKAGE/-/raw/{{ dist_git_branch }}/.fmf/version' \
+       --log-file "$workingdir/{{ package }}-logs.txt" \
+       --verbose \
+       --output-file "$workingdir/{{ package }}-source-deps.txt"
+     ```
+     Read the source packages list from "$workingdir/{{ package }}-source-deps.txt" and read it back to me.
+
+  2. Select no more than {{ number_of_requests }} source packages from the list that would be good candidates for testing. Use your pre-existing knowledge of what the packages do, along with their provided descriptions, and how they relate to {{ package }} to make selections. Also, consider this relevant change to {{ package }} when deciding which dependents to test:
+
+  ```text
+  {{ change }}
+  ```
+
+  3. For each selected source package, submit a Testing Farm request using the git url {{ git_url }}/<source package>.git and the branch {{ dist_git_branch }} and the compose {{ compose }}.
+
+  4. Track the job IDs and write the results as JSON in a file called "$workingdir/jobs.json". The jobs should be of the form `[{ package: "<package-name>", jobId: "<uuid>" }, ... ]`. Use those object properties specifically and exactly, so it can be machine parsed later.
+
+  5. Finally, as a last step, Tell me where $workingdir is on the filesystem and read back "$workingdir/jobs.json" to me. Do not clean up the contents of $workingdir. They will be harvested as workflow artifacts.

--- a/scripts/find-package-dependents.py
+++ b/scripts/find-package-dependents.py
@@ -1,0 +1,1682 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import os
+import re
+import shlex
+import signal
+import subprocess
+import sys
+from collections import deque
+from hashlib import sha256
+from pathlib import Path
+from typing import Dict, List, Set, Generator, Any
+from urllib.parse import urlparse
+
+
+EXIT_SUCCESS = 0
+EXIT_REPO_QUERY_ERROR = 1
+EXIT_NO_DEPENDENTS_FOUND = 2
+EXIT_INVALID_ARGUMENTS = 3
+EXIT_CACHE_UPDATE_ERROR = 4
+EXIT_PACKAGE_NOT_FOUND = 5
+
+KNOWN_ARCHS: Set[str] = {"x86_64", "aarch64", "ppc64le", "s390x", "noarch"}
+
+
+class RepoQueryMetrics:
+    """
+    Tracks metrics for dnf repoquery calls.
+
+    This class focuses purely on metrics gathering:
+    - Call counting by type
+    - Statistics generation
+    """
+
+    def __init__(self):
+        self._call_count: int = 0
+        self._calls_by_type: Dict[str, int] = {}
+        self._filter_calls: int = 0
+        self._filter_failures: int = 0
+
+    def log_call(self, purpose: str, package_name: str) -> None:
+        """
+        Log a dnf repoquery call with detailed information.
+
+        Args:
+            purpose: The purpose of the repoquery call (e.g., 'find_direct_dependents')
+            package_name: The package being queried
+        """
+        self._call_count += 1
+        self._calls_by_type[purpose] = self._calls_by_type.get(purpose, 0) + 1
+
+    def log_filter_call(self, package_name: str, success: bool) -> None:
+        """
+        Log a filter command call.
+
+        Args:
+            package_name: The package being filtered
+            success: Whether the filter command succeeded
+        """
+        self._filter_calls += 1
+        if not success:
+            self._filter_failures += 1
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        Get current statistics about dnf repoquery usage.
+
+        Returns:
+            Dictionary containing statistics about dnf repoquery calls
+        """
+        return {
+            "total_calls": self._call_count,
+            "calls_by_type": self._calls_by_type.copy(),
+            "filter_calls": self._filter_calls,
+            "filter_failures": self._filter_failures,
+        }
+
+
+class SourcePackageCache:
+    """
+    Caches source package mappings for performance optimization.
+
+    This class handles the caching of binary package to source package mappings
+    to avoid repeated repoquery calls for the same package.
+    """
+
+    def __init__(self):
+        self._cache: Dict[str, str] = {}
+
+    def get(self, package_name: str) -> str | None:
+        """
+        Get a cached source package name.
+
+        Args:
+            package_name: The binary package name
+
+        Returns:
+            The cached source package name, None if not cached, or '' if package not found
+        """
+        return self._cache.get(package_name)
+
+    def set(self, package_name: str, source_package_name: str | None) -> None:
+        """
+        Cache a source package mapping.
+
+        Args:
+            package_name: The binary package name
+            source_package_name: The source package name, or '' if package not found
+        """
+        self._cache[package_name] = source_package_name
+        if source_package_name == '':
+            logging.debug(f"   Cached package not found: {package_name} → not found")
+        else:
+            logging.debug(f"   Cached source package mapping: {package_name} → {source_package_name}")
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        Get cache statistics.
+
+        Returns:
+            Dictionary containing cache statistics
+        """
+        found_count = sum(1 for result in self._cache.values() if result is not None)
+        not_found_count = len(self._cache) - found_count
+        return {
+            "cache_size": len(self._cache),
+            "found_count": found_count,
+            "not_found_count": not_found_count,
+            "cached_packages": list(sorted(self._cache.keys())),
+        }
+
+
+class FilterCache:
+    """
+    Caches filter command results for performance optimization.
+
+    This class handles the caching of filter command results to avoid running
+    the same filter command multiple times for the same package.
+    """
+
+    def __init__(self):
+        self._cache: Dict[str, bool] = {}
+
+    def get(self, package_name: str) -> bool | None:
+        """
+        Get a cached filter result.
+
+        Args:
+            package_name: The package name
+
+        Returns:
+            The cached filter result (True if package passed filter, False if failed), or None if not cached
+        """
+        return self._cache.get(package_name)
+
+    def set(self, package_name: str, passed_filter: bool) -> None:
+        """
+        Cache a filter result.
+
+        Args:
+            package_name: The package name
+            passed_filter: Whether the package passed the filter (True) or failed (False)
+        """
+        self._cache[package_name] = passed_filter
+        logging.debug(f"   Cached filter result: {package_name} → {'pass' if passed_filter else 'fail'}")
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        Get cache statistics.
+
+        Returns:
+            Dictionary containing cache statistics
+        """
+        passed_count = sum(1 for result in self._cache.values() if result)
+        failed_count = len(self._cache) - passed_count
+        return {
+            "cache_size": len(self._cache),
+            "passed_count": passed_count,
+            "failed_count": failed_count,
+            "cached_packages": list(sorted(self._cache.keys())),
+        }
+
+
+class DependencyCache:
+    """
+    Caches dependency query results for performance optimization.
+
+    This class handles the caching of dnf repoquery --whatdepends results to avoid
+    repeated calls for the same package. It also tracks whether the cached results
+    are partial (limited by max_results) or complete.
+    """
+
+    def __init__(self):
+        self._cache: Dict[str, Dict[str, Any]] = {}
+
+    def get(self, package_name: str) -> List[str] | None:
+        """
+        Get cached dependencies for a package.
+
+        Args:
+            package_name: The package name
+
+        Returns:
+            The cached list of dependent packages, or None if not cached
+        """
+        entry = self._cache.get(package_name)
+        if entry is not None:
+            return entry["dependents"]
+        return None
+
+    def has(self, package_name: str) -> bool:
+        """
+        Check if a package has any cached results (partial or complete).
+
+        Args:
+            package_name: The package name
+
+        Returns:
+            True if the package has cached results, False otherwise
+        """
+        return package_name in self._cache
+
+    def has_all(self, package_name: str) -> bool:
+        """
+        Check if a package has complete (non-partial) cached results.
+
+        Args:
+            package_name: The package name
+
+        Returns:
+            True if the package has complete cached results, False otherwise
+        """
+        entry = self._cache.get(package_name)
+        if entry is not None:
+            return not entry["partial"]
+        return False
+
+    def set(self, package_name: str, dependents: List[str], partial: bool = False) -> None:
+        """
+        Cache dependency results for a package.
+
+        Args:
+            package_name: The package name
+            dependents: List of dependent package names
+            partial: Whether the results are partial (limited by max_results)
+        """
+        self._cache[package_name] = {
+            "dependents": dependents,
+            "partial": partial
+        }
+        partial_info = " (partial)" if partial else ""
+        logging.debug(f"   Cached dependency results: {package_name} → {len(dependents)} dependents{partial_info}")
+
+    def get_stats(self) -> Dict[str, Any]:
+        """
+        Get cache statistics.
+
+        Returns:
+            Dictionary containing cache statistics
+        """
+        total_dependents = sum(len(entry["dependents"]) for entry in self._cache.values())
+        partial_count = sum(1 for entry in self._cache.values() if entry["partial"])
+        complete_count = len(self._cache) - partial_count
+        return {
+            "cache_size": len(self._cache),
+            "total_dependents": total_dependents,
+            "complete_count": complete_count,
+            "partial_count": partial_count,
+            "cached_packages": list(sorted(self._cache.keys())),
+        }
+
+
+class RepoQueryError(Exception):
+    """Raised when a dnf repoquery call fails or returns invalid data."""
+
+    def __init__(self, message: str, exit_code: int = EXIT_REPO_QUERY_ERROR):
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+class NoDependentsFoundError(Exception):
+    """Raised when no dependents are found for a package."""
+
+    def __init__(self, package_name: str):
+        super().__init__(f"No dependents found for package: {package_name}")
+        self.package_name = package_name
+        self.exit_code = EXIT_NO_DEPENDENTS_FOUND
+
+
+class PackageNotFoundError(Exception):
+    """Raised when a package is not found in the repositories."""
+
+    def __init__(self, package_name: str):
+        super().__init__(f"Package not found in repositories: {package_name}")
+        self.package_name = package_name
+        self.exit_code = EXIT_PACKAGE_NOT_FOUND
+
+
+def run_filter_command(package_name: str, filter_command: str, metrics: RepoQueryMetrics, filter_cache: FilterCache, verbose: bool = False) -> bool:
+    """
+    Run a filter command on a package to determine if it should be included.
+
+    Args:
+        package_name: The package name to check
+        filter_command: The shell command to run
+        metrics: Metrics object to track filter command usage
+        filter_cache: Cache object to store filter results
+        verbose: Whether to enable verbose logging
+
+    Returns:
+        True if the command succeeds (package should be included), False otherwise
+    """
+    if not filter_command or not filter_command.strip():
+        return True
+
+    cached_result = filter_cache.get(package_name)
+    if cached_result is not None:
+        logging.debug(f"📋 Filter cache hit: Filter result for {package_name} → {'pass' if cached_result else 'fail'}")
+        return cached_result
+
+    logging.debug(f"🔍 Running filter command on package: {package_name}")
+
+    try:
+        result = run_command(
+            filter_command,
+            extra_environment={"PACKAGE": package_name}
+        )
+
+        success = result["return_code"] == 0
+        metrics.log_filter_call(package_name, success)
+
+        filter_cache.set(package_name, success)
+
+        if success:
+            logging.debug(f"   ✅ Filter command succeeded for {package_name}")
+        else:
+            logging.debug(f"   ❌ Filter command failed for {package_name} (exit code: {result['return_code']})")
+
+        return success
+
+    except Exception as e:
+        logging.debug(f"   💥 Filter command error for {package_name}: {e}")
+        metrics.log_filter_call(package_name, False)
+        filter_cache.set(package_name, False)
+        return False
+
+
+def update_dnf_cache(repository_paths: Dict[str, str], verbose: bool = False) -> None:
+    """
+    Update dnf cache for all repositories once upfront.
+    This allows subsequent repoquery calls to use --cacheonly for better performance.
+
+    Args:
+        repository_paths: Dictionary mapping repository IDs to URLs
+        verbose: Whether to enable verbose logging
+
+    Raises:
+        RepoQueryError: If the dnf cache update fails
+    """
+
+    logging.debug("🔄 Updating dnf cache for all repositories...")
+
+    try:
+        result = dnf("makecache --refresh", repository_paths, verbose, cache_only=False)
+        logging.debug("✅ Dnf cache updated successfully")
+        logging.debug(f"Cache update output: {result}")
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "Unknown error"
+        raise RepoQueryError(f"Failed to update dnf cache: {stderr}", EXIT_CACHE_UPDATE_ERROR)
+
+
+def derive_repository_id_from_url(repository_url: str) -> str:
+    """
+    Derive a unique repository key from a full repository URL.
+
+    The algorithm is:
+    - Uses hostname[_port] as fallback if no suitable path segment is found
+    - Picks the last path segment that isn't 'os' or known architectures
+    - Appends first 16 hex chars of SHA-256 for uniqueness
+
+    Args:
+        repository_url: The full repository URL to derive an ID from
+
+    Returns:
+        A unique repository identifier string
+    """
+    parsed_url = urlparse(repository_url)
+
+    segments = [segment for segment in parsed_url.path.strip("/").split("/") if segment]
+
+    component = None
+    for segment in reversed(segments):
+        if segment == "os" or segment in KNOWN_ARCHS:
+            continue
+        component = segment
+        break
+
+    if not component:
+        host = parsed_url.hostname or ""
+        component = f"{host}_{parsed_url.port}" if parsed_url.port else host
+
+    component_safe = re.sub(r"[^A-Za-z0-9_]+", "_", component)
+    digest = sha256(repository_url.encode("utf-8")).hexdigest()[:16]
+    return f"{component_safe}_{digest}"
+
+
+def get_signal_name(signal_num: int) -> str:
+    """
+    Get the name of a signal number.
+
+    Args:
+        signal_num: The signal number
+
+    Returns:
+        The signal name as a string
+    """
+    try:
+        return signal.Signals(signal_num).name
+    except ValueError:
+        return f"SIG{signal_num}"
+
+
+def quote_command(args):
+    """
+    Join a list of arguments into a command string, only quoting arguments
+    that would be semantically different if left unquoted.
+
+    An argument needs quoting if leaving it unquoted would cause the shell
+    to interpret it differently (split it into multiple arguments, perform
+    expansions, etc.).
+
+    Args:
+        args: List of string arguments
+
+    Returns:
+        String representing the command with minimal quoting
+    """
+    quoted_args = []
+
+    for arg in args:
+        if not arg:
+            quoted_args.append(shlex.quote(arg))
+            continue
+
+        try:
+            if shlex.split(arg) == [arg]:
+                quoted_args.append(arg)
+            else:
+                quoted_args.append(shlex.quote(arg))
+        except ValueError:
+            quoted_args.append(shlex.quote(arg))
+
+    return ' '.join(quoted_args)
+
+def run_command(command: List[str] | str, extra_environment: Dict[str, str] | None = None) -> Dict[str, Any]:
+    """
+    Run a command and log output.
+
+    Args:
+        command: List of command arguments to execute (or string)
+        extra_environment: Optional dictionary of additional environment variables
+
+    Returns:
+        Dictionary containing 'return_code' and 'output' keys
+
+    Raises:
+        subprocess.CalledProcessError: If the command returns a non-zero exit code
+    """
+    if isinstance(command, list):
+        command_string = quote_command(command)
+    else:
+        command_string = command
+
+    logging.debug(f"\n        ❯ {command_string}")
+
+    environment = None
+    if extra_environment:
+        environment = os.environ.copy()
+        environment.update(extra_environment)
+
+    result = subprocess.run(
+        command_string,
+        env=environment,
+        capture_output=True,
+        shell=True,
+        text=True
+    )
+
+    for line in result.stderr.splitlines():
+        if line.strip():
+            logging.debug(f"        {line.strip()}")
+
+    for line in result.stdout.splitlines():
+        if line.strip():
+            logging.debug(f"        {line.strip()}")
+
+    if result.returncode < 0:
+        signal_name = get_signal_name(abs(result.returncode))
+        logging.debug(f"        Process killed by signal {abs(result.returncode)} ({signal_name})")
+    else:
+        logging.debug(f"        Process exited with code {result.returncode}")
+
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, command,
+            result.stdout,
+            result.stderr
+        )
+
+    return {"return_code": result.returncode, "output": result.stdout}
+
+
+def dnf(command: str, repository_paths: Dict[str, str], verbose: bool = False, cache_only: bool = True) -> str:
+    """
+    Execute a dnf command with repository setup and return stdout content.
+
+    This function factors out the repeated pattern of setting up dnf commands
+    with repository configuration and executing them.
+
+    Args:
+        command: The dnf command as a string (e.g., "repoquery --whatdepends package")
+        repository_paths: Dictionary mapping repository IDs to URLs
+        verbose: Whether to enable verbose logging
+        cache_only: Whether to use --cacheonly flag (default: True)
+
+    Returns:
+        The stdout content as a string (stripped)
+
+    Raises:
+        subprocess.CalledProcessError: If the command returns a non-zero exit code
+    """
+    command_parts = shlex.split(command)
+    full_command = ["dnf"] + command_parts
+
+    full_command.extend(["--disablerepo=*"])
+    if not verbose:
+        full_command.append("--quiet")
+    if cache_only:
+        full_command.append("--cacheonly")
+    for repository_id, repository_url in repository_paths.items():
+        full_command.append(f"--repofrompath=repo-{repository_id},{repository_url}")
+    for repository_id in repository_paths:
+        full_command.append(f"--enablerepo=repo-{repository_id}")
+
+    result = run_command(full_command)
+    return result["output"].strip()
+
+
+def generate_direct_dependents(
+        package_name: str,
+        repository_paths: Dict[str, str],
+        metrics: RepoQueryMetrics,
+        dependency_cache: DependencyCache,
+        verbose: bool = False,
+        cache_only: bool = False,
+        max_results: int | None = None
+    ) -> Generator[str, None, None]:
+    """
+    Generator that yields direct dependents one at a time.
+
+    Args:
+        package_name: The package to find direct dependents for
+        repository_paths: Dictionary mapping repository IDs to URLs
+        metrics: Metrics object to track repoquery calls
+        dependency_cache: Cache object to store dependency results
+        verbose: Whether to enable verbose logging
+        cache_only: If True, only return cached results and never make repoquery calls
+        max_results: Maximum number of dependents to yield (None for unlimited)
+
+    Yields:
+        Package names that directly depend on the given package
+
+    Raises:
+        RepoQueryError: If the dnf repoquery call fails
+    """
+    logging.debug(f"\n🔍 Finding direct dependents for package: {package_name}")
+
+    if (not cache_only and dependency_cache.has_all(package_name)) or (cache_only and dependency_cache.has(package_name)):
+        cached_dependents = dependency_cache.get(package_name)
+        logging.debug(f"📋 Dependency cache hit: Dependents for {package_name} → {len(cached_dependents)} dependents")
+        count = 0
+        for dependent_name in cached_dependents:
+            if max_results is not None and count >= max_results:
+                break
+            yield dependent_name
+            count += 1
+        return
+
+    if cache_only:
+        logging.debug(f"📋 CACHE ONLY MODE: No sufficient cached dependents for {package_name}, skipping repoquery call")
+        return
+
+    metrics.log_call("dnf repoquery --whatdepends", package_name)
+    try:
+        stdout_content = dnf(f"repoquery --whatdepends {package_name} --qf '%{{name}}\\n'", repository_paths, verbose)
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "Unknown error"
+        raise RepoQueryError(
+            f"Failed to query reverse dependencies for {package_name!r}: {stderr}"
+        )
+
+    seen: Set[str] = set()
+    dependents_found = 0
+    dependents_list: List[str] = []
+    is_partial = False
+    count = 0
+    
+    for line in stdout_content.splitlines():
+        if max_results is not None and count > max_results:
+            is_partial = True
+            break
+
+        dependent_name = line.strip()
+        if dependent_name and dependent_name not in seen:
+            seen.add(dependent_name)
+            dependents_found += 1
+            dependents_list.append(dependent_name)
+            logging.debug(f"\n   Found dependent: {dependent_name}")
+            
+            if max_results is None or count <= max_results:
+                dependency_cache.set(package_name, dependents_list, partial=True)
+                yield dependent_name
+                count += 1
+
+    dependency_cache.set(package_name, dependents_list, is_partial)
+    logging.debug(f"\n   Total direct dependents found for {package_name}: {len(dependents_list)} ({'partial' if is_partial else 'complete'})")
+
+
+def query_source_package(
+        package_name: str,
+        repository_paths: Dict[str, str],
+        metrics: RepoQueryMetrics,
+        source_cache: SourcePackageCache,
+        verbose: bool = False,
+        allow_missing: bool = False
+    ) -> str:
+    """
+    Query the source package name for a given binary package.
+
+    Args:
+        package_name: The binary package name to find the source package for
+        repository_paths: Dictionary mapping repository IDs to URLs
+        metrics: Metrics object to track repoquery calls
+        source_cache: Cache object to store source package mappings
+        verbose: Whether to enable verbose logging
+        allow_missing: Whether to allow missing packages to be non-fatal
+
+    Returns:
+        The source package name, or empty string if package not found and allow_missing is True
+
+    Raises:
+        RepoQueryError: If the query fails or returns invalid data
+        PackageNotFoundError: If the package is not found and allow_missing is False
+    """
+
+    cached_source_package = source_cache.get(package_name)
+    if cached_source_package == '' and not allow_missing:
+        logging.debug(f"\n📋 Source cache hit: Package {package_name} → not found")
+        raise PackageNotFoundError(package_name)
+
+    if cached_source_package:
+        logging.debug(f"\n📋 Source cache hit: Source package for {package_name} → {cached_source_package}")
+        return cached_source_package
+
+    logging.debug(f"\n🔍 Querying source package for binary package: {package_name}")
+
+    metrics.log_call("dnf repoquery --qf '%{sourcerpm}'", package_name)
+    try:
+        stdout_content = dnf(f"repoquery {package_name} --qf '%{{sourcerpm}}\\n'", repository_paths, verbose)
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "Unknown error"
+        raise RepoQueryError(
+            f"Failed to query source package for {package_name!r}: {stderr}"
+        )
+
+    source_rpm = stdout_content.strip()
+    if not source_rpm:
+        source_cache.set(package_name, '')
+        if allow_missing:
+            logging.debug(f"   Package {package_name} not found, but continuing due to --allow-missing")
+            return ''
+        raise PackageNotFoundError(package_name)
+
+    m = re.match(r'^(?P<name>.*)-[^-]+-[^-]+\.src\.rpm$', source_rpm)
+    if not m:
+        raise RepoQueryError(
+            f"Unexpected source-RPM format for {package_name!r}: {source_rpm!r}"
+        )
+
+    source_package_name = m.group("name")
+    logging.debug(f"\n   Source package for {package_name}: {source_package_name}")
+
+    source_cache.set(package_name, source_package_name)
+
+    return source_package_name
+
+
+def query_package_description(
+        package_name: str,
+        repository_paths: Dict[str, str],
+        metrics: RepoQueryMetrics,
+        verbose: bool = False
+    ) -> str:
+    """
+    Query the description for a given package.
+
+    Args:
+        package_name: The package name to find the description for
+        repository_paths: Dictionary mapping repository IDs to URLs
+        metrics: Metrics object to track repoquery calls
+        verbose: Whether to enable verbose logging
+
+    Returns:
+        The package description with newlines removed
+
+    Raises:
+        RepoQueryError: If the query fails or returns invalid data
+    """
+
+    logging.debug(f"\n🔍 Querying description for package: {package_name}")
+
+    metrics.log_call("dnf repoquery --qf '%{description}'", package_name)
+    try:
+        stdout_content = dnf(f"repoquery {package_name} --qf %{{description}}", repository_paths, verbose)
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "Unknown error"
+        raise RepoQueryError(
+            f"Failed to query description for {package_name!r}: {stderr}"
+        )
+
+    description = stdout_content.strip()
+    if description:
+        description = " ".join(description.splitlines())
+
+    logging.debug(f"\n   Description for {package_name}: {description}")
+
+    return description
+
+
+def convert_to_source_packages(
+        dependents: Generator[str, None, None],
+        repository_paths: Dict[str, str],
+        metrics: RepoQueryMetrics,
+        source_cache: SourcePackageCache,
+        filter_cache: FilterCache,
+        max_results: int | None = None,
+        verbose: bool = False,
+        filter_command: str | None = None,
+        allow_missing: bool = False
+    ) -> Generator[str, None, None]:
+    """
+    Generator that converts a stream of binary package names into source package names.
+
+    Args:
+        dependents: Generator yielding binary package names
+        repository_paths: Dictionary mapping repository IDs to URLs
+        max_results: Maximum number of unique source packages to yield (None for unlimited)
+        filter_command: Optional shell command to run on each source package
+        allow_missing: Whether to allow missing packages to be non-fatal
+
+    Yields:
+        Source package names (unique, up to max_results if specified)
+
+    Raises:
+        RepoQueryError: If any source package query fails
+    """
+    logging.debug("🔄 Converting binary packages to source packages")
+
+    source_packages: Set[str] = set()
+    converted_count = 0
+
+    for package in dependents:
+        if max_results is not None and converted_count >= max_results:
+            logging.debug(f"Reached max_results={max_results}, stopping conversion")
+            break
+
+        logging.debug(f"   Converting binary package: {package}")
+        source_package = query_source_package(
+            package, repository_paths, metrics, source_cache, verbose, allow_missing
+        )
+
+        if not source_package:
+            logging.debug(f"   Skipping binary package {package} (no source package found)")
+            continue
+
+        if source_package not in source_packages:
+            source_packages.add(source_package)
+
+            if filter_command:
+                if not run_filter_command(source_package, filter_command, metrics, filter_cache, verbose):
+                    logging.debug(f"   Skipping source package {source_package} due to filter command")
+                    continue
+
+            converted_count += 1
+            logging.debug(f"   New source package found: {source_package}")
+            yield source_package
+        else:
+            logging.debug(f"   Source package already seen: {source_package}")
+
+    logging.debug(f"   Total unique source packages converted: {converted_count}")
+
+
+def compute_transitive_closure(
+        root_package: str,
+        dependents_map: Dict[str, Dict[str, Any]],
+        max_results: int | None = None,
+        filter_function = None,
+    ) -> Dict[str, Dict[str, Any]]:
+    """
+    Compute the transitive closure of the dependency graph.
+
+    For each package, returns a dictionary containing the list of all packages that can be reached
+    from it through the dependency graph (in breadth-first order) and a partial flag indicating
+    whether the results are incomplete due to max_results being reached.
+    If filter_function is provided, it should take a package name and a list of current dependents
+    and return True if the package should be included, False if it should be filtered out.
+    Filtered packages are excluded from the graph but still traversed to find their dependents.
+
+    Args:
+        root_package: root package name to check for partial results
+        dependents_map: Dictionary mapping package names to their dependent packages
+        max_results: Maximum number of results to return (including the root package)
+        filter_function: Optional function that takes a package name and dependents list and returns True/False
+
+    Returns:
+        Dictionary mapping package names to dictionaries containing 'dependents' list and 'partial' flag
+    """
+    graph: Dict[str, Dict[str, Any]] = {}
+
+    # The root package gets all results but itself as dependents
+    max_root_dependents = max_results - 1 if max_results is not None else None
+    
+    for package, entry in dependents_map.items():
+        known_packages: Set[str] = set()
+        transitive_dependents: List[str] = []
+        queue = deque(entry["dependents"])
+        is_partial = entry["partial"]
+
+        # We stop reading from the queue once the root package has all the results the user asked for
+        # (But we still need to extend the queue for the remaining of the loop to know if we're missing out
+        # on any results because of the max_results limit)
+        root_hit_max_dependents = False
+        
+        while queue:
+            dependent = queue.popleft()
+
+            if dependent in known_packages:
+                continue
+
+            # If the root package has hit its dependent limit, we don't add this dependent to the results,
+            # but we still need to use the dependent to extend the queue so we can know if we're missing out
+            # on any results because of the max_results limit
+            if package == root_package and max_root_dependents is not None and len(transitive_dependents) >= max_root_dependents:
+                root_hit_max_dependents = True
+
+            if package != root_package or not root_hit_max_dependents:
+                # Mark this package as seen to prevent future cycles
+                known_packages.add(dependent)
+
+                # Apply optional filtering function
+                if filter_function is None or filter_function(dependent, transitive_dependents):
+                    transitive_dependents.append(dependent)
+
+            if dependent in dependents_map:
+                dependent_entry = dependents_map[dependent]
+                if dependent_entry["partial"]:
+                    is_partial = True
+
+                queue.extend(dependent_entry["dependents"])
+            
+            if root_hit_max_dependents:
+                # At this point the queue accurately reflects what work is left to do
+                # so we can use it to know if the results are complete for the root package
+                is_partial = bool(queue)
+                break
+
+        if not max_results or len(graph.keys()) < max_results:
+            graph[package] = {
+                "dependents": transitive_dependents,
+                "partial": is_partial
+            }
+
+    return graph
+
+
+def build_dependents_list(
+        package_name: str,
+        repository_paths: Dict[str, str],
+        show_source_packages: bool,
+        source_cache: SourcePackageCache,
+        metrics: RepoQueryMetrics,
+        filter_cache: FilterCache,
+        dependency_cache: DependencyCache,
+        max_results: int | None = None,
+        verbose: bool = False,
+        keep_cycles: bool = False,
+        filter_command: str | None = None,
+        allow_missing: bool = False
+    ) -> List[str]:
+    """
+    Build a list of dependents for a given package.
+
+    Args:
+        package_name: The package to find dependents for
+        repository_paths: Dictionary mapping repository IDs to URLs
+        show_source_packages: Whether to convert to source package names
+        max_results: Maximum number of results to return
+        filter_command: Optional shell command to run on each dependent package
+        allow_missing: Whether to allow missing packages to be non-fatal
+
+    Returns:
+        List of dependent package names (binary or source depending on show_source_packages)
+    """
+    logging.debug(f"🔄 Building dependents list for: {package_name}")
+    logging.debug(f"   Show source packages: {show_source_packages}")
+    logging.debug(f"   Max results: {max_results}")
+    logging.debug(f"   Filter command: {filter_command}")
+
+    dependents = generate_direct_dependents(package_name, repository_paths, metrics, dependency_cache, verbose, cache_only=False)
+
+    if show_source_packages:
+        dependents = convert_to_source_packages(
+            dependents, repository_paths, metrics, source_cache, filter_cache,
+            max_results, verbose, filter_command, allow_missing
+        )
+
+    collected_packages: List[str] = []
+    discovered_count = 0
+    is_partial = False
+    for dependent_package in dependents:
+        if max_results is not None and discovered_count >= max_results:
+            is_partial = True
+            break
+
+        if not keep_cycles and package_name == dependent_package:
+            continue
+
+        if filter_command:
+            if not run_filter_command(dependent_package, filter_command, metrics, filter_cache, verbose):
+                logging.debug(f"   Skipping dependent package {dependent_package} due to filter command")
+                continue
+
+        discovered_count += 1
+        if max_results is None or discovered_count <= max_results:
+            collected_packages.append(dependent_package)
+
+    logging.debug(f"   Total dependents collected: {len(collected_packages)} ({'partial' if is_partial else 'complete'})")
+
+    if len(collected_packages) == 0:
+        raise NoDependentsFoundError(package_name)
+
+    return collected_packages
+
+
+def build_dependents_graph(
+        root_package: str,
+        repository_paths: Dict[str, str],
+        show_source_packages: bool,
+        source_cache: SourcePackageCache,
+        metrics: RepoQueryMetrics,
+        filter_cache: FilterCache,
+        dependency_cache: DependencyCache,
+        max_results: int | None = None,
+        keep_cycles: bool = False,
+        verbose: bool = False,
+        filter_command: str | None = None,
+        allow_missing: bool = False
+    ) -> Dict[str, Dict[str, Any]]:
+    """
+    Build a transitive graph of reverse dependencies for the given package.
+
+    Stops collecting dependents of the root package once max_results is reached.
+    From that point we fill in as much as we can of the graph without doing more
+    repoquery calls.
+
+    Returns:
+        Dictionary mapping package names to dictionaries containing 'dependents' list and 'partial' flag
+    """
+    logging.debug(f"🔄 Building dependents graph for: {root_package}")
+    logging.debug(f"   Show source packages: {show_source_packages}")
+    logging.debug(f"   Max results: {max_results}")
+    logging.debug(f"   Filter command: {filter_command}")
+
+    known_packages: Set[str] = {root_package}
+    queue = deque([root_package])
+    dependents_map: Dict[str, Dict[str, Any]] = {}
+    result_count = 0
+
+    result_limit_hit = False
+    while queue:
+        package = queue.popleft()
+        dependents_list: List[str] = []
+
+        any_filtered_dependents = False
+        for dependent in generate_direct_dependents(
+                package, repository_paths, metrics, dependency_cache, verbose,
+                cache_only=result_limit_hit, max_results=max_results
+        ):
+            if show_source_packages:
+                dependent = query_source_package(
+                    dependent,
+                    repository_paths,
+                    metrics,
+                    source_cache,
+                    verbose,
+                    allow_missing
+                )
+
+            if not dependent:
+                continue
+            if not keep_cycles and dependent in known_packages:
+                continue
+
+            if dependent not in known_packages:
+                known_packages.add(dependent)
+                queue.append(dependent)
+
+            dependent_is_filtered = filter_command and not run_filter_command(
+                dependent,
+                filter_command,
+                metrics,
+                filter_cache,
+                verbose
+            )
+
+            if not dependent_is_filtered:
+                dependents_list.append(dependent)
+
+                if package == root_package and max_results is not None:
+                    result_count += 1
+                    if result_count >= max_results:
+                        result_limit_hit = True
+                        break
+            else:
+                any_filtered_dependents = True
+
+        dependents_map[package] = {"dependents": dependents_list, "partial": result_limit_hit or any_filtered_dependents}
+
+    for package, entry in dependents_map.items():
+        has_unknown_dependents = any(dependent not in dependents_map for dependent in entry["dependents"])
+        has_partial_dependents = any(not dependency_cache.has_all(dependent) for dependent in entry["dependents"])
+        entry["partial"] = entry["partial"] or has_unknown_dependents or has_partial_dependents
+
+    def filter_function(package_name: str, dependents_list: List[str]) -> bool:
+        if max_results is not None and len(dependents_list) >= max_results:
+            return False
+
+        if not filter_command:
+            return True
+
+        return filter_cache.get(package_name) is not False
+
+    # We add 1 to max_results to make room for the root package
+    if max_results is not None:
+        max_results += 1
+
+    dependents_graph = compute_transitive_closure(root_package, dependents_map, max_results, filter_function)
+
+    if not dependents_graph.get(root_package):
+        raise NoDependentsFoundError(root_package)
+
+    return dependents_graph
+
+
+def max_result_type(value: str) -> int:
+    """
+    Convert a string to an integer, failing if the value is not a positive integer.
+    """
+    try:
+        result = int(value)
+    except ValueError:
+        result = -1
+
+    if result <= 0:
+        raise argparse.ArgumentTypeError(f"result limit must be positive whole number, got: {value}")
+
+    return result
+
+
+def parse_command_line_arguments() -> argparse.Namespace:
+    """
+    Parse command line arguments for the package dependents finder.
+
+    Returns:
+        argparse.Namespace: Parsed command line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="Find reverse dependencies of an RPM package."
+    )
+    parser.add_argument(
+        "package_name",
+        help="Name of the package to inspect"
+    )
+    parser.add_argument(
+        "--base-url",
+        dest="base_url",
+        default="http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10",
+        help="Base URL for nightly repositories"
+    )
+    parser.add_argument(
+        "--repositories",
+        dest="repository_names",
+        default="BaseOS,AppStream,CRB",
+        help=(
+            "Comma-separated list of repository names (relative to base URL) "
+            "or full repository URLs.\\n"
+            "Examples:\n"
+            "  --repositories BaseOS,AppStream,CRB\n"
+            "  --repositories BaseOS,https://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10/compose/RT/x86_64/os\n"
+        )
+    )
+    parser.add_argument(
+        "--arch",
+        choices=sorted(KNOWN_ARCHS),
+        dest="arch",
+        default="x86_64",
+        help="CPU architecture (for example: x86_64, s390x)"
+    )
+    parser.add_argument(
+        "--output-file",
+        dest="output_file",
+        type=Path,
+        help="Write output to this file instead of stdout"
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Include transitive reverse dependencies (default is direct only)"
+    )
+    parser.add_argument(
+        "--source-packages",
+        action="store_true",
+        help="Convert dependent package names to their source package names"
+    )
+    parser.add_argument(
+        "--max-results",
+        type=max_result_type,
+        help="Maximum number of results to return (limits both queries and output)"
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "plain"],
+        default="plain",
+        help="Output format: json or plain (one per line)"
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable debug logging"
+    )
+
+    parser.add_argument(
+        "--no-refresh",
+        action="store_true",
+        help="Skip dnf cache update and use existing cache only"
+    )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="Print detailed statistics about repoquery calls and cache usage"
+    )
+    parser.add_argument(
+        "--show-cycles",
+        action="store_true",
+        help="Show cycles in dependency graph"
+    )
+    parser.add_argument(
+        "--filter-command",
+        help="Optional shell command to run on each dependent package to filter results. "
+             "The command receives PACKAGE environment variable set to the package name. "
+             "If the command returns a non-zero exit code, the package is pruned from output. "
+             "Example: --filter-command 'echo $PACKAGE | grep -q \"^kernel$\"'"
+    )
+    parser.add_argument(
+        "--describe",
+        action="store_true",
+        help="Include package descriptions in output. For plain format, descriptions are appended to package names. "
+             "For JSON format, descriptions are added as a 'description' field to each package object."
+    )
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        help="Redirect all log output to this file instead of stderr"
+    )
+    parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="Allow missing packages to be non-fatal to operation. "
+             "If a package is not found in repositories, continue with empty results instead of exiting with error."
+    )
+    return parser.parse_args()
+
+
+def build_repository_paths(
+        base_url: str,
+        repository_names: str,
+        arch: str
+    ) -> Dict[str, str]:
+    """
+    Build repository paths from base URL and repository names.
+
+    Args:
+        base_url: Base URL for the repositories
+        repository_names: Comma-separated list of repository names or full URLs
+        arch: CPU architecture (e.g., 'x86_64', 'aarch64')
+
+    Returns:
+        Dictionary mapping repository IDs to their full URLs
+
+    Raises:
+        SystemExit: If no valid repositories are provided
+    """
+    repositories = [
+        repo.strip() for repo in repository_names.split(",")
+        if repo.strip()
+    ]
+    if not repositories:
+        logging.error("At least one repository alias or URL must be provided")
+        sys.exit(EXIT_INVALID_ARGUMENTS)
+
+    base = base_url.rstrip("/")
+    paths: Dict[str, str] = {}
+    for repository in repositories:
+        if repository.startswith(("http://", "https://")):
+            repository_url = repository.rstrip("/")
+            repository_id = derive_repository_id_from_url(repository_url)
+            paths[repository_id] = repository_url
+            continue
+
+        repository_id = repository
+        repository_url = f"{base}/compose/{repository}/{arch}/os/"
+        paths[repository_id] = repository_url
+
+        repository_id = repository + "-sources"
+        repository_url = f"{base}/compose/{repository}/source/tree/"
+        paths[repository_id] = repository_url
+    return paths
+
+
+def set_up_logging(verbose: bool, log_file: Path | None) -> None:
+    """
+    Set up logging configuration.
+
+    Args:
+        verbose: Whether to enable debug logging
+        log_file: Optional file path to redirect logs to
+    """
+    level = logging.DEBUG if verbose else logging.INFO
+
+    if log_file:
+        logger = logging.getLogger()
+        logger.setLevel(level)
+
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(level)
+        file_handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(file_handler)
+
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        stderr_handler.setLevel(logging.ERROR)
+        stderr_handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(stderr_handler)
+    else:
+        logging.basicConfig(format="%(message)s", level=level)
+
+
+def log_operation(
+        package_name: str,
+        all_dependents: bool,
+        source_packages: bool,
+        max_results: int | None,
+        filter_command: str | None,
+        output_file: Path | None
+    ) -> None:
+    """
+    Log information about the operation being performed.
+
+    Args:
+        package_name: Name of the package to inspect
+        all_dependents: Whether to include transitive dependencies
+        source_packages: Whether to convert to source package names
+        max_results: Maximum number of results to return
+        filter_command: Optional shell command to filter packages
+        output_file: Optional output file path
+    """
+    operation = "transitive" if all_dependents else "direct"
+    package_type = "as source packages" if source_packages else ""
+    max_info = f" (max {max_results})" if max_results else ""
+    filter_info = f" with filter: {filter_command}" if filter_command else ""
+    output_info = f" to \"{output_file}\"" if output_file else ""
+
+    logging.info(
+        f"\n🔍 Finding {operation} reverse dependencies of \"{package_name}\" "
+        f"{package_type}{max_info}{filter_info}{output_info}\n"
+    )
+
+
+def set_up_repositories_and_cache(
+        base_url: str,
+        repository_names: str,
+        arch: str,
+        no_refresh: bool,
+        verbose: bool
+    ) -> Dict[str, str]:
+    """
+    Set up repositories and update dnf cache if needed.
+
+    Args:
+        base_url: Base URL for nightly repositories
+        repository_names: Comma-separated list of repository names
+        arch: CPU architecture
+        no_refresh: Whether to skip dnf cache update
+        verbose: Whether to enable verbose logging
+
+    Returns:
+        Dictionary mapping repository IDs to URLs
+    """
+    repositories = build_repository_paths(base_url, repository_names, arch)
+
+    if not no_refresh:
+        update_dnf_cache(repositories, verbose)
+    else:
+        logging.info("⏭️  Skipping dnf cache update (using existing cache)")
+
+    return repositories
+
+
+def collect_package_descriptions(
+        arguments: argparse.Namespace,
+        repositories: Dict[str, str],
+        metrics: RepoQueryMetrics,
+        dependents_data: List[Dict[str, Any]] | List[str]
+    ) -> Dict[str, str]:
+    """
+    Collect package descriptions for all relevant packages.
+
+    Args:
+        arguments: Parsed command line arguments
+        repositories: Dictionary mapping repository IDs to URLs
+        metrics: Metrics object to track repoquery calls
+        dependents_data: Either a list of package dictionaries (for --all) or a list of strings (for direct only)
+
+    Returns:
+        Dictionary mapping package names to their descriptions
+    """
+    package_descriptions = {}
+
+    if arguments.all:
+        all_packages = set()
+        for package_entry in dependents_data:
+            all_packages.add(package_entry["package"])
+            all_packages.update(package_entry["dependents"])
+
+        for package in all_packages:
+            description = query_package_description(
+                package, repositories, metrics, arguments.verbose
+            )
+            package_descriptions[package] = description
+    else:
+        all_packages_to_describe = [arguments.package_name] + dependents_data
+        for package in all_packages_to_describe:
+            description = query_package_description(
+                package, repositories, metrics, arguments.verbose
+            )
+            package_descriptions[package] = description
+
+    return package_descriptions
+
+
+def generate_output(
+        arguments: argparse.Namespace,
+        dependents_data: List[Dict[str, Any]] | List[str],
+        package_descriptions: Dict[str, str] | None
+    ) -> str:
+    """
+    Generate output in the requested format.
+
+    Args:
+        arguments: Parsed command line arguments
+        dependents_data: Either a list of package dictionaries (for --all) or a list of strings (for direct only)
+        package_descriptions: Dictionary of package descriptions if --describe is used, None otherwise
+
+    Returns:
+        Formatted output string
+    """
+    if arguments.format == "json":
+        return generate_json_output(arguments, dependents_data, package_descriptions)
+    else:
+        return generate_plain_output(arguments, dependents_data, package_descriptions)
+
+
+def generate_json_output(
+        arguments: argparse.Namespace,
+        dependents_data: List[Dict[str, Any]] | List[str],
+        package_descriptions: Dict[str, str] | None
+    ) -> str:
+    """
+    Generate JSON formatted output.
+
+    Args:
+        arguments: Parsed command line arguments
+        dependents_data: Either a list of package dictionaries (for --all) or a list of strings (for direct only)
+        package_descriptions: Dictionary of package descriptions if --describe is used, None otherwise
+
+    Returns:
+        JSON formatted string
+    """
+    if arguments.all:
+        output_array = []
+        for package_entry in dependents_data:
+            package_obj = {"package": package_entry["package"]}
+            if arguments.describe and package_descriptions:
+                description = package_descriptions.get(package_entry["package"])
+                if description:
+                    package_obj["description"] = description
+            package_obj["dependents"] = package_entry["dependents"]
+            if "partial" in package_entry:
+                package_obj["partial"] = package_entry["partial"]
+            output_array.append(package_obj)
+    else:
+        output_array = [
+            {"package": arguments.package_name, "dependents": dependents_data}
+        ]
+        if arguments.describe and package_descriptions:
+            description = package_descriptions.get(arguments.package_name)
+            if description:
+                output_array[0]["description"] = description
+
+    return json.dumps(output_array, indent=2)
+
+
+def generate_plain_output(
+        arguments: argparse.Namespace,
+        dependents_data: List[Dict[str, Any]] | List[str],
+        package_descriptions: Dict[str, str] | None
+    ) -> str:
+    """
+    Generate plain text formatted output.
+
+    Args:
+        arguments: Parsed command line arguments
+        dependents_data: Either a list of package dictionaries (for --all) or a list of strings (for direct only)
+        package_descriptions: Dictionary of package descriptions if --describe is used, None otherwise
+
+    Returns:
+        Plain text formatted string
+    """
+    if arguments.all:
+        # Find the root package entry
+        root_package_entry = None
+        for package_entry in dependents_data:
+            if package_entry["package"] == arguments.package_name:
+                root_package_entry = package_entry
+                break
+
+        if root_package_entry:
+            collected_packages = root_package_entry["dependents"]
+        else:
+            collected_packages = []
+    else:
+        collected_packages = dependents_data
+
+    if arguments.describe and package_descriptions:
+        output_lines = []
+        for package in collected_packages:
+            description = package_descriptions.get(package)
+            if description:
+                output_lines.append(f"{package}: {description}")
+            else:
+                output_lines.append(package)
+        return "\n".join(output_lines)
+    else:
+        return "\n".join(collected_packages)
+
+
+def write_output(output_data: str, output_file: Path | None) -> None:
+    """
+    Write output to file or stdout.
+
+    Args:
+        output_data: The formatted output data
+        output_file: Optional output file path
+    """
+    logging.debug(f"\n✅ Final output:\n{output_data}\n")
+    if output_file:
+        output_file.write_text(output_data)
+    else:
+        print(output_data)
+
+
+def display_statistics(
+        filter_command: str | None,
+        metrics: RepoQueryMetrics,
+        source_cache: SourcePackageCache,
+        filter_cache: FilterCache,
+        dependency_cache: DependencyCache
+    ) -> None:
+    """
+    Display detailed statistics about the operation.
+
+    Args:
+        filter_command: Optional shell command used to filter packages
+        metrics: Metrics object containing operation statistics
+        source_cache: Cache object containing source package cache statistics
+        filter_cache: Cache object containing filter cache statistics
+    """
+    stats = metrics.get_stats()
+    print("\n📊 FINAL STATISTICS:", file=sys.stderr)
+    print(f"   Total dnf repoquery calls: {stats['total_calls']}", file=sys.stderr)
+    print("   Calls by type:", file=sys.stderr)
+    for call_type, count in stats["calls_by_type"].items():
+        print(f"     {call_type}: {count}", file=sys.stderr)
+
+    if filter_command:
+        print(f"   Filter command calls: {stats['filter_calls']}", file=sys.stderr)
+        print(f"   Filter command failures: {stats['filter_failures']}", file=sys.stderr)
+
+    source_cache_stats = source_cache.get_stats()
+    print(f"   Source package cache size: {source_cache_stats['cache_size']}", file=sys.stderr)
+    print(f"   Source package cache hits (found): {source_cache_stats['found_count']}", file=sys.stderr)
+    print(f"   Source package cache hits (not found): {source_cache_stats['not_found_count']}", file=sys.stderr)
+
+    if source_cache_stats["cached_packages"]:
+        print("   Cached source packages:", file=sys.stderr)
+        for package in source_cache_stats["cached_packages"]:
+            result = source_cache.get(package)
+            if result is None:
+                status = "not found"
+            else:
+                status = f"→ {result}"
+            print(f"     {package}: {status}", file=sys.stderr)
+
+    filter_cache_stats = filter_cache.get_stats()
+    print(f"   Filter cache size: {filter_cache_stats['cache_size']}", file=sys.stderr)
+    print(f"   Filter cache hits (passed): {filter_cache_stats['passed_count']}", file=sys.stderr)
+    print(f"   Filter cache hits (failed): {filter_cache_stats['failed_count']}", file=sys.stderr)
+
+    if filter_cache_stats["cached_packages"]:
+        print("   Cached filter results:", file=sys.stderr)
+        for package in filter_cache_stats["cached_packages"]:
+            result = filter_cache.get(package)
+            status = "pass" if result else "fail"
+            print(f"     {package}: {status}", file=sys.stderr)
+
+    dependency_cache_stats = dependency_cache.get_stats()
+    print(f"   Dependency cache size: {dependency_cache_stats['cache_size']}", file=sys.stderr)
+    print(f"   Dependency cache total dependents: {dependency_cache_stats['total_dependents']}", file=sys.stderr)
+    print(f"   Dependency cache complete results: {dependency_cache_stats['complete_count']}", file=sys.stderr)
+    print(f"   Dependency cache partial results: {dependency_cache_stats['partial_count']}", file=sys.stderr)
+
+    if dependency_cache_stats["cached_packages"]:
+        print("   Cached dependency results:", file=sys.stderr)
+        for package in dependency_cache_stats["cached_packages"]:
+            dependents = dependency_cache.get(package)
+            if dependents is not None:
+                entry = dependency_cache._cache[package]
+                partial_info = " (partial)" if entry["partial"] else " (complete)"
+                print(f"     {package}: {len(dependents)} dependents{partial_info}", file=sys.stderr)
+
+
+def main() -> None:
+    """
+    Main entry point for the package dependents finder.
+
+    Parses command line arguments, sets up repositories, and finds package dependents
+    according to the specified options. Outputs results in the requested format.
+
+    Raises:
+        SystemExit: On argument validation errors or RepoQueryError
+    """
+    arguments = parse_command_line_arguments()
+
+    set_up_logging(arguments.verbose, arguments.log_file)
+
+    log_operation(
+        arguments.package_name,
+        arguments.all,
+        arguments.source_packages,
+        arguments.max_results,
+        arguments.filter_command,
+        arguments.output_file
+    )
+
+    repositories = set_up_repositories_and_cache(
+        arguments.base_url,
+        arguments.repository_names,
+        arguments.arch,
+        arguments.no_refresh,
+        arguments.verbose
+    )
+
+    metrics = RepoQueryMetrics()
+    source_cache = SourcePackageCache()
+    filter_cache = FilterCache()
+    dependency_cache = DependencyCache()
+
+    try:
+        if arguments.all:
+            dependents_graph = build_dependents_graph(
+                arguments.package_name,
+                repositories,
+                show_source_packages=arguments.source_packages,
+                source_cache=source_cache,
+                metrics=metrics,
+                filter_cache=filter_cache,
+                dependency_cache=dependency_cache,
+                max_results=arguments.max_results,
+                verbose=arguments.verbose,
+                keep_cycles=arguments.show_cycles,
+                filter_command=arguments.filter_command,
+                allow_missing=arguments.allow_missing,
+            )
+
+            dependents_data = []
+            for package, entry in dependents_graph.items():
+                package_entry = {
+                    "package": package,
+                    "dependents": entry["dependents"],
+                    "partial": entry["partial"]
+                }
+                dependents_data.append(package_entry)
+        else:
+            dependents_data = build_dependents_list(
+                arguments.package_name,
+                repositories,
+                show_source_packages=arguments.source_packages,
+                source_cache=source_cache,
+                metrics=metrics,
+                filter_cache=filter_cache,
+                dependency_cache=dependency_cache,
+                max_results=arguments.max_results,
+                verbose=arguments.verbose,
+                keep_cycles=arguments.show_cycles,
+                filter_command=arguments.filter_command,
+                allow_missing=arguments.allow_missing,
+            )
+
+        package_descriptions = None
+        if arguments.describe:
+            logging.debug("🔄 Fetching package descriptions...")
+            package_descriptions = collect_package_descriptions(
+                arguments, repositories, metrics, dependents_data
+            )
+
+        output_data = generate_output(arguments, dependents_data, package_descriptions)
+        write_output(output_data, arguments.output_file)
+
+        if arguments.stats:
+            display_statistics(arguments.filter_command, metrics, source_cache, filter_cache, dependency_cache)
+
+    except RepoQueryError as error:
+        logging.error("%s", error)
+        sys.exit(error.exit_code)
+    except NoDependentsFoundError as error:
+        if arguments.allow_missing:
+            logging.info("%s (continuing with empty results due to --allow-missing)", error)
+            if arguments.all:
+                dependents_data = [{"package": arguments.package_name, "dependents": [], "partial": False}]
+            else:
+                dependents_data = []
+        else:
+            logging.error("%s", error)
+            sys.exit(error.exit_code)
+    except PackageNotFoundError as error:
+        if arguments.allow_missing:
+            logging.info("%s (continuing with empty results due to --allow-missing)", error)
+            if arguments.all:
+                dependents_data = [{"package": arguments.package_name, "dependents": [], "partial": False}]
+            else:
+                dependents_data = []
+        else:
+            logging.error("%s", f"Could not query dependents for {arguments.package_name} because repositories are incomplete (at least the {error.package_name} package is missing)")
+            sys.exit(error.exit_code)
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test-find-package-dependents.py
+++ b/scripts/tests/test-find-package-dependents.py
@@ -1,0 +1,1986 @@
+
+"""
+Tests for find-package-dependents.py script.
+"""
+
+import argparse
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from contextlib import contextmanager
+from io import StringIO
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import importlib.util
+spec = importlib.util.spec_from_file_location("find_package_dependents", os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "find-package-dependents.py"))
+find_package_dependents = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(find_package_dependents)
+
+
+@contextmanager
+def captured_stdout():
+    """Context manager to capture stdout output using StringIO."""
+    old_stdout = sys.stdout
+    captured = StringIO()
+    sys.stdout = captured
+    try:
+        yield captured
+    finally:
+        sys.stdout = old_stdout
+
+
+@contextmanager
+def captured_stderr():
+    """Context manager to capture stderr output using StringIO."""
+    old_stderr = sys.stderr
+    captured = StringIO()
+    sys.stderr = captured
+    try:
+        yield captured
+    finally:
+        sys.stderr = old_stderr
+
+
+class TestFindPackageDependents(unittest.TestCase):
+    """🧪 Comprehensive test suite for find-package-dependents.py script.
+
+    Tests all functionality with mocked dnf commands to ensure the script works correctly
+    without requiring actual system packages or network access.
+    """
+
+    def setUp(self):
+        """🎯 Set up test fixtures with realistic package examples."""
+        import logging
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format='%(message)s',
+            force=True
+        )
+
+        self.repositories = {
+            "BaseOS": "http://example.com/repo/BaseOS/x86_64/os/",
+            "AppStream": "http://example.com/repo/AppStream/x86_64/os/",
+            "BaseOS-sources": "http://example.com/repo/BaseOS/source/tree/",
+            "AppStream-sources": "http://example.com/repo/AppStream/source/tree/",
+        }
+
+        self.metrics = find_package_dependents.RepoQueryMetrics()
+        self.source_cache = find_package_dependents.SourcePackageCache()
+        self.filter_cache = find_package_dependents.FilterCache()
+        self.dependency_cache = find_package_dependents.DependencyCache()
+
+
+    def test_source_package_cache(self):
+        """Test that source package cache correctly stores and retrieves package mappings."""
+        cache = find_package_dependents.SourcePackageCache()
+
+        cache.set("podman", "podman-source")
+        self.assertEqual(cache.get("podman"), "podman-source")
+
+        cache.set("non-existent-package", None)
+        self.assertIsNone(cache.get("non-existent-package"))
+
+        self.assertIsNone(cache.get("missing-package"))
+
+        stats = cache.get_stats()
+        self.assertEqual(stats["cache_size"], 2)
+        self.assertEqual(stats["found_count"], 1)
+        self.assertEqual(stats["not_found_count"], 1)
+
+    def test_filter_cache(self):
+        """Test that filter cache correctly stores filter results for packages."""
+        cache = find_package_dependents.FilterCache()
+
+        cache.set("bootc", True)
+        cache.set("toolbox", False)
+
+        self.assertTrue(cache.get("bootc"))
+        self.assertFalse(cache.get("toolbox"))
+        self.assertIsNone(cache.get("non-existent"))
+
+        stats = cache.get_stats()
+        self.assertEqual(stats["cache_size"], 2)
+        self.assertEqual(stats["passed_count"], 1)
+        self.assertEqual(stats["failed_count"], 1)
+
+    def test_dependency_cache(self):
+        """Test that dependency cache correctly stores package dependency lists."""
+        cache = find_package_dependents.DependencyCache()
+
+        dependents = ["bootc", "toolbox", "container-tools"]
+        cache.set("podman", dependents)
+
+        cached_dependents = cache.get("podman")
+        self.assertEqual(cached_dependents, dependents)
+        self.assertIsNone(cache.get("non-existent"))
+
+        stats = cache.get_stats()
+        self.assertEqual(stats["cache_size"], 1)
+        self.assertEqual(stats["total_dependents"], 3)
+
+    def test_repo_query_metrics(self):
+        """Test that repository query metrics correctly track API calls and performance."""
+        metrics = find_package_dependents.RepoQueryMetrics()
+
+        metrics.log_call("test_call", "podman")
+        metrics.log_call("test_call", "libwayland-server")
+        metrics.log_call("different_call", "mutter")
+
+        metrics.log_filter_call("bootc", True)
+        metrics.log_filter_call("toolbox", False)
+
+        stats = metrics.get_stats()
+        self.assertEqual(stats["total_calls"], 3)
+        self.assertEqual(stats["calls_by_type"]["test_call"], 2)
+        self.assertEqual(stats["calls_by_type"]["different_call"], 1)
+        self.assertEqual(stats["filter_calls"], 2)
+        self.assertEqual(stats["filter_failures"], 1)
+
+
+    def test_derive_repository_id_from_url(self):
+        """Test that repository IDs are correctly derived from repository URLs."""
+        url = "http://download.devel.redhat.com/rhel-10/nightly/RHEL-10/latest-RHEL-10/compose/BaseOS/x86_64/os/"
+        repo_id = find_package_dependents.derive_repository_id_from_url(url)
+        self.assertIsInstance(repo_id, str)
+        self.assertIn("BaseOS_", repo_id)
+
+        url = "https://custom.repo.com/special/repo/"
+        repo_id = find_package_dependents.derive_repository_id_from_url(url)
+        self.assertIsInstance(repo_id, str)
+        self.assertIn("repo_", repo_id)
+
+        url = "http://example.com/os/"
+        repo_id = find_package_dependents.derive_repository_id_from_url(url)
+        self.assertIsInstance(repo_id, str)
+        self.assertIn("example_com_", repo_id)
+
+    def test_get_signal_name(self):
+        """Test that signal names are correctly retrieved from signal numbers."""
+        signal_name = find_package_dependents.get_signal_name(9)
+        self.assertEqual(signal_name, "SIGKILL")
+
+        signal_name = find_package_dependents.get_signal_name(99999)
+        self.assertEqual(signal_name, "SIG99999")
+
+    def test_quote_command(self):
+        """Test that command arguments are properly quoted for shell execution."""
+        args = ["echo", "hello", "world"]
+        result = find_package_dependents.quote_command(args)
+        self.assertEqual(result, "echo hello world")
+
+        args = ["echo", "hello world", "with spaces"]
+        result = find_package_dependents.quote_command(args)
+        self.assertIn("'hello world'", result)
+        self.assertIn("'with spaces'", result)
+
+        args = ["echo", "", "test"]
+        result = find_package_dependents.quote_command(args)
+        self.assertIn("''", result)
+
+    def test_max_result_type(self):
+        """Test max result type validation with various inputs."""
+        test_cases = [
+            ("10", 10, False),
+            ("1", 1, False),
+            ("100", 100, False),
+            ("0", None, True),
+            ("-1", None, True),
+            ("invalid", None, True),
+            ("", None, True),
+        ]
+
+        for input_value, expected, should_raise in test_cases:
+            with self.subTest(input_value=input_value, expected=expected, should_raise=should_raise):
+                if should_raise:
+                    with self.assertRaises(argparse.ArgumentTypeError):
+                        find_package_dependents.max_result_type(input_value)
+                else:
+                    result = find_package_dependents.max_result_type(input_value)
+                    self.assertEqual(result, expected)
+
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_dnf_command_execution(self, mock_run_command):
+        """Test that DNF commands are properly constructed and executed with repository configuration."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "bootc-1.0.0-1.x86_64\ncontainer-tools-2.0.0-1.x86_64"
+        }
+
+        result = find_package_dependents.dnf(
+            "repoquery --whatdepends podman",
+            self.repositories,
+            verbose=True
+        )
+
+        mock_run_command.assert_called_once()
+        call_args = mock_run_command.call_args[0][0]
+        self.assertIn("dnf", call_args)
+        self.assertIn("--disablerepo=*", call_args)
+        self.assertIn("--cacheonly", call_args)
+        self.assertIn("--repofrompath=repo-BaseOS,http://example.com/repo/BaseOS/x86_64/os/", call_args)
+        self.assertIn("--enablerepo=repo-BaseOS", call_args)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_generate_direct_dependents(self, mock_run_command):
+        """Test that direct package dependents are correctly identified and returned."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "bootc\ntoolbox\ncontainer-tools"
+        }
+
+        dependents = list(find_package_dependents.generate_direct_dependents(
+            "podman",
+            self.repositories,
+            self.metrics,
+            self.dependency_cache,
+            verbose=True
+        ))
+
+        self.assertEqual(len(dependents), 3)
+        self.assertIn("bootc", dependents)
+        self.assertIn("toolbox", dependents)
+        self.assertIn("container-tools", dependents)
+
+        cached_dependents = list(find_package_dependents.generate_direct_dependents(
+            "podman",
+            self.repositories,
+            self.metrics,
+            self.dependency_cache,
+            verbose=True,
+            cache_only=True
+        ))
+
+        self.assertEqual(cached_dependents, dependents)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_query_source_package(self, mock_run_command):
+        """Test that source package names are correctly queried from binary package names."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "podman-1.0.0-1.src.rpm"
+        }
+
+        source_package = find_package_dependents.query_source_package(
+            "podman",
+            self.repositories,
+            self.metrics,
+            self.source_cache,
+            verbose=True
+        )
+
+        self.assertEqual(source_package, "podman")
+
+        cached_source = find_package_dependents.query_source_package(
+            "podman",
+            self.repositories,
+            self.metrics,
+            self.source_cache,
+            verbose=True
+        )
+
+        self.assertEqual(cached_source, "podman")
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_query_source_not_found(self, mock_run_command):
+        """Test that missing packages are properly handled with appropriate error messages."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": ""
+        }
+
+        with self.assertRaises(find_package_dependents.PackageNotFoundError):
+            find_package_dependents.query_source_package(
+                "non-existent-package",
+                self.repositories,
+                self.metrics,
+                self.source_cache,
+                verbose=False
+            )
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_query_source_allow_missing(self, mock_run_command):
+        """Test that missing packages are gracefully handled when allow_missing is enabled."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": ""
+        }
+
+        source_package = find_package_dependents.query_source_package(
+            "non-existent-package",
+            self.repositories,
+            self.metrics,
+            self.source_cache,
+            verbose=False,
+            allow_missing=True
+        )
+
+        self.assertEqual(source_package, "")
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_query_package_description(self, mock_run_command):
+        """Test that package descriptions are correctly retrieved and formatted."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "This is a container engine\nwith multiple lines\nof description"
+        }
+
+        description = find_package_dependents.query_package_description(
+            "podman",
+            self.repositories,
+            self.metrics,
+            verbose=False
+        )
+
+        self.assertEqual(description, "This is a container engine with multiple lines of description")
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_run_filter_command(self, mock_run_command):
+        """Test that filter commands are correctly executed on package names."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "filtered output"
+        }
+
+        result = find_package_dependents.run_filter_command(
+            "bootc",
+            "echo $PACKAGE | grep -q bootc",
+            self.metrics,
+            self.filter_cache,
+            verbose=False
+        )
+
+        self.assertTrue(result)
+
+        cached_result = find_package_dependents.run_filter_command(
+            "bootc",
+            "echo $PACKAGE | grep -q bootc",
+            self.metrics,
+            self.filter_cache,
+            verbose=False
+        )
+
+        self.assertTrue(cached_result)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_filter_command_failure(self, mock_run_command):
+        """Test that failed filter commands are properly handled."""
+        mock_run_command.return_value = {
+            "return_code": 1,
+            "output": "filter failed"
+        }
+
+        result = find_package_dependents.run_filter_command(
+            "toolbox",
+            "echo $PACKAGE | grep -q nonexistent",
+            self.metrics,
+            self.filter_cache,
+            verbose=False
+        )
+
+        self.assertFalse(result)
+
+    def test_filter_command_empty(self):
+        """Test that empty filter commands are treated as passing."""
+        result = find_package_dependents.run_filter_command(
+            "container-tools",
+            "",
+            self.metrics,
+            self.filter_cache,
+            verbose=False
+        )
+
+        self.assertTrue(result)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_update_dnf_cache(self, mock_run_command):
+        """Test that DNF cache is successfully updated."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "Cache updated successfully"
+        }
+
+        find_package_dependents.update_dnf_cache(self.repositories, verbose=False)
+
+        mock_run_command.assert_called_once()
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_dnf_cache_failure(self, mock_run_command):
+        """Test that DNF cache update failures are properly handled with exceptions."""
+        mock_run_command.side_effect = subprocess.CalledProcessError(
+            1, "dnf makecache", "Cache update failed", "Error message"
+        )
+
+        with self.assertRaises(find_package_dependents.RepoQueryError):
+            find_package_dependents.update_dnf_cache(self.repositories, verbose=False)
+
+
+    def test_convert_to_source_packages(self):
+        """Test that binary packages are correctly converted to their source package equivalents."""
+        with patch.object(find_package_dependents, 'query_source_package') as mock_query:
+            mock_query.side_effect = lambda pkg, *args, **kwargs: f"{pkg}-source" if pkg != "not-found" else ""
+
+            def binary_packages():
+                yield "bootc"
+                yield "toolbox"
+                yield "not-found"
+                yield "container-tools"
+
+            source_packages = list(find_package_dependents.convert_to_source_packages(
+                binary_packages(),
+                self.repositories,
+                self.metrics,
+                self.source_cache,
+                self.filter_cache,
+                max_results=5,
+                verbose=False
+            ))
+
+            self.assertEqual(len(source_packages), 3)
+            self.assertIn("bootc-source", source_packages)
+            self.assertIn("toolbox-source", source_packages)
+            self.assertIn("container-tools-source", source_packages)
+
+    def test_convert_to_source_with_filter(self):
+        """Test that source package conversion respects filter commands."""
+        with patch.object(find_package_dependents, 'query_source_package') as mock_query:
+            mock_query.side_effect = lambda pkg, *args, **kwargs: f"{pkg}-source"
+
+            with patch.object(find_package_dependents, 'run_filter_command') as mock_filter:
+                mock_filter.side_effect = lambda pkg, cmd, *args, **kwargs: pkg != "toolbox-source"
+
+                def binary_packages():
+                    yield "bootc"
+                    yield "toolbox"
+                    yield "container-tools"
+
+                source_packages = list(find_package_dependents.convert_to_source_packages(
+                    binary_packages(),
+                    self.repositories,
+                    self.metrics,
+                    self.source_cache,
+                    self.filter_cache,
+                    filter_command="test filter",
+                    verbose=False
+                ))
+
+                self.assertEqual(len(source_packages), 2)
+                self.assertIn("bootc-source", source_packages)
+                self.assertIn("container-tools-source", source_packages)
+
+    def test_build_dependents_list(self):
+        """Test that complete lists of package dependents are correctly built."""
+        with patch.object(find_package_dependents, 'generate_direct_dependents') as mock_generate:
+            mock_generate.return_value = iter(["bootc", "toolbox", "container-tools"])
+
+            with patch.object(find_package_dependents, 'run_filter_command') as mock_filter:
+                mock_filter.return_value = True
+
+                dependents = find_package_dependents.build_dependents_list(
+                    "podman",
+                    self.repositories,
+                    show_source_packages=False,
+                    source_cache=self.source_cache,
+                    metrics=self.metrics,
+                    filter_cache=self.filter_cache,
+                    dependency_cache=self.dependency_cache,
+                    verbose=False
+                )
+
+                self.assertEqual(len(dependents), 3)
+                self.assertIn("bootc", dependents)
+                self.assertIn("toolbox", dependents)
+                self.assertIn("container-tools", dependents)
+
+    def test_build_dependents_with_max_results(self):
+        """Test that dependents lists respect maximum result limits."""
+        with patch.object(find_package_dependents, 'generate_direct_dependents') as mock_generate:
+            mock_generate.return_value = iter(["bootc", "toolbox", "container-tools", "skopeo", "buildah"])
+
+            with patch.object(find_package_dependents, 'run_filter_command') as mock_filter:
+                mock_filter.return_value = True
+
+                dependents = find_package_dependents.build_dependents_list(
+                    "podman",
+                    self.repositories,
+                    show_source_packages=False,
+                    source_cache=self.source_cache,
+                    metrics=self.metrics,
+                    filter_cache=self.filter_cache,
+                    dependency_cache=self.dependency_cache,
+                    max_results=3,
+                    verbose=False
+                )
+
+                self.assertEqual(len(dependents), 3)
+                self.assertIn("bootc", dependents)
+                self.assertIn("toolbox", dependents)
+
+    def test_build_dependents_no_dependents(self):
+        """Test that appropriate errors are raised when no dependents are found."""
+        with patch.object(find_package_dependents, 'generate_direct_dependents') as mock_generate:
+            mock_generate.return_value = iter([])
+
+            with self.assertRaises(find_package_dependents.NoDependentsFoundError):
+                find_package_dependents.build_dependents_list(
+                    "podman",
+                    self.repositories,
+                    show_source_packages=False,
+                    source_cache=self.source_cache,
+                    metrics=self.metrics,
+                    filter_cache=self.filter_cache,
+                    dependency_cache=self.dependency_cache,
+                    verbose=False
+                )
+
+    def test_build_dependents_list_with_source_packages(self):
+        """Test that build_dependents_list correctly converts to source packages when show_source_packages=True."""
+        with patch.object(find_package_dependents, 'generate_direct_dependents') as mock_generate:
+            mock_generate.return_value = iter(["bootc", "toolbox", "container-tools"])
+
+            with patch.object(find_package_dependents, 'convert_to_source_packages') as mock_convert:
+                mock_convert.return_value = iter(["bootc-src", "toolbox-src", "container-tools-src"])
+
+                dependents = find_package_dependents.build_dependents_list(
+                    "podman",
+                    self.repositories,
+                    show_source_packages=True,  # This is the key parameter
+                    source_cache=self.source_cache,
+                    metrics=self.metrics,
+                    filter_cache=self.filter_cache,
+                    dependency_cache=self.dependency_cache,
+                    verbose=False
+                )
+
+                self.assertEqual(len(dependents), 3)
+                self.assertIn("bootc-src", dependents)
+                self.assertIn("toolbox-src", dependents)
+                self.assertIn("container-tools-src", dependents)
+
+                mock_convert.assert_called_once()
+
+    def test_build_dependents_list_without_source_packages(self):
+        """Test that build_dependents_list returns binary package names when show_source_packages=False."""
+        with patch.object(find_package_dependents, 'generate_direct_dependents') as mock_generate:
+            mock_generate.return_value = iter(["bootc", "toolbox", "container-tools"])
+
+            with patch.object(find_package_dependents, 'convert_to_source_packages') as mock_convert:
+                dependents = find_package_dependents.build_dependents_list(
+                    "podman",
+                    self.repositories,
+                    show_source_packages=False,  # Default behavior
+                    source_cache=self.source_cache,
+                    metrics=self.metrics,
+                    filter_cache=self.filter_cache,
+                    dependency_cache=self.dependency_cache,
+                    verbose=False
+                )
+
+                self.assertEqual(len(dependents), 3)
+                self.assertIn("bootc", dependents)
+                self.assertIn("toolbox", dependents)
+                self.assertIn("container-tools", dependents)
+
+                mock_convert.assert_not_called()
+
+    def test_compute_transitive_closure(self):
+        """Test that transitive dependency relationships are correctly computed."""
+        dependents_map = {
+            "libwayland-server": {"dependents": ["mutter", "weston"], "partial": False},
+            "mutter": {"dependents": ["gnome-shell"], "partial": False},
+            "weston": {"dependents": ["kwin"], "partial": False},
+            "gnome-shell": {"dependents": [], "partial": False},
+        }
+
+        result = find_package_dependents.compute_transitive_closure("libwayland-server", dependents_map)
+
+        self.assertIn("libwayland-server", result)
+        self.assertIn("mutter", result)
+        self.assertIn("weston", result)
+        self.assertIn("gnome-shell", result)
+
+        root_dependents = result["libwayland-server"]["dependents"]
+        self.assertIn("mutter", root_dependents)
+        self.assertIn("weston", root_dependents)
+        self.assertIn("gnome-shell", root_dependents)
+
+    def test_transitive_closure_with_filter(self):
+        """Test that transitive closure computation respects filter functions."""
+        dependents_map = {
+            "libwayland-server": {"dependents": ["mutter", "weston"], "partial": False},
+            "mutter": {"dependents": ["gnome-shell"], "partial": False},
+            "weston": {"dependents": ["kwin"], "partial": False},
+            "gnome-shell": {"dependents": [], "partial": False},
+        }
+
+        def filter_function(package, dependents):
+            if package == "weston":
+                return False
+            return True
+
+        result = find_package_dependents.compute_transitive_closure("libwayland-server", dependents_map, filter_function=filter_function)
+
+        self.assertIn("libwayland-server", result)
+        self.assertIn("mutter", result)
+        self.assertIn("weston", result)
+        self.assertIn("gnome-shell", result)
+
+        root_dependents = result["libwayland-server"]["dependents"]
+        self.assertIn("mutter", root_dependents)
+        self.assertNotIn("weston", root_dependents)
+        self.assertIn("gnome-shell", root_dependents)
+
+    def test_deep_narrow_dependent_tree(self):
+        """Test that deep and narrow dependent trees are correctly handled with proper partial flags."""
+        dependents_map = {
+            "libwayland-server": {"dependents": ["mutter"], "partial": False},
+            "mutter": {"dependents": ["gnome-shell"], "partial": False},
+            "gnome-shell": {"dependents": ["gnome-session"], "partial": False},
+            "gnome-session": {"dependents": ["gnome-initial-setup"], "partial": False},
+            "gnome-initial-setup": {"dependents": ["gnome-control-center"], "partial": False},
+            "gnome-control-center": {"dependents": [], "partial": False},
+        }
+
+        result = find_package_dependents.compute_transitive_closure("libwayland-server", dependents_map)
+
+        self.assertIn("libwayland-server", result)
+        self.assertIn("mutter", result)
+        self.assertIn("gnome-shell", result)
+        self.assertIn("gnome-session", result)
+        self.assertIn("gnome-initial-setup", result)
+        self.assertIn("gnome-control-center", result)
+
+        root_dependents = result["libwayland-server"]["dependents"]
+        self.assertIn("mutter", root_dependents)
+        self.assertIn("gnome-shell", root_dependents)
+        self.assertIn("gnome-session", root_dependents)
+        self.assertIn("gnome-initial-setup", root_dependents)
+        self.assertIn("gnome-control-center", root_dependents)
+
+        for package_data in result.values():
+            self.assertFalse(package_data["partial"])
+
+    def test_deep_tree_max_results_scenarios(self):
+        """Test various max-results and partial flag scenarios in deep dependency trees."""
+        test_scenarios = [
+            {
+                "name": "basic_max_results_limit",
+                "description": "Test max-results limits creating partial results",
+                "dependents_map": {
+                    "libwayland-server": {"dependents": ["mutter", "weston"], "partial": True},
+                    "mutter": {"dependents": ["gnome-shell"], "partial": False},
+                    "weston": {"dependents": ["kwin"], "partial": False},
+                    "gnome-shell": {"dependents": ["gnome-session"], "partial": False},
+                    "kwin": {"dependents": ["plasma-desktop"], "partial": False},
+                    "gnome-session": {"dependents": [], "partial": False},
+                    "plasma-desktop": {"dependents": [], "partial": False},
+                },
+                "filter_func": lambda package, dependents: True if package == "libwayland-server" else len(dependents) < 2,
+                "expected_root_partial": True,
+                "expected_max_root_dependents": 2,
+                "expected_non_partial": ["mutter", "weston", "gnome-shell", "kwin"]
+            },
+            {
+                "name": "non_root_package_limits",
+                "description": "Test max-results limits on non-root packages",
+                "dependents_map": {
+                    "libwayland-server": {"dependents": ["mutter", "weston"], "partial": False},
+                    "mutter": {"dependents": ["gnome-shell", "gnome-session", "gnome-control-center"], "partial": True},
+                    "weston": {"dependents": ["kwin"], "partial": False},
+                    "gnome-shell": {"dependents": ["gnome-initial-setup"], "partial": False},
+                    "gnome-session": {"dependents": ["gnome-settings-daemon"], "partial": False},
+                    "gnome-control-center": {"dependents": [], "partial": False},
+                    "kwin": {"dependents": ["plasma-desktop"], "partial": False},
+                    "gnome-initial-setup": {"dependents": [], "partial": False},
+                    "gnome-settings-daemon": {"dependents": [], "partial": False},
+                    "plasma-desktop": {"dependents": [], "partial": False},
+                },
+                "filter_func": lambda package, dependents: True if package == "mutter" else len(dependents) < 2,
+                "expected_root_partial": True,
+                "expected_mutter_partial": True,
+                "expected_max_mutter_dependents": 2,
+                "expected_non_partial": ["weston", "gnome-shell", "kwin"]
+            },
+            {
+                "name": "multiple_partial_branches",
+                "description": "Test multiple branches with different partial states",
+                "dependents_map": {
+                    "libwayland-server": {"dependents": ["mutter", "weston"], "partial": False},
+                    "mutter": {"dependents": ["gnome-shell"], "partial": True},
+                    "weston": {"dependents": ["kwin"], "partial": False},
+                    "gnome-shell": {"dependents": ["gnome-session"], "partial": False},
+                    "kwin": {"dependents": ["plasma-desktop"], "partial": False},
+                    "gnome-session": {"dependents": [], "partial": False},
+                    "plasma-desktop": {"dependents": [], "partial": False},
+                },
+                "filter_func": None,  # No filter function
+                "expected_root_partial": True,
+                "expected_mutter_partial": True,
+                "expected_non_partial": ["weston", "gnome-shell", "kwin", "gnome-session", "plasma-desktop"]
+            },
+            {
+                "name": "edge_case_single_dependent",
+                "description": "Test edge case with single dependent limit",
+                "dependents_map": {
+                    "libwayland-server": {"dependents": ["mutter"], "partial": True},
+                    "mutter": {"dependents": ["gnome-shell"], "partial": False},
+                    "gnome-shell": {"dependents": ["gnome-session"], "partial": False},
+                    "gnome-session": {"dependents": [], "partial": False},
+                },
+                "filter_func": lambda package, dependents: True if package == "libwayland-server" else len(dependents) < 1,
+                "expected_root_partial": True,
+                "expected_exact_root_dependents": 1,
+                "expected_root_has_mutter": True,
+                "expected_non_partial": ["mutter", "gnome-shell", "gnome-session"]
+            },
+            {
+                "name": "zero_max_results",
+                "description": "Test behavior with zero dependents allowed",
+                "dependents_map": {
+                    "libwayland-server": {"dependents": [], "partial": True},
+                    "mutter": {"dependents": ["gnome-shell"], "partial": False},
+                    "gnome-shell": {"dependents": [], "partial": False},
+                },
+                "filter_func": lambda package, dependents: False if package == "libwayland-server" and len(dependents) > 0 else True,
+                "expected_root_partial": True,
+                "expected_exact_root_dependents": 0,
+                "expected_non_partial": ["mutter", "gnome-shell"]
+            }
+        ]
+
+        for scenario in test_scenarios:
+            with self.subTest(scenario=scenario["name"]):
+                result = find_package_dependents.compute_transitive_closure(
+                    "libwayland-server",
+                    scenario["dependents_map"],
+                    filter_function=scenario["filter_func"]
+                )
+
+                self.assertEqual(result["libwayland-server"]["partial"], scenario["expected_root_partial"])
+
+                root_dependents = result["libwayland-server"]["dependents"]
+                if "expected_max_root_dependents" in scenario:
+                    self.assertLessEqual(len(root_dependents), scenario["expected_max_root_dependents"])
+                if "expected_exact_root_dependents" in scenario:
+                    self.assertEqual(len(root_dependents), scenario["expected_exact_root_dependents"])
+                if "expected_root_has_mutter" in scenario:
+                    self.assertIn("mutter", root_dependents)
+
+                if "expected_mutter_partial" in scenario:
+                    self.assertTrue(result["mutter"]["partial"])
+                    if "expected_max_mutter_dependents" in scenario:
+                        mutter_dependents = result["mutter"]["dependents"]
+                        self.assertLessEqual(len(mutter_dependents), scenario["expected_max_mutter_dependents"])
+
+                if "expected_non_partial" in scenario:
+                    for package in scenario["expected_non_partial"]:
+                        if package in result:
+                            self.assertFalse(result[package]["partial"], f"Package {package} should not be partial")
+
+    def test_json_output_with_partial_flags(self):
+        """Test JSON output with mixed partial flags and descriptions."""
+        test_cases = [
+            {
+                "name": "mixed_partial_flags_only",
+                "describe": False,
+                "package_descriptions": None,
+                "expected_has_descriptions": False
+            },
+            {
+                "name": "partial_flags_with_descriptions",
+                "describe": True,
+                "package_descriptions": {
+                    "libwayland-server": "Wayland display server library",
+                    "mutter": "GNOME window manager",
+                    "weston": "Wayland reference compositor",
+                    "gnome-shell": "GNOME desktop shell",
+                    "kwin": "KDE window manager"
+                },
+                "expected_has_descriptions": True
+            }
+        ]
+
+        for case in test_cases:
+            with self.subTest(scenario=case["name"]):
+                arguments = Mock()
+                arguments.all = True
+                arguments.package_name = "libwayland-server"
+                arguments.describe = case["describe"]
+
+                dependents_data = [
+                    {"package": "libwayland-server", "dependents": ["mutter", "weston"], "partial": True},
+                    {"package": "mutter", "dependents": ["gnome-shell"], "partial": False},
+                    {"package": "weston", "dependents": ["kwin"], "partial": False},
+                    {"package": "gnome-shell", "dependents": [], "partial": False},
+                    {"package": "kwin", "dependents": [], "partial": False}
+                ]
+
+                output = find_package_dependents.generate_json_output(
+                    arguments, dependents_data, case["package_descriptions"]
+                )
+
+                parsed = json.loads(output)
+                self.assertEqual(len(parsed), 5)
+
+                root_package = next(pkg for pkg in parsed if pkg["package"] == "libwayland-server")
+                self.assertTrue(root_package["partial"])
+
+                for pkg_name in ["mutter", "weston", "gnome-shell", "kwin"]:
+                    pkg = next(p for p in parsed if p["package"] == pkg_name)
+                    self.assertFalse(pkg["partial"])
+
+                if case["expected_has_descriptions"]:
+                    self.assertEqual(root_package["description"], "Wayland display server library")
+                    mutter_pkg = next(p for p in parsed if p["package"] == "mutter")
+                    self.assertEqual(mutter_pkg["description"], "GNOME window manager")
+                else:
+                    self.assertNotIn("description", root_package)
+
+    def test_build_repository_paths(self):
+        """Test repository path construction with various input scenarios."""
+        test_cases = [
+            {
+                "name": "standard_repository_names",
+                "base_url": "http://example.com/repo",
+                "repository_names": "BaseOS,AppStream",
+                "arch": "x86_64",
+                "should_raise": False,
+                "expected_repos": ["BaseOS", "AppStream", "BaseOS-sources", "AppStream-sources"],
+                "expected_paths": {
+                    "BaseOS": "http://example.com/repo/compose/BaseOS/x86_64/os/",
+                    "AppStream": "http://example.com/repo/compose/AppStream/x86_64/os/",
+                    "BaseOS-sources": "http://example.com/repo/compose/BaseOS/source/tree/",
+                    "AppStream-sources": "http://example.com/repo/compose/AppStream/source/tree/"
+                }
+            },
+            {
+                "name": "mixed_names_and_urls",
+                "base_url": "http://example.com/repo",
+                "repository_names": "BaseOS,https://custom.repo.com/special/",
+                "arch": "x86_64",
+                "should_raise": False,
+                "expected_repos": ["BaseOS"],
+                "expected_paths": {
+                    "BaseOS": "http://example.com/repo/compose/BaseOS/x86_64/os/"
+                },
+                "has_custom_repo": True,
+                "custom_repo_prefix": "special_",
+                "custom_repo_url_start": "https://custom.repo.com/special"
+            },
+            {
+                "name": "empty_repository_names",
+                "base_url": "http://example.com/repo",
+                "repository_names": "",
+                "arch": "x86_64",
+                "should_raise": True
+            }
+        ]
+
+        for case in test_cases:
+            with self.subTest(scenario=case["name"]):
+                if case["should_raise"]:
+                    with self.assertRaises(SystemExit):
+                        find_package_dependents.build_repository_paths(
+                            case["base_url"], case["repository_names"], case["arch"]
+                        )
+                else:
+                    paths = find_package_dependents.build_repository_paths(
+                        case["base_url"], case["repository_names"], case["arch"]
+                    )
+
+                    for repo in case["expected_repos"]:
+                        self.assertIn(repo, paths)
+
+                    for repo, expected_path in case["expected_paths"].items():
+                        self.assertEqual(paths[repo], expected_path)
+
+                    if case.get("has_custom_repo"):
+                        custom_key = None
+                        for key in paths.keys():
+                            if key.startswith(case["custom_repo_prefix"]):
+                                custom_key = key
+                                break
+                        self.assertIsNotNone(custom_key, "Custom repository key not found")
+                        self.assertTrue(paths[custom_key].startswith(case["custom_repo_url_start"]))
+
+    def test_generate_json_output(self):
+        """Test JSON output generation with and without descriptions."""
+        test_cases = [
+            {
+                "name": "without_descriptions",
+                "describe": False,
+                "package_descriptions": None,
+                "expected_has_description": False
+            },
+            {
+                "name": "with_descriptions",
+                "describe": True,
+                "package_descriptions": {
+                    "podman": "Container engine for managing pods and containers",
+                    "bootc": "Bootable container images for Fedora CoreOS",
+                    "toolbox": "Tool for developing inside containers"
+                },
+                "expected_has_description": True
+            }
+        ]
+
+        for case in test_cases:
+            with self.subTest(scenario=case["name"]):
+                arguments = Mock()
+                arguments.all = False
+                arguments.package_name = "podman"
+                arguments.describe = case["describe"]
+
+                dependents_data = ["bootc", "toolbox", "container-tools"]
+
+                output = find_package_dependents.generate_json_output(
+                    arguments, dependents_data, case["package_descriptions"]
+                )
+
+                parsed = json.loads(output)
+                self.assertEqual(len(parsed), 1)
+                self.assertEqual(parsed[0]["package"], "podman")
+                self.assertEqual(parsed[0]["dependents"], ["bootc", "toolbox", "container-tools"])
+
+                if case["expected_has_description"]:
+                    self.assertIn("description", parsed[0])
+                    self.assertEqual(parsed[0]["description"], "Container engine for managing pods and containers")
+                else:
+                    self.assertNotIn("description", parsed[0])
+
+    def test_generate_plain_output(self):
+        """Test plain text output generation with and without descriptions."""
+        test_cases = [
+            {
+                "name": "without_descriptions",
+                "describe": False,
+                "dependents_data": ["bootc", "toolbox", "container-tools"],
+                "package_descriptions": None,
+                "expected_lines": ["bootc", "toolbox", "container-tools"]
+            },
+            {
+                "name": "with_descriptions",
+                "describe": True,
+                "dependents_data": ["bootc", "toolbox"],
+                "package_descriptions": {
+                    "bootc": "Bootable container images for Fedora CoreOS",
+                    "toolbox": "Tool for developing inside containers"
+                },
+                "expected_lines": [
+                    "bootc: Bootable container images for Fedora CoreOS",
+                    "toolbox: Tool for developing inside containers"
+                ]
+            }
+        ]
+
+        for case in test_cases:
+            with self.subTest(scenario=case["name"]):
+                arguments = Mock()
+                arguments.all = False
+                arguments.describe = case["describe"]
+
+                output = find_package_dependents.generate_plain_output(
+                    arguments, case["dependents_data"], case["package_descriptions"]
+                )
+
+                lines = output.split('\n')
+                self.assertEqual(len(lines), len(case["expected_lines"]))
+
+                for expected_line in case["expected_lines"]:
+                    self.assertIn(expected_line, lines)
+
+    def test_generate_output_formats(self):
+        """Test output format selection (JSON vs plain text)."""
+        test_cases = [
+            {
+                "name": "json_format",
+                "format": "json",
+                "validator": lambda output: json.loads(output) and isinstance(json.loads(output), list)
+            },
+            {
+                "name": "plain_format",
+                "format": "plain",
+                "validator": lambda output: isinstance(output, str) and "bootc" in output and "toolbox" in output
+            }
+        ]
+
+        for case in test_cases:
+            with self.subTest(format=case["format"]):
+                arguments = Mock()
+                arguments.format = case["format"]
+                arguments.all = False
+                arguments.package_name = "podman"
+                arguments.describe = False
+
+                dependents_data = ["bootc", "toolbox"]
+                package_descriptions = None
+
+                output = find_package_dependents.generate_output(
+                    arguments, dependents_data, package_descriptions
+                )
+
+                self.assertTrue(case["validator"](output))
+
+    def test_write_output_to_file(self):
+        """Test that output is correctly written to files."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+            temp_path = Path(temp_file.name)
+
+        try:
+            output_data = "test output\nwith multiple lines"
+            find_package_dependents.write_output(output_data, temp_path)
+
+            with open(temp_path, 'r') as f:
+                written_data = f.read()
+
+            self.assertEqual(written_data, output_data)
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+    def test_write_output_to_stdout(self):
+        """Test that output is correctly written to standard output."""
+        output_data = "test output"
+
+        with captured_stdout() as captured:
+            find_package_dependents.write_output(output_data, None)
+
+            output = captured.getvalue()
+            self.assertEqual(output, output_data + "\n")
+
+    def test_display_statistics(self):
+        """Test that performance statistics are correctly displayed."""
+        with captured_stderr() as captured:
+            find_package_dependents.display_statistics(
+                "test filter",
+                self.metrics,
+                self.source_cache,
+                self.filter_cache,
+                self.dependency_cache
+            )
+
+            output = captured.getvalue()
+            self.assertIn("statistics", output.lower())
+
+    def test_log_operation(self):
+        """Test that operation logging works correctly."""
+        find_package_dependents.log_operation(
+            "podman",
+            True,
+            True,
+            10,
+            "test filter",
+            Path("/tmp/test")
+        )
+
+    def test_set_up_logging(self):
+        """Test that logging configuration is correctly set up."""
+        find_package_dependents.set_up_logging(True, None)
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_file:
+            temp_path = Path(temp_file.name)
+
+        try:
+            find_package_dependents.set_up_logging(False, temp_path)
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_basic_functionality(self, mock_run_command):
+        """Test that the main function correctly processes package dependencies and outputs results."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "bootc\ntoolbox\ncontainer-tools"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'podman']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "podman"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = False
+                mock_args.source_packages = False
+                mock_args.max_results = None
+                mock_args.format = "plain"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = None
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_list') as mock_build_list:
+                        mock_build_list.return_value = ["bootc", "toolbox", "container-tools"]
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+
+                            self.assertIn("bootc", output)
+                            self.assertIn("toolbox", output)
+                            self.assertIn("container-tools", output)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_json_output(self, mock_run_command):
+        """Test that the main function correctly generates JSON output format."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "bootc\ntoolbox"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'podman', '--format', 'json']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "podman"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = False
+                mock_args.source_packages = False
+                mock_args.max_results = None
+                mock_args.format = "json"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = None
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_list') as mock_build_list:
+                        mock_build_list.return_value = ["bootc", "toolbox"]
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            parsed = json.loads(output)
+                            self.assertIsInstance(parsed, list)
+                            self.assertEqual(len(parsed), 1)
+                            self.assertEqual(parsed[0]["package"], "podman")
+                            self.assertEqual(parsed[0]["dependents"], ["bootc", "toolbox"])
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_filter_command(self, mock_run_command):
+        """Test that the main function correctly applies filter commands to package dependents."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "bootc\ntoolbox\ncontainer-tools"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'podman', '--filter-command', 'echo $PACKAGE | grep -q bootc']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "podman"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = False
+                mock_args.source_packages = False
+                mock_args.max_results = None
+                mock_args.format = "plain"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = "echo $PACKAGE | grep -q bootc"
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_list') as mock_build_list:
+                        mock_build_list.return_value = ["bootc"]
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            self.assertIn("bootc", output)
+                            self.assertNotIn("toolbox", output)
+                            self.assertNotIn("container-tools", output)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_max_results(self, mock_run_command):
+        """Test that the main function correctly limits output to maximum number of results."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "bootc\ntoolbox\ncontainer-tools\nskopeo\nbuildah"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'podman', '--max-results', '2']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "podman"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = False
+                mock_args.source_packages = False
+                mock_args.max_results = 2
+                mock_args.format = "plain"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = None
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_list') as mock_build_list:
+                        mock_build_list.return_value = ["bootc", "toolbox"]
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            self.assertIn("bootc", output)
+                            self.assertIn("toolbox", output)
+                            self.assertNotIn("container-tools", output)
+                            self.assertNotIn("skopeo", output)
+                            self.assertNotIn("buildah", output)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_allow_missing(self, mock_run_command):
+        """Test that the main function gracefully handles missing packages when allow_missing is enabled."""
+        mock_run_command.side_effect = subprocess.CalledProcessError(
+            1, "dnf repoquery", "Package not found", "Error: No package found"
+        )
+
+        with patch('sys.argv', ['find-package-dependents.py', 'non-existent-package', '--allow-missing']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "non-existent-package"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = False
+                mock_args.source_packages = False
+                mock_args.max_results = None
+                mock_args.format = "plain"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = None
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = True
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_list') as mock_build_list:
+                        mock_build_list.return_value = []
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            self.assertEqual(output.strip(), "")
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_deep_tree_with_max_results(self, mock_run_command):
+        """Test that the main function correctly handles deep trees with max-results limits."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "mutter\nweston"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'libwayland-server', '--max-results', '2', '--all', '--format', 'json']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "libwayland-server"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = True
+                mock_args.source_packages = False
+                mock_args.max_results = 2
+                mock_args.format = "json"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = None
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_graph') as mock_build_graph:
+                        mock_build_graph.return_value = {
+                            "libwayland-server": {
+                                "dependents": ["mutter", "weston"],
+                                "partial": True
+                            },
+                            "mutter": {
+                                "dependents": ["gnome-shell"],
+                                "partial": False
+                            },
+                            "weston": {
+                                "dependents": ["kwin"],
+                                "partial": False
+                            },
+                            "gnome-shell": {
+                                "dependents": [],
+                                "partial": False
+                            },
+                            "kwin": {
+                                "dependents": [],
+                                "partial": False
+                            }
+                        }
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            parsed = json.loads(output)
+
+                            self.assertEqual(len(parsed), 5)
+
+                            root_package = next(pkg for pkg in parsed if pkg["package"] == "libwayland-server")
+                            self.assertTrue(root_package["partial"])
+                            self.assertEqual(len(root_package["dependents"]), 2)
+
+                            mutter_package = next(pkg for pkg in parsed if pkg["package"] == "mutter")
+                            self.assertFalse(mutter_package["partial"])
+
+                            weston_package = next(pkg for pkg in parsed if pkg["package"] == "weston")
+                            self.assertFalse(weston_package["partial"])
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_deep_tree_with_filter_and_max_results(self, mock_run_command):
+        """Test that the main function correctly combines filter commands with max-results in deep trees."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "mutter\nweston"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'libwayland-server', '--max-results', '1', '--filter-command', 'echo $PACKAGE | grep -q mutter', '--all', '--format', 'json']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "libwayland-server"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = True
+                mock_args.source_packages = False
+                mock_args.max_results = 1
+                mock_args.format = "json"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = "echo $PACKAGE | grep -q mutter"
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_graph') as mock_build_graph:
+                        mock_build_graph.return_value = {
+                            "libwayland-server": {
+                                "dependents": ["mutter"],
+                                "partial": True
+                            },
+                            "mutter": {
+                                "dependents": ["gnome-shell"],
+                                "partial": False
+                            },
+                            "gnome-shell": {
+                                "dependents": [],
+                                "partial": False
+                            }
+                        }
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            parsed = json.loads(output)
+
+                            self.assertEqual(len(parsed), 3)
+
+                            root_package = next(pkg for pkg in parsed if pkg["package"] == "libwayland-server")
+                            self.assertTrue(root_package["partial"])
+                            self.assertEqual(len(root_package["dependents"]), 1)
+                            self.assertIn("mutter", root_package["dependents"])
+
+                            self.assertNotIn("weston", root_package["dependents"])
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_deep_tree_with_descriptions_and_partial_flags(self, mock_run_command):
+        """Test that the main function correctly includes descriptions with partial flags in deep trees."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "mutter\nweston"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'libwayland-server', '--max-results', '2', '--all', '--format', 'json', '--describe']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "libwayland-server"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = True
+                mock_args.source_packages = False
+                mock_args.max_results = 2
+                mock_args.format = "json"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = None
+                mock_args.describe = True
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_graph') as mock_build_graph:
+                        mock_build_graph.return_value = {
+                            "libwayland-server": {
+                                "dependents": ["mutter", "weston"],
+                                "partial": True
+                            },
+                            "mutter": {
+                                "dependents": ["gnome-shell"],
+                                "partial": False
+                            },
+                            "weston": {
+                                "dependents": ["kwin"],
+                                "partial": False
+                            },
+                            "gnome-shell": {
+                                "dependents": [],
+                                "partial": False
+                            },
+                            "kwin": {
+                                "dependents": [],
+                                "partial": False
+                            }
+                        }
+
+                        with patch.object(find_package_dependents, 'collect_package_descriptions') as mock_collect_descriptions:
+                            mock_collect_descriptions.return_value = {
+                                "libwayland-server": "Wayland display server library",
+                                "mutter": "GNOME window manager",
+                                "weston": "Wayland reference compositor",
+                                "gnome-shell": "GNOME desktop shell",
+                                "kwin": "KDE window manager"
+                            }
+
+                            with captured_stdout() as captured:
+                                find_package_dependents.main()
+
+                                output = captured.getvalue()
+                                parsed = json.loads(output)
+
+                                self.assertEqual(len(parsed), 5)
+
+                                root_package = next(pkg for pkg in parsed if pkg["package"] == "libwayland-server")
+                                self.assertEqual(root_package["description"], "Wayland display server library")
+                                self.assertTrue(root_package["partial"])
+
+                                mutter_package = next(pkg for pkg in parsed if pkg["package"] == "mutter")
+                                self.assertEqual(mutter_package["description"], "GNOME window manager")
+                                self.assertFalse(mutter_package["partial"])
+
+                                weston_package = next(pkg for pkg in parsed if pkg["package"] == "weston")
+                                self.assertEqual(weston_package["description"], "Wayland reference compositor")
+                                self.assertFalse(weston_package["partial"])
+
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_with_source_packages_flag(self, mock_run_command):
+        """Test that the main function correctly converts binary packages to source packages when --source-packages is used."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "bootc\ntoolbox"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'podman', '--source-packages']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "podman"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = False
+                mock_args.source_packages = True  # This is the key flag we're testing
+                mock_args.max_results = None
+                mock_args.format = "plain"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = None
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_list') as mock_build_list:
+                        mock_build_list.return_value = ["bootc-src", "toolbox-src"]
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            self.assertIn("bootc-src", output)
+                            self.assertIn("toolbox-src", output)
+
+                        mock_build_list.assert_called_once()
+                        call_args = mock_build_list.call_args
+                        self.assertEqual(call_args.kwargs['show_source_packages'], True)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_with_show_cycles_flag(self, mock_run_command):
+        """Test that the main function correctly includes cycles when --show-cycles is used with --all."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "mutter\nweston"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'libwayland-server', '--all', '--show-cycles', '--format', 'json']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "libwayland-server"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = True
+                mock_args.source_packages = False
+                mock_args.max_results = None
+                mock_args.format = "json"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = True  # This is the key flag we're testing
+                mock_args.filter_command = None
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_graph') as mock_build_graph:
+                        mock_build_graph.return_value = {
+                            "libwayland-server": {
+                                "dependents": ["mutter", "libwayland-server"],  # Cycle: depends on itself through mutter
+                                "partial": False
+                            },
+                            "mutter": {
+                                "dependents": ["libwayland-server"],  # Creates the cycle
+                                "partial": False
+                            }
+                        }
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            parsed = json.loads(output)
+
+                            self.assertEqual(len(parsed), 2)
+                            libwayland_pkg = next(pkg for pkg in parsed if pkg["package"] == "libwayland-server")
+                            mutter_pkg = next(pkg for pkg in parsed if pkg["package"] == "mutter")
+
+                            self.assertIn("mutter", libwayland_pkg["dependents"])
+                            self.assertIn("libwayland-server", libwayland_pkg["dependents"])  # Shows cycle
+                            self.assertIn("libwayland-server", mutter_pkg["dependents"])
+
+                        mock_build_graph.assert_called_once()
+                        call_args = mock_build_graph.call_args
+                        self.assertEqual(call_args.kwargs['keep_cycles'], True)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_without_show_cycles_flag(self, mock_run_command):
+        """Test that the main function correctly excludes cycles when --show-cycles is not used (default behavior)."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "mutter\nweston"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'libwayland-server', '--all', '--format', 'json']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "libwayland-server"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = True
+                mock_args.source_packages = False
+                mock_args.max_results = None
+                mock_args.format = "json"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False  # Default: no cycles
+                mock_args.filter_command = None
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_graph') as mock_build_graph:
+                        mock_build_graph.return_value = {
+                            "libwayland-server": {
+                                "dependents": ["mutter", "weston"],  # No cycle back to self
+                                "partial": False
+                            },
+                            "mutter": {
+                                "dependents": ["gnome-shell"],  # No cycle back to libwayland-server
+                                "partial": False
+                            },
+                            "weston": {
+                                "dependents": ["kwin"],
+                                "partial": False
+                            },
+                            "gnome-shell": {
+                                "dependents": [],
+                                "partial": False
+                            },
+                            "kwin": {
+                                "dependents": [],
+                                "partial": False
+                            }
+                        }
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            parsed = json.loads(output)
+
+                            self.assertEqual(len(parsed), 5)
+                            libwayland_pkg = next(pkg for pkg in parsed if pkg["package"] == "libwayland-server")
+                            mutter_pkg = next(pkg for pkg in parsed if pkg["package"] == "mutter")
+
+                            self.assertIn("mutter", libwayland_pkg["dependents"])
+                            self.assertIn("weston", libwayland_pkg["dependents"])
+                            self.assertNotIn("libwayland-server", libwayland_pkg["dependents"])  # No cycle
+                            self.assertIn("gnome-shell", mutter_pkg["dependents"])
+                            self.assertNotIn("libwayland-server", mutter_pkg["dependents"])  # No cycle
+
+                        mock_build_graph.assert_called_once()
+                        call_args = mock_build_graph.call_args
+                        self.assertEqual(call_args.kwargs['keep_cycles'], False)
+
+    @patch.object(find_package_dependents, 'run_command')
+    def test_main_source_packages_with_all_flag(self, mock_run_command):
+        """Test that --source-packages works correctly with --all flag (transitive dependencies)."""
+        mock_run_command.return_value = {
+            "return_code": 0,
+            "output": "mutter\nweston"
+        }
+
+        with patch('sys.argv', ['find-package-dependents.py', 'libwayland-server', '--all', '--source-packages', '--format', 'json']):
+            with patch.object(find_package_dependents, 'parse_command_line_arguments') as mock_parse:
+                mock_args = Mock()
+                mock_args.package_name = "libwayland-server"
+                mock_args.base_url = "http://example.com/repo"
+                mock_args.repository_names = "BaseOS,AppStream"
+                mock_args.arch = "x86_64"
+                mock_args.output_file = None
+                mock_args.all = True
+                mock_args.source_packages = True  # Convert to source packages
+                mock_args.max_results = None
+                mock_args.format = "json"
+                mock_args.verbose = False
+                mock_args.no_refresh = True
+                mock_args.stats = False
+                mock_args.show_cycles = False
+                mock_args.filter_command = None
+                mock_args.describe = False
+                mock_args.log_file = None
+                mock_args.allow_missing = False
+                mock_parse.return_value = mock_args
+
+                with patch.object(find_package_dependents, 'build_repository_paths') as mock_build_repos:
+                    mock_build_repos.return_value = self.repositories
+
+                    with patch.object(find_package_dependents, 'build_dependents_graph') as mock_build_graph:
+                        mock_build_graph.return_value = {
+                            "libwayland-src": {  # Source package name
+                                "dependents": ["mutter-src", "weston-src"],
+                                "partial": False
+                            },
+                            "mutter-src": {
+                                "dependents": ["gnome-shell-src"],
+                                "partial": False
+                            },
+                            "weston-src": {
+                                "dependents": ["kwin-src"],
+                                "partial": False
+                            },
+                            "gnome-shell-src": {
+                                "dependents": [],
+                                "partial": False
+                            },
+                            "kwin-src": {
+                                "dependents": [],
+                                "partial": False
+                            }
+                        }
+
+                        with captured_stdout() as captured:
+                            find_package_dependents.main()
+
+                            output = captured.getvalue()
+                            parsed = json.loads(output)
+
+                            self.assertEqual(len(parsed), 5)
+                            package_names = [pkg["package"] for pkg in parsed]
+                            self.assertIn("libwayland-src", package_names)
+                            self.assertIn("mutter-src", package_names)
+                            self.assertIn("weston-src", package_names)
+                            self.assertIn("gnome-shell-src", package_names)
+                            self.assertIn("kwin-src", package_names)
+
+                        mock_build_graph.assert_called_once()
+                        call_args = mock_build_graph.call_args
+                        self.assertEqual(call_args.kwargs['show_source_packages'], True)
+
+    def test_build_dependents_graph_with_cycles(self):
+        """Test that build_dependents_graph correctly handles cycles when keep_cycles=True."""
+        with patch.object(find_package_dependents, 'generate_direct_dependents') as mock_generate:
+            def mock_dependents(package_name, *args, **kwargs):
+                if package_name == "libwayland-server":
+                    return iter(["mutter"])
+                elif package_name == "mutter":
+                    return iter(["libwayland-server"])  # Creates cycle
+                else:
+                    return iter([])
+
+            mock_generate.side_effect = mock_dependents
+
+            with patch.object(find_package_dependents, 'run_filter_command') as mock_filter:
+                mock_filter.return_value = True  # All packages pass filter
+
+                result = find_package_dependents.build_dependents_graph(
+                    root_package="libwayland-server",
+                    repository_paths=self.repositories,
+                    show_source_packages=False,
+                    source_cache=self.source_cache,
+                    metrics=self.metrics,
+                    filter_cache=self.filter_cache,
+                    dependency_cache=self.dependency_cache,
+                    max_results=None,
+                    keep_cycles=True,  # Allow cycles
+                    verbose=False,
+                    filter_command=None,
+                    allow_missing=False
+                )
+
+                self.assertIn("libwayland-server", result)
+                self.assertIn("mutter", result)
+
+                self.assertIn("mutter", result["libwayland-server"]["dependents"])
+                self.assertIn("libwayland-server", result["mutter"]["dependents"])
+
+    def test_build_dependents_graph_without_cycles(self):
+        """Test that build_dependents_graph correctly excludes cycles when keep_cycles=False."""
+        with patch.object(find_package_dependents, 'generate_direct_dependents') as mock_generate:
+            def mock_dependents(package_name, *args, **kwargs):
+                if package_name == "libwayland-server":
+                    return iter(["mutter"])
+                elif package_name == "mutter":
+                    return iter(["libwayland-server"])  # Would create cycle but should be excluded
+                else:
+                    return iter([])
+
+            mock_generate.side_effect = mock_dependents
+
+            with patch.object(find_package_dependents, 'run_filter_command') as mock_filter:
+                mock_filter.return_value = True  # All packages pass filter
+
+                result = find_package_dependents.build_dependents_graph(
+                    root_package="libwayland-server",
+                    repository_paths=self.repositories,
+                    show_source_packages=False,
+                    source_cache=self.source_cache,
+                    metrics=self.metrics,
+                    filter_cache=self.filter_cache,
+                    dependency_cache=self.dependency_cache,
+                    max_results=None,
+                    keep_cycles=False,  # Exclude cycles (default)
+                    verbose=False,
+                    filter_command=None,
+                    allow_missing=False
+                )
+
+                self.assertIn("libwayland-server", result)
+                self.assertIn("mutter", result)
+
+                self.assertIn("mutter", result["libwayland-server"]["dependents"])
+                self.assertNotIn("libwayland-server", result["mutter"]["dependents"])
+
+
+def print_header():
+    print("─" * 70)
+    print("find-package-dependents.py test suite")
+    print("─" * 70)
+    print()
+
+def print_footer(passed, total, duration):
+    print()
+    print("─" * 70)
+    if passed == total:
+        print(f"All tests passed! ({passed}/{total})")
+    else:
+        print(f"Some tests failed! ({passed}/{total})")
+        print("Please check the failing tests above.")
+    print(f"Total time: {duration:.2f} seconds")
+    print("─" * 70)
+
+def run_tests():
+    start_time = time.time()
+
+    test_methods = []
+    for attr_name in dir(TestFindPackageDependents):
+        if attr_name.startswith('test_'):
+            method = getattr(TestFindPackageDependents, attr_name)
+            if hasattr(method, '__doc__') and method.__doc__:
+                doc = method.__doc__.strip()
+                test_methods.append((attr_name, doc))
+
+    test_methods.sort(key=lambda x: x[0])
+
+    print_header()
+
+    total_tests = len(test_methods)
+    passed_tests = 0
+    failed_tests = 0
+    error_tests = 0
+
+    for i, (method_name, description) in enumerate(test_methods, 1):
+        suite = unittest.TestSuite()
+        test_instance = TestFindPackageDependents(method_name)
+        suite.addTest(test_instance)
+
+        with captured_stdout() as test_stdout, captured_stderr() as test_stderr:
+            runner = unittest.TextTestRunner(stream=io.StringIO(), verbosity=0)
+            result = runner.run(suite)
+
+            stdout_output = test_stdout.getvalue()
+            stderr_output = test_stderr.getvalue()
+
+        if result.failures:
+            print(f"{i}. {description} ... fail")
+            failed_tests += 1
+            error_msg = result.failures[0][1]
+            lines = error_msg.split('\n')
+            error_lines = [line for line in lines[:5] if line.strip()]
+            if error_lines:
+                print("        ┌─────────────────────────────────────────────────────────────")
+                for line in error_lines:
+                    print(f"        │ {line}")
+                if len(lines) > 5:
+                    print(f"        │ ... ({len(lines) - 5} more lines)")
+                print("        └─────────────────────────────────────────────────────────────")
+        elif result.errors:
+            print(f"{i}. {description} ... error")
+            error_tests += 1
+            error_msg = result.errors[0][1]
+            lines = error_msg.split('\n')
+            error_lines = [line for line in lines[:5] if line.strip()]
+            if error_lines:
+                print("        ┌─────────────────────────────────────────────────────────────")
+                for line in error_lines:
+                    print(f"        │ {line}")
+                if len(lines) > 5:
+                    print(f"        │ ... ({len(lines) - 5} more lines)")
+                print("        └─────────────────────────────────────────────────────────────")
+        else:
+            print(f"{i}. {description} ... ok")
+            passed_tests += 1
+
+        all_output = []
+        if stdout_output.strip():
+            all_output.extend(stdout_output.rstrip('\n').split('\n'))
+        if stderr_output.strip():
+            all_output.extend(stderr_output.rstrip('\n').split('\n'))
+
+        while all_output and not all_output[0].strip():
+            all_output.pop(0)
+
+        if all_output:
+            print("        ┌─────────────────────────────────────────────────────────────")
+            for line in all_output:
+                print(f"        │ {line}")
+            print("        └─────────────────────────────────────────────────────────────")
+
+    duration = time.time() - start_time
+    print(f"\nRan {total_tests} tests in {duration:.3f}s")
+
+    success = (failed_tests == 0 and error_tests == 0)
+
+    print_footer(passed_tests, total_tests, duration)
+
+    return 0 if success else 1
+
+
+if __name__ == '__main__':
+    exit_code = run_tests()
+    sys.exit(exit_code)


### PR DESCRIPTION
This is a draft merge request to get the reverse-dependencies recipe computing indirect dependents as well. It's Draft status, because, as written, the LLM writes the python script dynamically, and I think it would be better to instead ship a script in-tree.

I also need to check if the input for testing-farm is a source package list (scm module names) or binary package list. if the former, we'll need an additional step to plumb things properly.