### PR TITLE
Fix tool calling

### DIFF
--- a/beeai/agents/backport_agent.py
+++ b/beeai/agents/backport_agent.py
@@ -102,7 +102,7 @@ def get_prompt() -> str:
 def create_backport_agent(_: list[Tool]) -> RequirementAgent:
     return RequirementAgent(
         name="BackportAgent",
-        llm=ChatModel.from_name(os.environ["CHAT_MODEL"], allow_parallel_tool_calls=True),
+        llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
         tools=[
             ThinkTool(),
             RunShellCommandTool(),
@@ -119,7 +119,7 @@ def create_backport_agent(_: list[Tool]) -> RequirementAgent:
         ],
         memory=UnconstrainedMemory(),
         requirements=[
-            ConditionalRequirement(ThinkTool, force_after=Tool, consecutive_allowed=False),
+            ConditionalRequirement(ThinkTool, force_at_step=1, force_after=Tool, consecutive_allowed=False),
         ],
         middlewares=[GlobalTrajectoryMiddleware(pretty=True)],
         role="Red Hat Enterprise Linux developer",

--- a/beeai/agents/build_agent.py
+++ b/beeai/agents/build_agent.py
@@ -38,7 +38,7 @@ def get_prompt() -> str:
 def create_build_agent(mcp_tools: list[Tool]) -> RequirementAgent:
     return RequirementAgent(
         name="BuildAgent",
-        llm=ChatModel.from_name(os.environ["CHAT_MODEL"], allow_parallel_tool_calls=True),
+        llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
         tools=[
             ThinkTool(),
             RunShellCommandTool(),
@@ -50,7 +50,7 @@ def create_build_agent(mcp_tools: list[Tool]) -> RequirementAgent:
         ] + [t for t in mcp_tools if t.name in ["build_package", "download_artifacts"]],
         memory=UnconstrainedMemory(),
         requirements=[
-            ConditionalRequirement(ThinkTool, force_after=Tool, consecutive_allowed=False),
+            ConditionalRequirement(ThinkTool, force_at_step=1, force_after=Tool, consecutive_allowed=False),
             ConditionalRequirement("build_package", min_invocations=1),
             ConditionalRequirement("download_artifacts", only_after="build_package"),
         ],

--- a/beeai/agents/rebase_agent.py
+++ b/beeai/agents/rebase_agent.py
@@ -101,7 +101,7 @@ def get_prompt() -> str:
 def create_rebase_agent(mcp_tools: list[Tool]) -> RequirementAgent:
     return RequirementAgent(
         name="RebaseAgent",
-        llm=ChatModel.from_name(os.environ["CHAT_MODEL"], allow_parallel_tool_calls=True),
+        llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
         tools=[
             ThinkTool(),
             RunShellCommandTool(),
@@ -114,7 +114,7 @@ def create_rebase_agent(mcp_tools: list[Tool]) -> RequirementAgent:
         ] + [t for t in mcp_tools if t.name == "upload_sources"],
         memory=UnconstrainedMemory(),
         requirements=[
-            ConditionalRequirement(ThinkTool, force_after=Tool, consecutive_allowed=False),
+            ConditionalRequirement(ThinkTool, force_at_step=1, force_after=Tool, consecutive_allowed=False),
         ],
         middlewares=[GlobalTrajectoryMiddleware(pretty=True)],
         role="Red Hat Enterprise Linux developer",

--- a/beeai/agents/triage_agent.py
+++ b/beeai/agents/triage_agent.py
@@ -279,12 +279,12 @@ async def main() -> None:
         async with mcp_tools(os.getenv("MCP_GATEWAY_URL")) as gateway_tools:
             triage_agent = RequirementAgent(
                 name="TriageAgent",
-                llm=ChatModel.from_name(os.getenv("CHAT_MODEL"), allow_parallel_tool_calls=True),
+                llm=ChatModel.from_name(os.environ["CHAT_MODEL"]),
                 tools=[ThinkTool(), RunShellCommandTool(), PatchValidatorTool(), VersionMapperTool()]
                 + [t for t in gateway_tools if t.name in ["get_jira_details", "set_jira_fields"]],
                 memory=UnconstrainedMemory(),
                 requirements=[
-                    ConditionalRequirement(ThinkTool, force_after=Tool, consecutive_allowed=False),
+                    ConditionalRequirement(ThinkTool, force_at_step=1, force_after=Tool, consecutive_allowed=False),
                     ConditionalRequirement("get_jira_details", min_invocations=1),
                     ConditionalRequirement(RunShellCommandTool, only_after="get_jira_details"),
                     ConditionalRequirement(PatchValidatorTool, only_after="get_jira_details"),


### PR DESCRIPTION
Enabling parallel tool calls didn't really work, it led to errors like `The model was required to produce a tool call for the 'think' tool, but no tool calls were generated.`.

Disable the option and enforce the think tool as the first tool to be called with a requirement.