### PR TITLE
goose-container: install missing wait_mcp_server.sh script

### DIFF
--- a/goose-container/Containerfile
+++ b/goose-container/Containerfile
@@ -47,6 +47,9 @@ COPY --chown=goose:goose \
 COPY --chown=goose:goose \
      scripts/ \
      /home/goose/scripts/
+COPY --chown=goose:goose \
+     adk-workflows/wait_mcp_server.sh \
+     /home/goose/
 
 USER goose
 WORKDIR /home/goose


### PR DESCRIPTION
This script is used by many of the workflows and was missing inside the container.

Fixes #169
