### PR TITLE
Enable parallel tool calls

### DIFF
--- a/beeai/agents/backport_agent.py
+++ b/beeai/agents/backport_agent.py
@@ -102,7 +102,7 @@ def get_prompt() -> str:
 def create_backport_agent(_: list[Tool]) -> RequirementAgent:
     return RequirementAgent(
         name="BackportAgent",
-        llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
+        llm=ChatModel.from_name(os.environ["CHAT_MODEL"], allow_parallel_tool_calls=True),
         tools=[
             ThinkTool(),
             RunShellCommandTool(),

--- a/beeai/agents/build_agent.py
+++ b/beeai/agents/build_agent.py
@@ -38,7 +38,7 @@ def get_prompt() -> str:
 def create_build_agent(mcp_tools: list[Tool]) -> RequirementAgent:
     return RequirementAgent(
         name="BuildAgent",
-        llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
+        llm=ChatModel.from_name(os.environ["CHAT_MODEL"], allow_parallel_tool_calls=True),
         tools=[
             ThinkTool(),
             RunShellCommandTool(),

--- a/beeai/agents/rebase_agent.py
+++ b/beeai/agents/rebase_agent.py
@@ -101,7 +101,7 @@ def get_prompt() -> str:
 def create_rebase_agent(mcp_tools: list[Tool]) -> RequirementAgent:
     return RequirementAgent(
         name="RebaseAgent",
-        llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
+        llm=ChatModel.from_name(os.environ["CHAT_MODEL"], allow_parallel_tool_calls=True),
         tools=[
             ThinkTool(),
             RunShellCommandTool(),

--- a/beeai/agents/triage_agent.py
+++ b/beeai/agents/triage_agent.py
@@ -279,7 +279,7 @@ async def main() -> None:
         async with mcp_tools(os.getenv("MCP_GATEWAY_URL")) as gateway_tools:
             triage_agent = RequirementAgent(
                 name="TriageAgent",
-                llm=ChatModel.from_name(os.getenv("CHAT_MODEL")),
+                llm=ChatModel.from_name(os.getenv("CHAT_MODEL"), allow_parallel_tool_calls=True),
                 tools=[ThinkTool(), RunShellCommandTool(), PatchValidatorTool(), VersionMapperTool()]
                 + [t for t in gateway_tools if t.name in ["get_jira_details", "set_jira_fields"]],
                 memory=UnconstrainedMemory(),


### PR DESCRIPTION
The triage agent, at the beginning of its execution, tends to run two tools in parallel - `think` and `get_jira_details`. That's disallowed by default, but I don't really see a reason why not to allow it. If it proves problematic, we can disable it and try to overcome the problem by using requirements.