### PR TITLE
Bind agents and MCP gateway to the same node

### DIFF
--- a/beeai/openshift/deployment-backport-agent.yml
+++ b/beeai/openshift/deployment-backport-agent.yml
@@ -22,6 +22,8 @@ spec:
         app: backport-agent
         deployment: backport-agent
     spec:
+      nodeSelector:
+        kubernetes.io/hostname: ip-10-30-34-89.us-east-1.compute.internal
       containers:
       - args:
         - agents/backport_agent.py

--- a/beeai/openshift/deployment-mcp-gateway.yml
+++ b/beeai/openshift/deployment-mcp-gateway.yml
@@ -22,6 +22,8 @@ spec:
         app: mcp-gateway
         deployment: mcp-gateway
     spec:
+      nodeSelector:
+        kubernetes.io/hostname: ip-10-30-34-89.us-east-1.compute.internal
       containers:
       - args:
         - mcp_server/gateway.py

--- a/beeai/openshift/deployment-rebase-agent.yml
+++ b/beeai/openshift/deployment-rebase-agent.yml
@@ -22,6 +22,8 @@ spec:
         app: rebase-agent
         deployment: rebase-agent
     spec:
+      nodeSelector:
+        kubernetes.io/hostname: ip-10-30-34-89.us-east-1.compute.internal
       containers:
       - args:
         - agents/rebase_agent.py

--- a/beeai/openshift/deployment-triage-agent.yml
+++ b/beeai/openshift/deployment-triage-agent.yml
@@ -22,6 +22,8 @@ spec:
         app: triage-agent
         deployment: triage-agent
     spec:
+      nodeSelector:
+        kubernetes.io/hostname: ip-10-30-34-89.us-east-1.compute.internal
       containers:
       - args:
         - agents/triage_agent.py


### PR DESCRIPTION
To prevent issues like:
```
Multi-Attach error for volume "pvc-7be4cb58-c0b2-4c5b-94f3-62babed8b99c"
Volume is already used by pod(s) triage-agent-6b78fbbcfb-f4kbq,
rebase-agent-56449b88bd-qvm2r, backport-agent-84c565555b-dm6kf
```