### PR TITLE
Stage changes before running log agent

### DIFF
--- a/beeai/agents/log_agent.py
+++ b/beeai/agents/log_agent.py
@@ -26,8 +26,8 @@ def get_instructions() -> str:
       To document a change corresponding to <JIRA_ISSUE> Jira issue, having a brief summary
       of changes performed, do the following:
 
-      1. Use `git diff HEAD` to see what are the final changes that have been made in dist-git.
-         This command shows all changes (staged and unstaged) since the last commit.
+      1. Use `git diff --cached` to see what are the final changes that have been made
+         in dist-git and staged for commit.
 
       2. Add a new changelog entry to the spec file. Use the `add_changelog_entry` tool.
          Examine the previous changelog entries and try to use the same style. In general,

--- a/beeai/agents/rebase_agent.py
+++ b/beeai/agents/rebase_agent.py
@@ -253,7 +253,7 @@ async def main() -> None:
                 )
                 build_result = BuildOutputSchema.model_validate_json(response.last_message.text)
                 if build_result.success:
-                    return "run_log_agent"
+                    return "stage_changes"
                 state.attempts_remaining -= 1
                 if state.attempts_remaining <= 0:
                     state.rebase_result.success = False
@@ -263,6 +263,22 @@ async def main() -> None:
                     return "comment_in_jira"
                 state.build_error = build_result.error
                 return "run_rebase_agent"
+
+            async def stage_changes(state):
+                # Use files specified by rebase agent, fallback to *.spec if none specified
+                files_to_git_add = state.rebase_result.files_to_git_add or ["*.spec"]
+
+                try:
+                    await tasks.stage_changes(
+                        local_clone=state.local_clone,
+                        files_to_commit=files_to_git_add,
+                    )
+                except Exception as e:
+                    logger.warning(f"Error staging changes: {e}")
+                    state.rebase_result.success = False
+                    state.rebase_result.error = f"Could not stage changes: {e}"
+                    return "comment_in_jira"
+                return "run_log_agent"
 
             async def run_log_agent(state):
                 response = await log_agent.run(
@@ -280,13 +296,9 @@ async def main() -> None:
                 return "commit_push_and_open_mr"
 
             async def commit_push_and_open_mr(state):
-                # Use files specified by rebase agent, fallback to *.spec if none specified
-                files_to_git_add = state.rebase_result.files_to_git_add or ["*.spec"]
-
                 try:
                     state.merge_request_url = await tasks.commit_push_and_open_mr(
                         local_clone=state.local_clone,
-                        files_to_commit=files_to_git_add,
                         commit_message=(
                             f"{state.log_result.title}\n\n"
                             f"{state.log_result.description}\n\n"
@@ -335,6 +347,7 @@ async def main() -> None:
             workflow.add_step("fork_and_prepare_dist_git", fork_and_prepare_dist_git)
             workflow.add_step("run_rebase_agent", run_rebase_agent)
             workflow.add_step("run_build_agent", run_build_agent)
+            workflow.add_step("stage_changes", stage_changes)
             workflow.add_step("run_log_agent", run_log_agent)
             workflow.add_step("commit_push_and_open_mr", commit_push_and_open_mr)
             workflow.add_step("comment_in_jira", comment_in_jira)


### PR DESCRIPTION
So it can do `git diff --cached` and examine all files to be committed.