### PR TITLE
constants: Use the term "software maintenance" and not "packaging"

### DIFF
--- a/beeai/agents/constants.py
+++ b/beeai/agents/constants.py
@@ -11,7 +11,7 @@ AGENT_WARNING = (
 
 JIRA_COMMENT_TEMPLATE = Template(f"""Output from $AGENT_TYPE Agent: \n\n$JIRA_COMMENT\n\n{AGENT_WARNING}""")
 
-I_AM_JOTNAR = "by Jotnar, a Red Hat Enterprise Linux packaging AI agent."
+I_AM_JOTNAR = "by Jotnar, a Red Hat Enterprise Linux software maintenance AI agent."
 CAREFULLY_REVIEW_CHANGES = "Carefully review the changes and make sure they are correct."
 
 class JiraLabels(Enum):


### PR DESCRIPTION
This may feel superficial but I think its not. I am very strongly of the opinion that the value of RHEL is not "packaging". In my opinion the value that were looking at here is better thought of as "software maintenance".

Backporting upstream patches for example is really a form of *software development*, its not "packaging". For particularly complex components, ensuring that we're running the upstream test suite for example is extremely important - and that can get quite nontrivial.

While I know this project is scoped only to work on things that are packages today, there are things in RHEL for example that aren't packages, they're containers.

But further IMO a creeping/blending into the
huge domain of AI for *upstream* development is inevitable.

This is just preparing us for that space mentally.

(Feel free to just close this of course as the term "packaging"
 is pervasive in this project, but I hope instead the choice
 is taken to move beyond packaging slowly, at least in the
 most visible parts of branding)

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
