### PR TITLE
Decrease cpu limits for non-agent containers

### DIFF
--- a/beeai/openshift/cronjob-jira-issue-fetcher.yml
+++ b/beeai/openshift/cronjob-jira-issue-fetcher.yml
@@ -56,7 +56,9 @@ spec:
                 configMapKeyRef:
                   key: LOGLEVEL
                   name: jira-issue-fetcher
-            # TODO: add limits on cpu and memory.
+            resources:
+              limits:
+                cpu: "200m"
             securityContext:
               allowPrivilegeEscalation: false
               runAsNonRoot: true

--- a/beeai/openshift/deployment-mcp-atlassian.yml
+++ b/beeai/openshift/deployment-mcp-atlassian.yml
@@ -44,8 +44,9 @@ spec:
         ports:
         - containerPort: 9000
           protocol: TCP
-        # TODO: add limits on cpu and memory.
-        resources: {}
+        resources:
+          limits:
+            cpu: "200m"
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst

--- a/beeai/openshift/deployment-mcp-gateway.yml
+++ b/beeai/openshift/deployment-mcp-gateway.yml
@@ -55,8 +55,9 @@ spec:
         ports:
         - containerPort: 8000
           protocol: TCP
-        # TODO: add limits on cpu and memory.
-        resources: {}
+        resources:
+          limits:
+            cpu: "200m"
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/beeai/openshift/deployment-redis-commander.yml
+++ b/beeai/openshift/deployment-redis-commander.yml
@@ -30,8 +30,9 @@ spec:
         ports:
         - containerPort: 8081
           protocol: TCP
-        # TODO: add limits on cpu and memory.
-        resources: {}
+        resources:
+          limits:
+            cpu: "200m"
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst

--- a/beeai/openshift/deployment-valkey.yml
+++ b/beeai/openshift/deployment-valkey.yml
@@ -27,8 +27,9 @@ spec:
         ports:
         - containerPort: 6379
           protocol: TCP
-        # TODO: add limits on cpu and memory.
-        resources: {}
+        resources:
+          limits:
+            cpu: "200m"
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:


### PR DESCRIPTION
This should be enough to fit into 4 cpu limit.
As of now we have no data in the metrics, since the deployment is not running yet. We may need to adjust this.
