### PR TITLE
Add missing dependencies for building beeai-agents

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -12,6 +12,7 @@ RUN dnf -y install --allowerasing \
       centpkg \
       curl \
       gcc \
+      gcc-c++ \
       git \
       python3 \
       python3-beautifulsoup4 \

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -8,6 +8,7 @@ RUN dnf -y install --allowerasing \
       centpkg \
       curl \
       gcc \
+      gcc-c++ \
       git \
       python3-rpm \
       rpm-build \


### PR DESCRIPTION
Similar as done in d6abfe5b2cc7ab64c89dbd1fb9574dc64c6ae00e

