### PR TITLE
update MR title when reusing MR

### DIFF
--- a/beeai/mcp_server/gitlab_tools.py
+++ b/beeai/mcp_server/gitlab_tools.py
@@ -60,6 +60,7 @@ async def open_merge_request(
                     # we have to update the MR description to include the new commit hash
                     # this is an active API call via PR's setter method
                     pr.description = description
+                    pr.title = title
                     break
             else:
                 raise


### PR DESCRIPTION
before Log Agent, our MRs were the exact same even between runs

now that LLM is creating them, we need to update them all the time