### PR TITLE
Introduce dry-run mode for skipping pushing and creating MRs

### DIFF
--- a/beeai/Makefile
+++ b/beeai/Makefile
@@ -1,5 +1,6 @@
 IMAGE_NAME ?= beeai-agent
 COMPOSE_FILE ?= compose.yaml
+DRY_RUN ?= false
 
 COMPOSE ?= $(shell command -v podman >/dev/null 2>&1 && echo "podman compose" || echo "docker-compose")
 
@@ -28,6 +29,7 @@ run-rebase-agent-standalone:
 		-e VERSION=$(VERSION) \
 		-e JIRA_ISSUE=$(JIRA_ISSUE) \
 		-e BRANCH=$(BRANCH) \
+		-e DRY_RUN=$(DRY_RUN) \
 		rebase-agent
 
 
@@ -41,6 +43,7 @@ run-backport-agent-standalone:
 		-e UPSTREAM_FIX=$(UPSTREAM_FIX) \
 		-e JIRA_ISSUE=$(JIRA_ISSUE) \
 		-e BRANCH=$(BRANCH) \
+		-e DRY_RUN=$(DRY_RUN) \
 		backport-agent
 
 
@@ -51,11 +54,11 @@ run-backport-agent-standalone:
 
 .PHONY: start
 start:
-	$(COMPOSE) -f $(COMPOSE_FILE) up
+	DRY_RUN=$(DRY_RUN) $(COMPOSE) -f $(COMPOSE_FILE) up
 
 .PHONY: start-detached
 start-detached:
-	$(COMPOSE) -f $(COMPOSE_FILE) up -d
+	DRY_RUN=$(DRY_RUN) $(COMPOSE) -f $(COMPOSE_FILE) up -d
 
 .PHONY: stop
 stop:

--- a/beeai/README.md
+++ b/beeai/README.md
@@ -41,6 +41,12 @@ make PACKAGE=httpd VERSION=2.4.62 JIRA_ISSUE=RHEL-12345 BRANCH=c10s run-rebase-a
 make PACKAGE=httpd UPSTREAM_FIX=https://github.com/... JIRA_ISSUE=RHEL-12345 BRANCH=c10s run-backport-agent-standalone
 ```
 
+## Dry-Run mode
+
+Both backport and rebase agents support **dry-run mode** for testing workflows without actually pushing changes or creating merge requests. By default, agents run in **production mode** and will create actual commits, pushes, and merge requests.
+
+To enable dry-run mode for testing, set the `DRY_RUN=true` environment variable.
+
 ## Observability
 
 You can connect to http://localhost:6006/ to access Phoenix web interface and trace agents

--- a/beeai/agents/constants.py
+++ b/beeai/agents/constants.py
@@ -1,0 +1,4 @@
+
+COMMIT_PREFIX = "[DO NOT MERGE: AI EXPERIMENTS]"
+
+BRANCH_PREFIX = "automated-package-update"

--- a/beeai/agents/utils.py
+++ b/beeai/agents/utils.py
@@ -1,3 +1,5 @@
+import os
+
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Callable
 
@@ -28,3 +30,49 @@ async def mcp_tools(
         if filter:
             tools = [t for t in tools if filter(t.name)]
         yield tools
+
+
+def get_git_finalization_steps(
+    package: str,
+    jira_issue: str,
+    commit_title: str,
+    files_to_commit: str,
+    branch_name: str,
+    git_user: str = "RHEL Packaging Agent",
+    git_email: str = "rhel-packaging-agent@redhat.com",
+    git_url: str = "https://gitlab.com/redhat/centos-stream/rpms",
+    dist_git_branch: str = "c9s",
+) -> str:
+    """Generate Git finalization steps with dry-run support"""
+    dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
+
+    # Common commit steps
+    git_config_steps = f"""* Configure git user: `git config user.name "{git_user}"`
+            * Configure git email: `git config user.email "{git_email}"`"""
+
+    commit_steps = f"""* Add files to commit: {files_to_commit}
+            * Create commit with title: "{commit_title}"
+            * Include JIRA reference: "Resolves: {jira_issue}" in commit body"""
+
+    if dry_run:
+        return f"""
+        **DRY RUN MODE**: Commit changes locally only
+
+        Commit the changes:
+            {git_config_steps}
+            {commit_steps}
+
+        **Important**: In dry-run mode, only commit locally. Do not push or create merge requests.
+        """
+    else:
+        return f"""
+        Commit and push the changes:
+            {git_config_steps}
+            {commit_steps}
+            * Push the branch `{branch_name}` to the fork
+
+        Open a merge request:
+            * Authenticate using `glab`
+            * Open a merge request against {git_url}/{package}
+            * Target branch: {dist_git_branch}
+        """

--- a/beeai/compose.yaml
+++ b/beeai/compose.yaml
@@ -13,6 +13,7 @@ x-beeai-agent: &beeai-agent
     - REDIS_URL=redis://valkey:6379/0
     - COLLECTOR_ENDPOINT=http://phoenix:6006/v1/traces
     - MAX_RETRIES=3
+    - DRY_RUN=${DRY_RUN:-false}
   env_file:
     - .secrets/beeai-agent.env
   volumes:


### PR DESCRIPTION
I have been temporarily removing those steps when playing with this locally, but I think this could be good for testing in general.