### PR TITLE
Fix Prequisities in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This platform consists of several integrated components:
 ## 🚀 Quick Start
 
 ### Prerequisites
-- Podman
+- Podman, podman-compose
 - Make
 - API tokens (see Configuration section)
 


### PR DESCRIPTION
podman-compose or similar is required as well:

```
$ make build
podman compose build
[  331.100290] evm: overlay not supported
Error: looking up compose provider failed
7 errors occurred:
        * exec: "/root/.docker/cli-plugins/docker-compose": stat /root/.docker/cli-plugins/docker-compose: no such file or directory
        * exec: "/usr/local/lib/docker/cli-plugins/docker-compose": stat /usr/local/lib/docker/cli-plugins/docker-compose: no such file or directory
        * exec: "/usr/local/libexec/docker/cli-plugins/docker-compose": stat /usr/local/libexec/docker/cli-plugins/docker-compose: no such file or directory
        * exec: "/usr/lib/docker/cli-plugins/docker-compose": stat /usr/lib/docker/cli-plugins/docker-compose: no such file or directory
        * exec: "/usr/libexec/docker/cli-plugins/docker-compose": stat /usr/libexec/docker/cli-plugins/docker-compose: no such file or directory
        * exec: "docker-compose": executable file not found in $PATH
        * exec: "podman-compose": executable file not found in $PATH
make: *** [Makefile:61: build] Error 125

```
