### PR TITLE
Fix some type errors and warnings

### DIFF
--- a/beeai/agents/backport_agent.py
+++ b/beeai/agents/backport_agent.py
@@ -240,7 +240,7 @@ async def main() -> None:
                     continue
 
                 _, payload = element
-                logger.info(f"Received task from queue.")
+                logger.info("Received task from queue.")
 
                 task = Task.model_validate_json(payload)
                 backport_data = BackportData.model_validate(task.metadata)

--- a/beeai/agents/backport_agent.py
+++ b/beeai/agents/backport_agent.py
@@ -77,12 +77,12 @@ def render_prompt(input: InputSchema) -> str:
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
-    setup_observability(os.getenv("COLLECTOR_ENDPOINT"))
+    setup_observability(os.environ["COLLECTOR_ENDPOINT"])
     cve_id = os.getenv("CVE_ID", "")
 
-    async with mcp_tools(os.getenv("MCP_GATEWAY_URL")) as gateway_tools:
+    async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
         backport_agent = RequirementAgent(
-            llm=ChatModel.from_name(os.getenv("CHAT_MODEL")),
+            llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
             tools=[
                 ThinkTool(),
                 RunShellCommandTool(),
@@ -228,7 +228,7 @@ async def main() -> None:
             attempts: int = Field(default=0, description="Number of processing attempts")
 
         logger.info("Starting backport agent in queue mode")
-        async with redis_client(os.getenv("REDIS_URL")) as redis:
+        async with redis_client(os.environ["REDIS_URL"]) as redis:
             max_retries = int(os.getenv("MAX_RETRIES", 3))
             logger.info(f"Connected to Redis, max retries set to {max_retries}")
 

--- a/beeai/agents/rebase_agent.py
+++ b/beeai/agents/rebase_agent.py
@@ -100,11 +100,11 @@ def render_prompt(input: InputSchema) -> str:
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
-    setup_observability(os.getenv("COLLECTOR_ENDPOINT"))
+    setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
-    async with mcp_tools(os.getenv("MCP_GATEWAY_URL")) as gateway_tools:
+    async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
         rebase_agent = RequirementAgent(
-            llm=ChatModel.from_name(os.getenv("CHAT_MODEL")),
+            llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
             tools=[
                 ThinkTool(),
                 RunShellCommandTool(),
@@ -231,7 +231,7 @@ async def main() -> None:
             attempts: int = Field(default=0, description="Number of processing attempts")
 
         logger.info("Starting rebase agent in queue mode")
-        async with redis_client(os.getenv("REDIS_URL")) as redis:
+        async with redis_client(os.environ["REDIS_URL"]) as redis:
             max_retries = int(os.getenv("MAX_RETRIES", 3))
             logger.info(f"Connected to Redis, max retries set to {max_retries}")
 

--- a/beeai/agents/rebase_agent.py
+++ b/beeai/agents/rebase_agent.py
@@ -243,7 +243,7 @@ async def main() -> None:
                     continue
 
                 _, payload = element
-                logger.info(f"Received task from queue.")
+                logger.info("Received task from queue.")
 
                 task = Task.model_validate_json(payload)
                 rebase_data = RebaseData.model_validate(task.metadata)

--- a/beeai/agents/triage_agent.py
+++ b/beeai/agents/triage_agent.py
@@ -253,11 +253,11 @@ def render_prompt(input: InputSchema) -> str:
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
-    setup_observability(os.getenv("COLLECTOR_ENDPOINT"))
+    setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
-    async with mcp_tools(os.getenv("MCP_GATEWAY_URL")) as gateway_tools:
+    async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
         agent = RequirementAgent(
-            llm=ChatModel.from_name(os.getenv("CHAT_MODEL")),
+            llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
             tools=[ThinkTool(), RunShellCommandTool(), PatchValidatorTool(), VersionMapperTool()]
             + [t for t in gateway_tools if t.name in ["get_jira_details", "set_jira_fields"]],
             memory=UnconstrainedMemory(),
@@ -297,7 +297,7 @@ async def main() -> None:
             attempts: int = Field(default=0, description="Number of processing attempts")
 
         logger.info("Starting triage agent in queue mode")
-        async with redis_client(os.getenv("REDIS_URL")) as redis:
+        async with redis_client(os.environ["REDIS_URL"]) as redis:
             max_retries = int(os.getenv("MAX_RETRIES", 3))
             logger.info(f"Connected to Redis, max retries set to {max_retries}")
 

--- a/beeai/agents/triage_agent.py
+++ b/beeai/agents/triage_agent.py
@@ -309,7 +309,7 @@ async def main() -> None:
                     continue
 
                 _, payload = element
-                logger.info(f"Received task from queue")
+                logger.info("Received task from queue")
 
                 task = Task.model_validate_json(payload)
                 input = InputSchema.model_validate(task.metadata)

--- a/beeai/agents/utils.py
+++ b/beeai/agents/utils.py
@@ -1,11 +1,12 @@
 import asyncio
+import inspect
 import logging
 import os
 import shlex
 import subprocess
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, AsyncGenerator, Callable, Tuple
+from typing import Any, AsyncGenerator, Awaitable, Callable, TypeVar, Tuple
 
 import redis.asyncio as redis
 from mcp import ClientSession
@@ -94,6 +95,26 @@ async def redis_client(redis_url: str) -> AsyncGenerator[redis.Redis, None]:
         yield client
     finally:
         await client.aclose()
+
+
+T = TypeVar("T")
+
+async def fix_await(v: T | Awaitable[T]) -> T:
+    """
+    Work around typing problems in the asyncio redis client.
+
+    Typing for the asyncio redis client is messed up, and functions
+    return `T | Awaitable[T]` instead of `T`. This function
+    fixes the type error by asserting that the value is awaitable
+    before awaiting it.
+
+    For a proper fix, see: https://github.com/redis/redis-py/pull/3619
+
+
+    Usage: `await fixAwait(redis.get("key"))`
+    """
+    assert inspect.isawaitable(v)
+    return await v
 
 
 @asynccontextmanager


### PR DESCRIPTION
Here are some fixes for a few type errors and warnings I get when loading the project in vscode.

The most intrusive part here is the workaround for type hinting on redis methods .... this would be improved if some of the repeated code for managing the redis queue was refactored out to a single place.