### PR TITLE
supervisor: Add a search_resultsdb tool

### DIFF
--- a/beeai/.gitignore
+++ b/beeai/.gitignore
@@ -29,4 +29,3 @@ ENV/
 *.tar.gz
 
 .coverage*
-/certs/*.pem

--- a/beeai/Containerfile.c10s
+++ b/beeai/Containerfile.c10s
@@ -4,6 +4,10 @@ RUN dnf -y install epel-release \
     && dnf config-manager --set-enabled crb \
     && dnf -y update
 
+# Install RH IT Root CAs for access to internal services
+COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
+
 RUN dnf -y install --allowerasing \
       centpkg \
       curl \

--- a/beeai/Makefile
+++ b/beeai/Makefile
@@ -7,12 +7,8 @@ COMPOSE_AGENTS=$(COMPOSE) -f $(COMPOSE_FILE) --profile=agents
 COMPOSE_SUPERVISOR=$(COMPOSE) -f $(COMPOSE_FILE) --profile=supervisor
 
 .PHONY: build
-build: certs/Current-IT-Root-CAs.pem
+build:
 	$(COMPOSE) -f $(COMPOSE_FILE) build
-
-certs/Current-IT-Root-CAs.pem:
-	curl -o certs/Current-IT-Root-CAs.pem \
-	https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
 
 .PHONY: run-beeai-bash
 run-beeai-bash:

--- a/beeai/compose.yaml
+++ b/beeai/compose.yaml
@@ -61,14 +61,12 @@ x-supervisor: &supervisor
     - COLLECTOR_ENDPOINT=http://phoenix:6006/v1/traces
     - GIT_REPO_BASEPATH=/git-repos
     - "KRB5CCNAME=FILE:/home/beeai/ccache/krb5cc"
-    - REDHAT_IT_CA_BUNDLE=/home/beeai/certs/Current-IT-Root-CAs.pem
   env_file:
     - .secrets/supervisor.env
   volumes:
     - ./agents:/home/beeai/agents:ro,z
     - ./supervisor:/home/beeai/supervisor:ro,z
     - .secrets/ccache:/home/beeai/ccache:ro,z,U
-    - ./certs:/home/beeai/certs:ro,z,U
   restart: unless-stopped
 
 services:

--- a/beeai/supervisor/errata_utils.py
+++ b/beeai/supervisor/errata_utils.py
@@ -5,15 +5,12 @@ import os
 
 from bs4 import BeautifulSoup, Tag  # type: ignore
 from pydantic import BaseModel
-import requests
 from requests_gssapi import HTTPSPNEGOAuth
 
+from .http_utils import requests_session
 from .supervisor_types import Erratum, ErrataStatus
 
 logger = logging.getLogger(__name__)
-
-
-session = requests.Session()
 
 
 ET_URL = "https://errata.engineering.redhat.com/"
@@ -29,7 +26,7 @@ def ET_verify() -> bool | str:
 
 
 def ET_api_get(path: str):
-    response = session.get(
+    response = requests_session().get(
         f"{ET_URL}/api/v1/{path}",
         auth=HTTPSPNEGOAuth(opportunistic_auth=True),
         verify=ET_verify(),
@@ -39,7 +36,7 @@ def ET_api_get(path: str):
 
 
 def ET_api_post(path: str, data: dict):
-    response = session.post(
+    response = requests_session().post(
         f"{ET_URL}/api/v1/{path}",
         data=data,
         auth=HTTPSPNEGOAuth(opportunistic_auth=True),
@@ -50,7 +47,7 @@ def ET_api_post(path: str, data: dict):
 
 
 def ET_get_html(path: str):
-    response = session.get(
+    response = requests_session().get(
         f"{ET_URL}/{path}",
         auth=HTTPSPNEGOAuth(opportunistic_auth=True),
         verify=ET_verify(),

--- a/beeai/supervisor/http_utils.py
+++ b/beeai/supervisor/http_utils.py
@@ -1,0 +1,127 @@
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+import aiohttp
+import os
+import ssl
+
+import requests
+import requests.adapters
+
+
+# We use *both* aiohttp and requests in various places, so we need to
+# set up sessions for both libraries. (We can't convert everything to
+# aiohttp because of our usage of requests_gssapi, but aiohttp is nice
+# within code that is already async.)
+
+
+def _create_ssl_context_with_extra_ca() -> ssl.SSLContext:
+    """
+    Create an SSL context that includes extra CA certificates from the
+    REDHAT_IT_CA_BUNDLE environment variable, if set.
+    """
+    context = ssl.create_default_context()
+    redhat_it_ca_bundle = os.getenv("REDHAT_IT_CA_BUNDLE")
+    if redhat_it_ca_bundle:
+        context.load_verify_locations(cafile=redhat_it_ca_bundle)
+    return context
+
+
+_aiohttp_session = ContextVar[aiohttp.ClientSession | None](
+    "aiohttp_session", default=None
+)
+
+
+@asynccontextmanager
+async def with_aiohttp_session():
+    """
+    Context manager that sets up a scoped aiohttp.ClientSession
+    appropriate for our usage, including using any extra CA certificates
+    specified in the REDHAT_IT_CA_BUNDLE environment variable.
+
+    This can also be used as a decorator on async functions.
+    """
+    session = _aiohttp_session.get()
+
+    if session is None:
+        connector = aiohttp.TCPConnector(ssl=_create_ssl_context_with_extra_ca())
+
+        async with aiohttp.ClientSession(connector=connector) as session:
+            token = _aiohttp_session.set(session)
+            try:
+                yield session
+            finally:
+                _aiohttp_session.reset(token)
+    else:
+        yield session
+
+
+def aiohttp_session() -> aiohttp.ClientSession:
+    """
+    Get the current aiohttp.ClientSession. Must be called within the
+    context of an enclosing with_aiohttp_session() decorator or block.
+    """
+    session = _aiohttp_session.get()
+    if session is None:
+        raise RuntimeError("Session not initialized - use within with_aiohttp_session")
+
+    return session
+
+
+class ExtraCAHTTPAdapter(requests.adapters.HTTPAdapter):
+    def __init__(self):
+        self._ssl_context = _create_ssl_context_with_extra_ca()
+        super().__init__()
+
+    def init_poolmanager(self, *args, **kwargs) -> None:
+        kwargs["ssl_context"] = self._ssl_context
+        return super().init_poolmanager(*args, **kwargs)
+
+
+_requests_session = ContextVar[requests.Session | None](
+    "requests_session", default=None
+)
+
+
+@asynccontextmanager
+async def with_requests_session():
+    """
+    Context manager that sets up a scoped requests.Session
+    appropriate for our usage, including using any extra CA certificates
+    specified in the REDHAT_IT_CA_BUNDLE environment variable.
+
+    This can also be used as a decorator on async functions.
+    """
+    session = _requests_session.get()
+
+    if session is None:
+        with requests.Session() as session:
+            session.mount("https://", ExtraCAHTTPAdapter())
+            token = _requests_session.set(session)
+            try:
+                yield session
+            finally:
+                _requests_session.reset(token)
+    else:
+        yield session
+
+
+def requests_session() -> requests.Session:
+    """
+    Get the current requests.Session. Must be called within the
+    context of an enclosing with_requests_session() decorator or block.
+    """
+    session = _requests_session.get()
+    if session is None:
+        raise RuntimeError("Session not initialized - use within with_requests_session")
+
+    return session
+
+
+@asynccontextmanager
+async def with_http_sessions():
+    """
+    Convenience context manager that sets up both aiohttp and requests sessions.
+    """
+    async with with_aiohttp_session():
+        async with with_requests_session():
+            yield

--- a/beeai/supervisor/jira_utils.py
+++ b/beeai/supervisor/jira_utils.py
@@ -48,6 +48,12 @@ def quote(component: str):
 
 
 @cache
+def jira_url() -> str:
+    url = os.environ.get("JIRA_URL", "https://issues.redhat.com")
+    return url.rstrip("/")
+
+
+@cache
 def jira_headers() -> dict[str, str]:
     jira_token = os.environ["JIRA_TOKEN"]
 
@@ -58,21 +64,21 @@ def jira_headers() -> dict[str, str]:
 
 
 def jira_api_get(path: str) -> Any:
-    url = f"https://issues.redhat.com/rest/api/2/{path}"
+    url = f"{jira_url()}/rest/api/2/{path}"
     response = requests_session().get(url, headers=jira_headers())
     response.raise_for_status()
     return response.json()
 
 
 def jira_api_post(path: str, json: dict[str, Any]) -> Any:
-    url = f"https://issues.redhat.com/rest/api/2/{path}"
+    url = f"{jira_url()}/rest/api/2/{path}"
     response = requests_session().post(url, headers=jira_headers(), json=json)
     response.raise_for_status()
     return response.json()
 
 
 def jira_api_put(path: str, json: dict[str, Any]) -> Any:
-    url = f"https://issues.redhat.com/rest/api/2/{path}"
+    url = f"{jira_url()}/rest/api/2/{path}"
     response = requests_session().put(url, headers=jira_headers(), json=json)
     response.raise_for_status()
     return response.json()

--- a/beeai/supervisor/main.py
+++ b/beeai/supervisor/main.py
@@ -36,11 +36,8 @@ def check_env(chat: bool = False, jira: bool = False, redis: bool = False):
             ("CHAT_MODEL", "name of model to use (e.g., gemini:gemini-2.5-pro)")
         )
     if jira:
-        required_vars.extend(
-            [
-                ("JIRA_URL", "Jira instance URL (e.g., https://issues.redhat.com)"),
-                ("JIRA_TOKEN", "Jira authentication token"),
-            ]
+        required_vars.append(
+            ("JIRA_TOKEN", "Jira authentication token"),
         )
     if redis:
         required_vars.append(

--- a/beeai/supervisor/main.py
+++ b/beeai/supervisor/main.py
@@ -12,6 +12,7 @@ from .erratum_handler import ErratumHandler, erratum_needs_attention
 from .issue_handler import IssueHandler
 from .jira_utils import get_current_issues, get_issue
 from .supervisor_types import ErrataStatus, IssueStatus
+from .http_utils import with_http_sessions
 from .work_queue import WorkItem, WorkQueue, WorkItemType, work_queue
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ def check_env(chat: bool = False, jira: bool = False, redis: bool = False):
         raise typer.Exit(1)
 
 
+@with_http_sessions()
 async def collect_once(queue: WorkQueue):
     logger.info("Getting all relevant issues from JIRA")
     issues = [i for i in get_current_issues()]
@@ -112,6 +114,7 @@ def collect(
     asyncio.run(do_collect(repeat, repeat_delay))
 
 
+@with_http_sessions()
 async def process_once(queue: WorkQueue):
     work_item = await queue.wait_first_ready_work_item()
     if work_item.item_type == WorkItemType.PROCESS_ISSUE:
@@ -166,6 +169,7 @@ def process(repeat: bool = typer.Option(True)):
     asyncio.run(do_process(repeat))
 
 
+@with_http_sessions()
 async def do_process_issue(key: str):
     issue = get_issue(key, full=True)
     result = await IssueHandler(issue, dry_run=app_state.dry_run).run()
@@ -197,6 +201,7 @@ def process_issue(
     asyncio.run(do_process_issue(key))
 
 
+@with_http_sessions()
 async def do_process_erratum(id: str):
     check_env(chat=True, jira=True)
 

--- a/beeai/supervisor/qe_data.py
+++ b/beeai/supervisor/qe_data.py
@@ -1,0 +1,92 @@
+import asyncio
+from collections.abc import Callable
+from functools import wraps
+from typing import Awaitable, Coroutine, TypeVar
+from pydantic import BaseModel
+
+from .http_utils import aiohttp_session
+
+QE_DATA_REPO = "https://gitlab.cee.redhat.com/otaylor/jotnar-qe-data"
+QE_DATA_URL = (
+    f"{QE_DATA_REPO}/-/raw/main/jotnar_qe_data.json?ref_type=heads&inline=false"
+)
+
+
+class TestLocationInfo(BaseModel):
+    component: str
+    qa_contact: str
+    tests_location: str | None = None
+    test_config_location: str | None = None
+    test_trigger_method: str | None = None
+    test_result_location: str | None = None
+    test_docs_url: str | None = None
+    notes: str | None = None
+
+
+R = TypeVar("R")
+
+
+def cache_async(
+    *,
+    max_age: float | None,
+) -> Callable[[Callable[[], Coroutine[None, None, R]]], Callable[[], Awaitable[R]]]:
+    """
+    Decorator to cache the result of an async function for a specified duration.
+    (For simplicity, max_age is required, and we don't need the standard decorator pattern
+    where it can be called with or without parentheses when no arguments are passed.)
+
+    Args:
+        func: The async function to be cached.
+        max_age: The maximum age (in seconds) for which the cached result is valid.
+    Returns:
+        An async function that returns the cached result if valid, otherwise calls the original function.
+    """
+
+    def decorator(
+        func: Callable[[], Coroutine[None, None, R]],
+    ) -> Callable[[], Awaitable[R]]:
+        cache_task: asyncio.Task[R] | None = None
+        cache_time: float | None = None
+
+        @wraps(func)
+        def wrapper() -> Awaitable[R]:
+            nonlocal cache_task, cache_time
+            now = asyncio.get_running_loop().time()
+
+            if (
+                cache_task is None
+                or cache_task.cancelled()
+                or (cache_task.done() and cache_task.exception() is not None)
+                or cache_time is None
+                or (max_age is not None and (now - cache_time) > max_age)
+            ):
+                cache_task = asyncio.create_task(func())
+                cache_time = now
+
+            return cache_task
+
+        return wrapper
+
+    return decorator
+
+
+@cache_async(max_age=10 * 60)  # cache for 10 minutes
+async def get_qe_data_map() -> dict[str, dict[str, dict[str, str]]]:
+    async with aiohttp_session().get(QE_DATA_URL) as response:
+        response.raise_for_status()
+        return await response.json(content_type=None)
+
+
+async def get_qe_data(component: str) -> TestLocationInfo:
+    map = await get_qe_data_map()
+    component_values = map["components"][component]
+    team_values = map["teams"][component_values["assigned_team"]]
+    organization_values = map["organizations"][team_values["organization"]]
+
+    combined_values = {
+        k: v.replace("$c", component)
+        for k, v in {**organization_values, **team_values, **component_values}.items()
+        if k not in {"assigned_team", "organization"}
+    }
+
+    return TestLocationInfo(**combined_values)

--- a/beeai/supervisor/testing_analyst.py
+++ b/beeai/supervisor/testing_analyst.py
@@ -45,16 +45,16 @@ def render_prompt(input: InputSchema) -> str:
          comment: [explain what needs to be done to start tests]
 
       If the tests are complete and failed:
-         state: tests-failed:
-         comment: [list failed tests with URLs.t]
+         state: tests-failed
+         comment: [list failed tests with URLs]
 
       If the tests are complete and passed:
-         state: tests-passed:
+         state: tests-passed
          comment: [Give a brief summary of what was tested with a link to the result.]
 
-      If the tests will be started automatically without user intervention, but are not yet running::
+      If the tests will be started automatically without user intervention, but are not yet running:
          state: tests-pending
-         commnet: [Provide a brief description of what tests are expected to run and where the results will be]
+         comment: [Provide a brief description of what tests are expected to run and where the results will be]
 
       If the tests are currently running:
          state: tests-running

--- a/beeai/supervisor/testing_analyst.py
+++ b/beeai/supervisor/testing_analyst.py
@@ -68,7 +68,7 @@ async def analyze_issue(jira_issue: FullIssue) -> OutputSchema:
     agent = ToolCallingAgent(
         llm=ChatModel.from_name(
             os.environ["CHAT_MODEL"],
-            allow_parallel_tools_calls=True,
+            allow_parallel_tool_calls=True,
         ),
         memory=UnconstrainedMemory(),
         tools=[ReadReadmeTool()],

--- a/beeai/supervisor/testing_analyst.py
+++ b/beeai/supervisor/testing_analyst.py
@@ -12,6 +12,7 @@ from agents.utils import get_agent_execution_config
 from .qe_data import get_qe_data, TestLocationInfo
 from .supervisor_types import FullIssue, TestingState
 from .tools.read_readme import ReadReadmeTool
+from .tools.search_resultsdb import SearchResultsdbTool
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +72,7 @@ async def analyze_issue(jira_issue: FullIssue) -> OutputSchema:
             allow_parallel_tool_calls=True,
         ),
         memory=UnconstrainedMemory(),
-        tools=[ReadReadmeTool()],
+        tools=[ReadReadmeTool(), SearchResultsdbTool()],
     )
 
     async def run(input: InputSchema):

--- a/beeai/supervisor/tools/search_resultsdb.py
+++ b/beeai/supervisor/tools/search_resultsdb.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+from enum import StrEnum
+import logging
+from urllib.parse import quote as urlquote
+
+from aiohttp import client_exceptions
+from pydantic import BaseModel, Field
+
+from beeai_framework.context import RunContext
+from beeai_framework.emitter import Emitter
+from beeai_framework.tools import ToolOutput, Tool, ToolRunOptions
+
+from ..http_utils import aiohttp_session
+
+
+logger = logging.getLogger(__name__)
+
+
+RESULTS_DB_URL = "https://resultsdb-api.engineering.redhat.com"
+
+
+class ResultsdbOutput(StrEnum):
+    """The possible resultsdb outcome values, we only care about a subset of them."""
+
+    PASSED = "PASSED"
+    INFO = "INFO"
+    FAILED = "FAILED"
+    NEEDS_INSPECTION = "NEEDS_INSPECTION"
+    NOT_APPLICABLE = "NOT_APPLICABLE"
+    QUEUED = "QUEUED"
+    RUNNING = "RUNNING"
+    ERROR = "ERROR"
+    PENDING = "PENDING"
+
+
+class ResultsDbResult(BaseModel):
+    """A small subset of the full resultsdb result schema, but it is all we need."""
+
+    testcase_name: str
+    outcome: ResultsdbOutput
+    ref_url: str
+    # Renamed from submit_time, since that sounds like when the test was
+    # started, but it means when the result was submitted to resultsdb
+    last_updated: datetime
+
+
+# Arbitrary limit, we shouldn't get this many results for a single NVR
+MAX_RESULTS = 100
+
+
+async def search_resultsdb(
+    package_nvr: str, name_pattern: str
+) -> list[ResultsDbResult]:
+    session = aiohttp_session()
+    url = (
+        f"{RESULTS_DB_URL}/api/v2.0/results"
+        f"?item={urlquote(package_nvr)}"
+        f"&testcases:like={urlquote(name_pattern)}"
+        f"&limit={MAX_RESULTS}"
+    )
+    logger.info("Fetching resultsdb data from %s", url)
+    async with session.get(url) as response:
+        if response.status == 200:
+            response_json = await response.json()
+
+            if response_json.get("next") is not None:
+                raise ValueError(f"ResultsDB returned more than {MAX_RESULTS} results")
+
+            results: list[ResultsDbResult] = [
+                ResultsDbResult(
+                    testcase_name=r["testcase"]["name"],
+                    outcome=ResultsdbOutput(r["outcome"]),
+                    ref_url=r["ref_url"],
+                    last_updated=datetime.fromisoformat(r["submit_time"]),
+                )
+                for r in response_json.get("data", [])
+            ]
+
+            # Now only keep the latest result for each testcase
+            latest_results: dict[str, ResultsDbResult] = {}
+            for r in results:
+                if (
+                    r.testcase_name not in latest_results
+                    or r.last_updated > latest_results[r.testcase_name].last_updated
+                ):
+                    latest_results[r.testcase_name] = r
+
+            logger.info(
+                "Found %d results in resultsdb (%d after filtering for latest submissions)",
+                len(results),
+                len(latest_results),
+            )
+
+            return list(latest_results.values())
+        else:
+            text = await response.text()
+            raise client_exceptions.ClientResponseError(
+                response.request_info,
+                response.history,
+                status=response.status,
+                message=text,
+                headers=response.headers,
+            )
+
+
+class SearchResultsdbInput(BaseModel):
+    package_nvr: str = Field(
+        description="NVR of the package to search in the results database"
+    )
+    name_pattern: str = Field(
+        description="Pattern to search for in the testcase names, e.g. 'frontend.regression.test-%'"
+    )
+
+
+class SearchResultsdbOutput(BaseModel, ToolOutput):
+    results: list[ResultsDbResult]
+
+    def get_text_content(self) -> str:
+        return self.model_dump_json(indent=2, exclude_unset=True)
+
+    def is_empty(self) -> bool:
+        return len(self.results) == 0
+
+
+class SearchResultsdbTool(
+    Tool[SearchResultsdbInput, ToolRunOptions, SearchResultsdbOutput]
+):
+    """
+    Tool to search for results for a specific package build in resultsdb.
+    https://github.com/release-engineering/resultsdb
+    """
+
+    name = "search_resultsdb"  # type: ignore
+    description = "Search for results for a specific package build in resultsdb"  # type: ignore
+    input_schema = SearchResultsdbInput  # type: ignore
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "search_resultsdb"],
+            creator=self,
+        )
+
+    async def _run(
+        self,
+        input: SearchResultsdbInput,
+        options: ToolRunOptions | None,
+        context: RunContext,
+    ) -> SearchResultsdbOutput:
+        try:
+            return SearchResultsdbOutput(
+                results=await search_resultsdb(input.package_nvr, input.name_pattern)
+            )
+        except Exception as e:
+            logger.exception("Error fetching or parsing resultsdb data: %s", e)
+            raise e


### PR DESCRIPTION
This merge requestadds a new tool for the supervisor's testing-analyst agent - it searches in resultsdb
(https://github.com/release-engineering/resultsdb) to find test results.

This provides the testing analyst agent a convenient way to locate and check on the results of testing for the Display Systems packages. (Details of what names the tests are under are provided in the downloaded QE data.)

The merge request takes a bit of a roundabout route, there are also commits here:
 - To change to how HTTP sessions are handled (because results DB also need the internal Red Hat IT CA cert)
 - To change the QE data file format to not duplicate date (because duplicating the long comment about how to find things in resultsdb made the old file format get even bigger and messier.)
 - A couple of related small fixes

With this:

```
$ make process-issue JIRA_ISSUE=RHEL-114857 DEBUG=true DRY_RUN=true
DEBUG:supervisor.jira_utils:Dry run: would post {'transition': {'id': '101'}, 'update': {'comment': [{'add': {'body': 'Both the gating and final test suites have passed.\n\nYou can find the results here:\n* Gating tests: https://desktop-ci.spice.lab.eng.brq2.redhat.com/job/beaker-glib2-RHEL-10.1/4/\n* Final tests: https://desktop-ci.spice.lab.eng.brq2.redhat.com/job/beaker-glib2-RHEL-10.1/3/'}}]}} to issue/RHEL-114857/transitions
```

So the testing analyst finds the tests in resultsdb, sees that they passed, and reports that back to the supervisor's issue handler which adds a comment and moves the issue to ReleasePending.

To break that comment out:

```
Both the gating and final test suites have passed.

You can find the results here:
* Gating tests: https://desktop-ci.spice.lab.eng.brq2.redhat.com/job/beaker-glib2-RHEL-10.1/4/
* Final tests: https://desktop-ci.spice.lab.eng.brq2.redhat.com/job/beaker-glib2-RHEL-10.1/3/
```
