### PR TITLE
reverse-dependences: Fix bug in find-package-dependents script

### DIFF
--- a/scripts/find-package-dependents.py
+++ b/scripts/find-package-dependents.py
@@ -997,7 +997,7 @@ def build_dependents_graph(
         any_filtered_dependents = False
         for dependent in generate_direct_dependents(
                 package, repository_paths, metrics, dependency_cache, verbose,
-                cache_only=result_limit_hit, max_results=max_results
+                cache_only=result_limit_hit
         ):
             if show_source_packages:
                 dependent = query_source_package(


### PR DESCRIPTION
find-package-dependents was passing the user's max_results limit to the generate_direct_dependents function. This would be fine, except we sometimes need more than max_results generated if some of the results are filtered by the user's filter command.

The upshot is the script would sometimes traverse the dependents tree deep instead of wide, leading to performance issues.

This commit drops the max_result limit on generate_direct_dependents, since it's wrong and not needed anyway (because max_results is already handled elsewhere).

This commit also adds a couple of test cases to make sure the problem doesn't creep in again.