### PR TITLE
triage agent can output multiple patches

### DIFF
--- a/beeai/agents/tools/patch_validator.py
+++ b/beeai/agents/tools/patch_validator.py
@@ -15,13 +15,14 @@ class PatchValidatorInput(BaseModel):
 
 
 class PatchValidatorResult(BaseModel):
+    url: str = Field(description="URL of the patch/commit")
     is_accessible: bool = Field(description="Whether the URL is accessible and not an issue reference")
     status_code: int | None = Field(description="HTTP status code")
     content: str | None = Field(description="Content of the URL (truncated if too long)")
     reason: str = Field(description="Brief explanation")
 
 
-class PatchValidatorOutput(JSONToolOutput[PatchValidatorResult]):
+class PatchValidatorOutput(JSONToolOutput[list[PatchValidatorResult]]):
     pass
 
 
@@ -65,48 +66,50 @@ class PatchValidatorTool(Tool[PatchValidatorInput, ToolRunOptions, PatchValidato
     async def _run(
         self, tool_input: PatchValidatorInput, options: ToolRunOptions | None, context: RunContext
     ) -> PatchValidatorOutput:
+        results = []
+        for url in tool_input.urls:
+            url = url.strip()
 
-        url = tool_input.url.strip()
+            is_issue, reason = self._is_issue_reference(url)
 
-        is_issue, reason = self._is_issue_reference(url)
+            status_code = None
+            is_accessible = False
+            content = None
 
-        status_code = None
-        is_accessible = False
-        content = None
+            if not is_issue:
+                try:
+                    timeout = aiohttp.ClientTimeout(total=30)
+                    async with aiohttp.ClientSession(timeout=timeout) as session:
+                        async with session.get(url) as response:
+                            status_code = response.status
+                            is_accessible = response.status < 400
 
-        if not is_issue:
-            try:
-                timeout = aiohttp.ClientTimeout(total=30)
-                async with aiohttp.ClientSession(timeout=timeout) as session:
-                    async with session.get(url) as response:
-                        status_code = response.status
-                        is_accessible = response.status < 400
-
-                        if is_accessible:
-                            max_length = MAX_CONTENT_LENGTH
-                            if response.content_length and response.content_length > max_length:
-                                # Avoid reading a huge response into memory.
-                                partial_bytes = await response.content.read(max_length)
-                                content = partial_bytes.decode(response.get_encoding() or 'utf-8', errors='ignore')
-                                content += f"\n\n[Content truncated - showing first {max_length} bytes of {response.content_length} total]"
+                            if is_accessible:
+                                max_length = MAX_CONTENT_LENGTH
+                                if response.content_length and response.content_length > max_length:
+                                    # Avoid reading a huge response into memory.
+                                    partial_bytes = await response.content.read(max_length)
+                                    content = partial_bytes.decode(response.get_encoding() or 'utf-8', errors='ignore')
+                                    content += f"\n\n[Content truncated - showing first {max_length} bytes of {response.content_length} total]"
+                                else:
+                                    # For responses without content-length or smaller ones, read fully and then truncate.
+                                    raw_content = await response.text()
+                                    content = self._truncate_content(raw_content)
+                                reason = "URL is accessible and content fetched successfully"
                             else:
-                                # For responses without content-length or smaller ones, read fully and then truncate.
-                                raw_content = await response.text()
-                                content = self._truncate_content(raw_content)
-                            reason = "URL is accessible and content fetched successfully"
-                        else:
-                            reason = f"Not an issue reference but not accessible (HTTP {response.status})"
+                                reason = f"Not an issue reference but not accessible (HTTP {response.status})"
 
-            except asyncio.TimeoutError:
-                reason = "Not an issue reference but request timeout"
-            except Exception as e:
-                reason = f"Not an issue reference but raised exception: {str(e)}"
+                except asyncio.TimeoutError:
+                    reason = "Not an issue reference but request timeout"
+                except Exception as e:
+                    reason = f"Not an issue reference but raised exception: {str(e)}"
 
-        result = PatchValidatorResult(
-            is_accessible=is_accessible,
-            status_code=status_code,
-            content=content,
-            reason=reason,
-        )
+            results.append(PatchValidatorResult(
+                url=url,
+                is_accessible=is_accessible,
+                status_code=status_code,
+                content=content,
+                reason=reason,
+            ))
 
-        return PatchValidatorOutput(result)
+        return PatchValidatorOutput(results)

--- a/beeai/agents/triage_agent.py
+++ b/beeai/agents/triage_agent.py
@@ -175,9 +175,9 @@ def render_prompt(input: InputSchema) -> str:
              - For CVEs, use the CVE publication date to narrow down the timeframe for fixes
              - Check upstream release notes and changelogs after the RHEL package version date
 
-         2.3. Validate the Fix and URL
-         * Use the PatchValidator tool to fetch content from any patch/commit URL you intend to use
-         * The tool will verify the URL is accessible and not an issue reference, then return the content
+         2.3. Validate the Fix and URLs
+         * Use the PatchValidator tool to fetch content from any patch/commit URLs you intend to use
+         * The tool will verify the URLs are accessible and not an issue references, then return the content
          * Once you have the content, you must validate two things:
            1. **Is it a patch/diff?** Look for diff indicators like:
               - `diff --git` headers
@@ -239,7 +239,7 @@ def render_prompt(input: InputSchema) -> str:
 
       If Backport:
           PACKAGE: [package name]
-          PATCH_URL: [URL or reference to the source of the fix]
+          PATCH_URLS: [URLs or references to the source of the fixes]
           CVE_ID: [CVE identifier, leave blank if not applicable]
           JUSTIFICATION: [A brief but clear explanation of why this patch fixes the issue, linking it to the root cause.]
           FIX_VERSION: [fix version set in JIRA]

--- a/beeai/common/models.py
+++ b/beeai/common/models.py
@@ -126,7 +126,7 @@ class RebaseData(BaseModel):
 class BackportData(BaseModel):
     """Data for backport resolution."""
     package: str = Field(description="Package name")
-    patch_url: str = Field(description="URL or reference to the source of the fix")
+    patch_urls: list[str] = Field(description="URLs or references to the source of the fixes")
     justification: str = Field(description="Clear explanation of why this patch fixes the issue")
     jira_issue: str = Field(description="Jira issue identifier")
     cve_id: str = Field(description="CVE identifier")


### PR DESCRIPTION
first part for https://github.com/packit/jotnar/issues/109

Surprisingly, this can already work, though it only found one patch for the referenced issue:
```
INFO:__main__:Direct run completed: {
    "resolution": "backport",
    "data": {
        "package": "glib2",
        "patch_urls": [
            "https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4049.patch"
        ],
        "justification": "The patch fixes an integer overflow vulnerability in the g_string_insert_unichar() function by adding a check to prevent the overflow. This directly addresses the root cause of the vulnerability described in the Jira issue.",
        "jira_issue": "RHEL-103916",
        "cve_id": "...",
        "fix_version": "..."
    }
}
```