### PR TITLE
workflows: Fix build-and-push workflow following Containerfile changes

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,7 +16,7 @@ jobs:
           registry_username: ${{ secrets.REGISTRY_LOGIN }}
           registry_token: ${{ secrets.REGISTRY_TOKEN }}
           dockerfile: "goose-container/Containerfile"
-          docker_context: "goose-container"
+          docker_context: "."
           image_name: "goose"
 
   build-and-push-beeai-container:


### PR DESCRIPTION
commit 89560a01e360b05e6bef91413cbf2d27286c2a3b reworked the Containerfile to use multiple stages. In the process it also changed the context (working directory) to the toplevel source dir.

The commit neglected to make the associated change in the github build-and-push workflow.

This commit rectifies that oversight.