### PR TITLE
Wait 0.5s before setting gitlab label

### DIFF
--- a/beeai/mcp_server/gitlab_tools.py
+++ b/beeai/mcp_server/gitlab_tools.py
@@ -69,9 +69,11 @@ async def open_merge_request(
         return "Failed to open the merge request"
     # by default, set this label on a newly created MR so we can inspect it ASAP
     try:
+        # Add a short delay before adding the label to avoid race conditions with MR creation
+        await asyncio.sleep(0.5)
         await asyncio.to_thread(pr.add_label, "jotnar_needs_attention")
     except OgrException as ex:
-        logger.error("Unable to set label 'jotnar_needs_attention' on MR %s", pr, exc_info=True)
+        logger.error("Unable to set label 'jotnar_needs_attention' on MR %s (%s)", pr, ex)
         # we should still continue and return the MR URL
     return pr.url
 


### PR DESCRIPTION
Fixes https://github.com/packit/jotnar/issues/142

```
196   File "/usr/lib/python3.13/site-packages/ogr/services/gitlab/pull_request.py", line 300, in add_label
197     self._raw_pr.save()
198     ~~~~~~~~~~~~~~~~~^^
...
Traceback (most recent call last):
  File "/home/mcp/mcp_server/gitlab_tools.py", line 72, in open_merge_request
    await asyncio.to_thread(pr.add_label, "jotnar_needs_attention")
  File "/usr/lib64/python3.13/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
ogr.exceptions.GitlabAPIException: 404: 404 Not found
```