### PR TITLE
test-reverse-dependencies: Allow incomplete repositories

### DIFF
--- a/goose-recipes/test-reverse-dependencies.yaml
+++ b/goose-recipes/test-reverse-dependencies.yaml
@@ -62,6 +62,7 @@ prompt: |
        workingdir=$(mktemp "$PWD/{{ package }}.reverse-deps-tests.XXXXXX")
        $(pwd)/scripts/find-package-dependents.py --base-url {{ baseurl }} --all --describe --max-results {{ max_results }} --source-packages --format=plain '{{ package }}' \
        --filter-command 'wget --spider -q https://gitlab.com/redhat/centos-stream/rpms/$PACKAGE/-/raw/{{ dist_git_branch }}/.fmf/version' \
+       --allow-missing \
        --log-file "$workingdir/{{ package }}-logs.txt" \
        --verbose \
        --output-file "$workingdir/{{ package }}-source-deps.txt"


### PR DESCRIPTION
In trying the reverse dependencies test on c10s, I see we're getting a failure for missing ceph packages.

This is likely because we're only checking AppStream, BaseOS, and CRB, and not some of the more niche repositories.

For now, change the repository to allow for missing dependencies.