### PR TITLE
split secrets into multiple env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+.secrets

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ reverse-dependencies:
 		--entrypoint /bin/sh goose \
 		-c "/usr/local/bin/goose run --recipe recipes/reverse-dependencies.yaml \
 			--params package=$(PACKAGE)"
+.PHONY: secrets
+secrets:
+	mkdir -p .secrets
+	cp -n templates/* .secrets
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ In this workflows we are using [MCP server for Atlassian tools](https://github.c
 
 ## Configure
 
-1. Copy `env.template` to `.env` and update it as follows
-2. Set your Gemini key in `GOOGLE_API_KEY` (take it from Google Cloud -> API & Services -> Credentials -> API Keys -> show key)
-3. Set your Jira Personal Token in `JIRA_PERSONAL_TOKEN` (create PATs in your Jira/Confluence profile settings - usually under "Personal Access Tokens")
-4. Change (if needed) the `JIRA_URL` now pointing at `https://issues.redhat.com/`
-5. Set your Gitlab Personal Token `GITLAB_TOKEN` with read permissions (read_user, read_repository, read_api).  Note that some recipes require write access to Gitlab: use it at your own risk.
+Secrets such as tokens are managed in the form of environment files.  The templates for those files can be found in the `./templates` directory.  To configure the deployment, run `make secrets` first to copy the files to the `.secrets` directory where you can manually edit the files to add your tokens and more.
+
+
+ `GOOGLE_API_KEY`: take it from Google Cloud -> API & Services -> Credentials -> API Keys -> show key)
+`JIRA_PERSONAL_TOKEN`: create PATs in your Jira/Confluence profile settings - usually under "Personal Access Tokens"
+`GITLAB_TOKEN` with read permissions (read_user, read_repository, read_api).  Note that some recipes require write access to Gitlab: use it at your own risk.
 
 If you need to change the llm provider and model, they are stored in the Goose config file: `goose-container/goose-config.yaml` (`GOOSE_PROVIDER`, `GOOSE_MODEL`)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
     ports:
       - "9000:9000"
     env_file:
-      - .env
+      - .secrets/mcp-atlassian.env
     command: ["--transport", "sse", "--port", "9000", "-vv"]
     restart: unless-stopped
 
@@ -16,7 +16,7 @@ services:
       context: ./goose-container
       dockerfile: Containerfile
     env_file:
-      - .env
+      - .secrets/goose.env
     volumes:
       - home-goose-persistent:/home/goose
       - ./goose-recipes:/home/goose/recipes:ro,z

--- a/templates/goose.env
+++ b/templates/goose.env
@@ -1,0 +1,17 @@
+# GOOSE CONFIGURATION
+GOOGLE_API_KEY=your_gemini_key
+GOOSE_DISABLE_KEYRING=yes
+
+
+
+# Gitlab
+# Personal Access Token
+# gitlab.com -> User Settings -> Access tokens -> Personal access tokens
+# permissions: read_user, read_repository, read_api
+GITLAB_TOKEN=your_gitlab_com_pat
+# Gitlab user needed for rebasing workflow
+GITLAB_USER=user_name
+
+# GITHUB (needed for accessing remote Github recipes from Goose AI)
+# scope: repo + admin:org -> read:org
+GH_TOKEN=your_github_token

--- a/templates/mcp-atlassian.env
+++ b/templates/mcp-atlassian.env
@@ -1,23 +1,3 @@
-# GOOSE CONFIGURATION
-GOOGLE_API_KEY=your_gemini_key
-GOOSE_DISABLE_KEYRING=yes
-
-
-
-# Gitlab
-# Personal Access Token
-# gitlab.com -> User Settings -> Access tokens -> Personal access tokens
-# permissions: read_user, read_repository, read_api
-GITLAB_TOKEN=your_gitlab_com_pat
-# Gitlab user needed for rebasing workflow
-GITLAB_USER=user_name
-
-# GITHUB (needed for accessing remote Github recipes from Goose AI)
-# scope: repo + admin:org -> read:org
-GH_TOKEN=your_github_token
-
-
-
 # MCP JIRA CONFIGURATION
 # see https://github.com/sooperset/mcp-atlassian/blob/main/.env.example
 


### PR DESCRIPTION
Split the secrets into multiple env files to avoid leaking tokens between services.  I tried to use the Compose-native secrets feature but this did not worked well as secrets are mounted as files (not env vars).