### PR TITLE
Temporarily pin beeai to avoid patch application issues for image builds

### DIFF
--- a/beeai/Containerfile
+++ b/beeai/Containerfile
@@ -19,7 +19,7 @@ COPY beeai-gemini.patch /tmp
 
 # Install BeeAI Framework and Phoenix
 RUN pip3 install \
-    beeai-framework[mcp,duckduckgo] \
+    beeai-framework[mcp,duckduckgo]==0.1.31 \
     openinference-instrumentation-beeai \
     arize-phoenix-otel \
     && cd /usr/local/lib/python3.13/site-packages \


### PR DESCRIPTION
With the new version of beeai being released, our patch fails to apply, making building new images impossible. As we are waiting for the patch being merged upstream, temporarily pinning until that code is merged and released should be enough. Alternatively, we could regenerate the patch for each new release touching the patched code.

