### PR TITLE
Explicitly set HOME in containers

### DIFF
--- a/beeai/Containerfile
+++ b/beeai/Containerfile
@@ -39,10 +39,11 @@ COPY common/ /home/beeai/common/
 RUN chgrp -R root /home/beeai && chmod -R g+rwX /home/beeai
 
 USER beeai
-WORKDIR /home/beeai
+ENV HOME=/home/beeai
+WORKDIR $HOME
 
 # Set PYTHONPATH so agents module can be imported
-ENV PYTHONPATH=/home/beeai:$PYTHONPATH
+ENV PYTHONPATH=$HOME:$PYTHONPATH
 
 # so that we can start working with gitlab.com immediately
 RUN mkdir ~/.ssh \

--- a/beeai/Containerfile.mcp
+++ b/beeai/Containerfile.mcp
@@ -30,8 +30,9 @@ RUN chgrp -R root /home/mcp && chmod -R g+rwX /home/mcp
 RUN mkdir /git-repos && chmod -R o+rwX /git-repos
 
 USER mcp
-WORKDIR /home/mcp
+ENV HOME=/home/mcp
+WORKDIR $HOME
 
-ENV PYTHONPATH=/home/mcp
+ENV PYTHONPATH=$HOME:$PYTHONPATH
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
`centpkg prep` in OpenShift fails because `%{_topdir}` is defined as `/rpmbuild` and that gives permission denied. `%{_topdir}` is based on `$HOME` which is set to be `/`. Fix that.