### PR TITLE
beeai: clone repositories to directory named after the package name

### DIFF
--- a/beeai/agents/tasks.py
+++ b/beeai/agents/tasks.py
@@ -32,7 +32,7 @@ async def fork_and_prepare_dist_git(
     local_clone = working_dir / package
     shutil.rmtree(local_clone, ignore_errors=True)
     await check_subprocess(
-        ["git", "clone", "--single-branch", "--branch", dist_git_branch, fork_url],
+        ["git", "clone", "--single-branch", "--branch", dist_git_branch, fork_url, package],
         cwd=working_dir,
     )
     update_branch = f"{BRANCH_PREFIX}-{jira_issue}"


### PR DESCRIPTION
In case of an already existing fork created with "centpkg fork", the repository will have the namespace in its name, e.g. centos_rpms_foo. Since we later assume the repository is in /git-repos/RHEL-XXX/package we have to specify the directory name to match the expectations.

