### PR TITLE
backporting: properly reference `state.backport_result.status`

### DIFF
--- a/beeai/agents/backport_agent.py
+++ b/beeai/agents/backport_agent.py
@@ -199,7 +199,7 @@ async def main() -> None:
                     f"{CAREFULLY_REVIEW_CHANGES}\n\n"
                     f"Upstream patch: {state.upstream_fix}\n"
                     "Backporting steps:\n"
-                    f"{state.status}"
+                    f"{state.backport_result.status}"
                 ),
                 available_tools=gateway_tools,
                 commit_only=dry_run,


### PR DESCRIPTION
Fixes
```
 | Traceback (most recent call last):
 |   File "/usr/local/lib/python3.13/site-packages/beeai_framework/workflows/workflow.py", line 135, in handler
 |     step_next: Any = await ensure_async(step.handler)(step_res.state)
 |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 |   File "/home/beeai/agents/backport_agent.py", line 202, in commit_push_and_open_mr
 |     f"{state.status}"
 |        ^^^^^^^^^^^^
 |   File "/usr/local/lib/python3.13/site-packages/pydantic/main.py", line 991, in __getattr__
 |     raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
 | AttributeError: 'State' object has no attribute 'status'
```