### PR TITLE
Move init_kerberos_ticket to common and use for supervisor

### DIFF
--- a/common/tests/unit/test_utils.py
+++ b/common/tests/unit/test_utils.py
@@ -1,0 +1,368 @@
+import asyncio
+import os
+import subprocess
+import pytest
+from flexmock import flexmock
+from unittest.mock import AsyncMock
+
+from common.utils import init_kerberos_ticket, KerberosError, extract_principal
+
+
+class TestInitKerberosTicket:
+    """Test cases for init_kerberos_ticket() function."""
+
+    @pytest.mark.asyncio
+    async def test_missing_krb5ccname_raises_error(self, monkeypatch):
+        """Test that missing KRB5CCNAME environment variable raises KerberosError."""
+        monkeypatch.delenv("KRB5CCNAME", raising=False)
+        monkeypatch.delenv("KEYTAB_FILE", raising=False)
+
+        with pytest.raises(KerberosError, match="KRB5CCNAME environment variable is not set"):
+            await init_kerberos_ticket()
+
+    @pytest.mark.asyncio
+    async def test_ccache_file_not_exists_no_keytab_raises_error(self, monkeypatch):
+        """Test that non-existent ccache file with no keytab raises error."""
+        monkeypatch.delenv("KEYTAB_FILE", raising=False)
+        monkeypatch.setenv("KRB5CCNAME", "/nonexistent/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/nonexistent/ccache").and_return(
+            False
+        )
+        mock_subprocess = flexmock(asyncio).should_receive("create_subprocess_exec").never()
+
+        # we should avoid calling klist when the ccache file doesn't exist
+        with pytest.raises(
+            KerberosError, match="No valid Kerberos ticket found and KEYTAB_FILE is not set"
+        ):
+            await init_kerberos_ticket()
+
+    @pytest.mark.asyncio
+    async def test_klist_command_failure_raises_error(self, monkeypatch):
+        """Test that klist command failure raises KerberosError."""
+        mock_proc = flexmock(returncode=1)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(b"error output", b"stderr output"))()
+        )
+
+        monkeypatch.delenv("KEYTAB_FILE", raising=False)
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        with pytest.raises(KerberosError, match="Failed to list Kerberos tickets"):
+            await init_kerberos_ticket()
+
+    @pytest.mark.asyncio
+    async def test_valid_ticket_in_cache_returns_principal(self, monkeypatch):
+        """Test that valid ticket in cache returns the principal."""
+        klist_output = b"""Principal name                 Cache name
+--------------                 ----------
+user@EXAMPLE.COM         KCM:1000
+"""
+        mock_proc = flexmock(returncode=0)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        monkeypatch.delenv("KEYTAB_FILE", raising=False)
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        result = await init_kerberos_ticket()
+        assert result == "user@EXAMPLE.COM"
+
+    @pytest.mark.asyncio
+    async def test_expired_ticket_ignored(self, monkeypatch):
+        """Test that expired tickets are ignored."""
+        klist_output = b"""Principal name                 Cache name
+--------------                 ----------
+user@EXAMPLE.COM         FILE:.secrets/ccache/krb5cc (Expired)
+"""
+        mock_proc = flexmock(returncode=0)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        monkeypatch.delenv("KEYTAB_FILE", raising=False)
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        with pytest.raises(
+            KerberosError, match="No valid Kerberos ticket found and KEYTAB_FILE is not set"
+        ):
+            await init_kerberos_ticket()
+
+    @pytest.mark.asyncio
+    async def test_no_tickets_in_cache(self, monkeypatch):
+        """Test behavior when klist returns no tickets."""
+        klist_output = b"""Principal name                 Cache name
+--------------                 ----------
+"""
+        mock_proc = flexmock(returncode=0)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        monkeypatch.delenv("KEYTAB_FILE", raising=False)
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        with pytest.raises(
+            KerberosError, match="No valid Kerberos ticket found and KEYTAB_FILE is not set"
+        ):
+            await init_kerberos_ticket()
+
+    @pytest.mark.asyncio
+    async def test_keytab_principal_already_in_cache(self, monkeypatch):
+        """Test that existing keytab principal in cache is used."""
+        klist_output = b"""Principal name                 Cache name
+--------------                 ----------
+jotnar-bot@IPA.REDHAT.COM    KCM:1000
+"""
+        mock_proc = flexmock(returncode=0)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        monkeypatch.setenv("KEYTAB_FILE", "/path/to/keytab")
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        from common import utils
+
+        flexmock(utils).should_receive("extract_principal").with_args("/path/to/keytab").and_return(
+            AsyncMock(return_value="jotnar-bot@IPA.REDHAT.COM")()
+        )
+
+        result = await init_kerberos_ticket()
+        assert result == "jotnar-bot@IPA.REDHAT.COM"
+
+    @pytest.mark.asyncio
+    async def test_keytab_kinit_success(self, monkeypatch):
+        """Test successful kinit with keytab when principal not in cache."""
+        klist_output = b"""Principal name                 Cache name
+--------------                 ----------
+"""
+        mock_klist_proc = flexmock(returncode=0)
+        mock_klist_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        mock_kinit_proc = flexmock(returncode=0)
+        mock_kinit_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(b"error output", b"stderr output"))()
+        )
+
+        monkeypatch.setenv("KEYTAB_FILE", "/path/to/keytab")
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
+
+        def mock_create_subprocess(*args, **kwargs):
+            if args[0] == "klist":
+                return AsyncMock(return_value=mock_klist_proc)()
+            elif args[0] == "kinit":
+                return AsyncMock(return_value=mock_kinit_proc)()
+
+        flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(
+            mock_create_subprocess
+        )
+
+        from common import utils
+
+        flexmock(utils).should_receive("extract_principal").with_args("/path/to/keytab").and_return(
+            AsyncMock(return_value="jotnar-bot@IPA.REDHAT.COM")()
+        )
+
+        result = await init_kerberos_ticket()
+        assert result == "jotnar-bot@IPA.REDHAT.COM"
+
+    @pytest.mark.asyncio
+    async def test_keytab_kinit_failure(self, monkeypatch):
+        """Test kinit failure with keytab raises error."""
+        klist_output = b"""Principal name                 Cache name
+--------------                 ----------
+"""
+        mock_klist_proc = flexmock(returncode=0)
+        mock_klist_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        mock_kinit_proc = flexmock(returncode=1)
+        mock_kinit_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(b"error output", b"stderr output"))()
+        )
+
+        monkeypatch.setenv("KEYTAB_FILE", "/path/to/keytab")
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
+
+        def mock_create_subprocess(*args, **kwargs):
+            if args[0] == "klist":
+                return AsyncMock(return_value=mock_klist_proc)()
+            elif args[0] == "kinit":
+                return AsyncMock(return_value=mock_kinit_proc)()
+
+        flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(
+            mock_create_subprocess
+        )
+
+        from common import utils
+
+        flexmock(utils).should_receive("extract_principal").with_args("/path/to/keytab").and_return(
+            AsyncMock(return_value="jotnar-bot@IPA.REDHAT.COM")()
+        )
+
+        with pytest.raises(KerberosError, match="kinit command failed"):
+            await init_kerberos_ticket()
+
+    @pytest.mark.asyncio
+    async def test_keytab_extract_principal_failure(self, monkeypatch):
+        """Test extract_principal failure raises error."""
+        monkeypatch.setenv("KEYTAB_FILE", "/path/to/keytab")
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+
+        from common import utils
+
+        flexmock(utils).should_receive("extract_principal").with_args("/path/to/keytab").and_return(
+            AsyncMock(return_value=None)()
+        )
+
+        with pytest.raises(KerberosError, match="Failed to extract principal from keytab file"):
+            await init_kerberos_ticket()
+
+    @pytest.mark.asyncio
+    async def test_multiple_valid_principals_returns_first(self, monkeypatch):
+        """Test that first valid principal is returned when multiple exist."""
+        klist_output = b"""Principal name                 Cache name
+--------------                 ----------
+user1@EXAMPLE.COM         KCM:1000
+user2@EXAMPLE.COM         KCM:1001
+"""
+        mock_proc = flexmock(returncode=0)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        monkeypatch.delenv("KEYTAB_FILE", raising=False)
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        result = await init_kerberos_ticket()
+        assert result == "user1@EXAMPLE.COM"
+
+    @pytest.mark.asyncio
+    async def test_mixed_valid_and_expired_principals(self, monkeypatch):
+        """Test that expired principals are ignored and valid ones are used."""
+        klist_output = b"""Principal name                 Cache name
+--------------                 ----------
+expired@EXAMPLE.COM      FILE:.secrets/ccache/krb5cc (Expired)
+valid@EXAMPLE.COM        KCM:1000
+"""
+        mock_proc = flexmock(returncode=0)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        monkeypatch.delenv("KEYTAB_FILE", raising=False)
+        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
+        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        result = await init_kerberos_ticket()
+        assert result == "valid@EXAMPLE.COM"
+
+
+class TestExtractPrincipal:
+    """Test cases for extract_principal() helper function."""
+
+    @pytest.mark.asyncio
+    async def test_extract_principal_success(self):
+        """Test successful principal extraction from keytab."""
+        klist_output = b"""Keytab name: FILE:openshift/jotnar-bot.keytab
+KVNO Principal
+---- --------------------------------------------------------------------------
+   2 jotnar-bot@IPA.REDHAT.COM (aes256-cts-hmac-sha1-96)  (0xabcdef0000000000000000000000000000000000000000000000000000000000)
+   2 jotnar-bot@IPA.REDHAT.COM (aes128-cts-hmac-sha1-96)  (0xabcdef000000000000000000000000000)
+"""
+        mock_proc = flexmock(returncode=0)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist",
+            "-k",
+            "-K",
+            "-e",
+            "/path/to/keytab",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        result = await extract_principal("/path/to/keytab")
+        assert result == "jotnar-bot@IPA.REDHAT.COM"
+
+    @pytest.mark.asyncio
+    async def test_extract_principal_klist_failure(self):
+        """Test extract_principal when klist command fails."""
+        mock_proc = flexmock(returncode=1)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(b"error", b"stderr"))()
+        )
+
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist",
+            "-k",
+            "-K",
+            "-e",
+            "/path/to/keytab",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        with pytest.raises(KerberosError, match="klist command failed"):
+            await extract_principal("/path/to/keytab")
+
+    @pytest.mark.asyncio
+    async def test_extract_principal_no_valid_key(self):
+        """Test extract_principal when no valid key found in output."""
+        klist_output = b"""Keytab name: FILE:openshift/jotnar-bot.keytab
+KVNO Principal
+---- --------------------------------------------------------------------------
+"""
+        mock_proc = flexmock(returncode=0)
+        mock_proc.should_receive("communicate").and_return(
+            AsyncMock(return_value=(klist_output, b""))()
+        )
+
+        flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
+            "klist",
+            "-k",
+            "-K",
+            "-e",
+            "/path/to/keytab",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).and_return(AsyncMock(return_value=mock_proc)())
+
+        with pytest.raises(KerberosError, match="No valid key found in the keytab file"):
+            await extract_principal("/path/to/keytab")

--- a/common/utils.py
+++ b/common/utils.py
@@ -2,10 +2,13 @@
 Common utility functions shared across the BeeAI system.
 """
 
+import asyncio
 import inspect
 import logging
+import os
 import re
 from contextlib import asynccontextmanager
+import subprocess
 from typing import AsyncGenerator, Awaitable, TypeVar
 
 import redis.asyncio as redis
@@ -61,5 +64,72 @@ async def redis_client(redis_url: str) -> AsyncGenerator[redis.Redis, None]:
 
 CS_BRANCH_PATTERN = re.compile(r"^c\d+s$")
 
+
 def is_cs_branch(dist_git_branch: str) -> bool:
     return CS_BRANCH_PATTERN.match(dist_git_branch) is not None
+
+
+async def extract_principal(keytab_file: str) -> str | None:
+    """
+    Extracts principal from the specified keytab file. Assumes that there is
+    a single principal in the keytab.
+
+    Args:
+        keytab_file: Path to a keytab file.
+
+    Returns:
+        Extracted principal.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "klist",
+        "-k",
+        "-K",
+        "-e",
+        keytab_file,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    print(stdout.decode(), flush=True)
+    if proc.returncode:
+        print(stderr.decode(), flush=True)
+        return None
+    key_pattern = re.compile(r"^\s*(\d+)\s+(\S+)\s+\((\S+)\)\s+\((\S+)\)$")
+    for line in stdout.decode().splitlines():
+        if not (match := key_pattern.match(line)):
+            continue
+        # just return the principal associated with the first key
+        return match.group(2)
+    return None
+
+
+async def init_kerberos_ticket() -> str | None:
+    """
+    Initializes Kerberos ticket unless it's already present in a credentials cache.
+    On success, returns the associated principal.
+    """
+    keytab_file = os.getenv("KEYTAB_FILE")
+    principal = await extract_principal(keytab_file)
+    if not principal:
+        print("Failed to extract principal", flush=True)
+        return None
+    proc = await asyncio.create_subprocess_exec(
+        "klist",
+        "-l",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    print(stdout.decode(), flush=True)
+    if proc.returncode:
+        print(stderr.decode(), flush=True)
+    elif any(
+        l for l in stdout.decode().splitlines() if principal in l and "Expired" not in l
+    ):
+        return principal
+    env = os.environ.copy()
+    env.update({"KRB5_TRACE": "/dev/stdout"})
+    proc = await asyncio.create_subprocess_exec(
+        "kinit", "-k", "-t", keytab_file, principal, env=env
+    )
+    return None if await proc.wait() else principal

--- a/mcp_server/copr_tools.py
+++ b/mcp_server/copr_tools.py
@@ -13,8 +13,8 @@ from copr.v3 import BuildProxy, ProjectProxy
 from fastmcp.exceptions import ToolError
 from pydantic import BaseModel, Field
 
+from common.utils import init_kerberos_ticket
 from common.validators import AbsolutePath
-from utils import init_kerberos_ticket
 
 COPR_CONFIG = {
     "copr_url": "https://copr.devel.redhat.com",

--- a/mcp_server/lookaside_tools.py
+++ b/mcp_server/lookaside_tools.py
@@ -6,9 +6,8 @@ from typing import Annotated
 from fastmcp.exceptions import ToolError
 from pydantic import Field
 
-from common.utils import is_cs_branch
+from common.utils import init_kerberos_ticket, is_cs_branch
 from common.validators import AbsolutePath
-from utils import init_kerberos_ticket
 
 
 async def download_sources(

--- a/mcp_server/utils.py
+++ b/mcp_server/utils.py
@@ -1,9 +1,7 @@
 import asyncio
 import logging
 import os
-import re
 import shutil
-import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -12,62 +10,6 @@ logger = logging.getLogger(__name__)
 
 REPO_CLEANUP_DAYS = 14
 
-
-async def extract_principal(keytab_file: str) -> str | None:
-    """
-    Extracts principal from the specified keytab file. Assumes that there is
-    a single principal in the keytab.
-
-    Args:
-        keytab_file: Path to a keytab file.
-
-    Returns:
-        Extracted principal.
-    """
-    proc = await asyncio.create_subprocess_exec(
-        "klist", "-k", "-K", "-e", keytab_file,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    stdout, stderr = await proc.communicate()
-    print(stdout.decode(), flush=True)
-    if proc.returncode:
-        print(stderr.decode(), flush=True)
-        return None
-    key_pattern = re.compile(r"^\s*(\d+)\s+(\S+)\s+\((\S+)\)\s+\((\S+)\)$")
-    for line in stdout.decode().splitlines():
-        if not (match := key_pattern.match(line)):
-            continue
-        # just return the principal associated with the first key
-        return match.group(2)
-    return None
-
-
-async def init_kerberos_ticket() -> str | None:
-    """
-    Initializes Kerberos ticket unless it's already present in a credentials cache.
-    On success, returns the associated principal.
-    """
-    keytab_file = os.getenv("KEYTAB_FILE")
-    principal = await extract_principal(keytab_file)
-    if not principal:
-        print("Failed to extract principal", flush=True)
-        return None
-    proc = await asyncio.create_subprocess_exec(
-        "klist", "-l",
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    stdout, stderr = await proc.communicate()
-    print(stdout.decode(), flush=True)
-    if proc.returncode:
-        print(stderr.decode(), flush=True)
-    elif any(l for l in stdout.decode().splitlines() if principal in l and "Expired" not in l):
-        return principal
-    env = os.environ.copy()
-    env.update({"KRB5_TRACE": "/dev/stdout"})
-    proc = await asyncio.create_subprocess_exec("kinit", "-k", "-t", keytab_file, principal, env=env)
-    return None if await proc.wait() else principal
 
 def cleanup_stale_directories(git_repos_path: Path, cutoff_time: datetime) -> int:
     """

--- a/supervisor/main.py
+++ b/supervisor/main.py
@@ -200,7 +200,6 @@ def process_issue(
 
 @with_http_sessions()
 async def do_process_erratum(id: str):
-    check_env(chat=True, jira=True)
 
     erratum = get_erratum(id)
     result = await ErratumHandler(erratum, dry_run=app_state.dry_run).run()
@@ -216,6 +215,8 @@ async def do_process_erratum(id: str):
 
 @app.command()
 def process_erratum(id_or_url: str):
+    check_env(chat=True, jira=True)
+
     if id_or_url.startswith("http"):
         m = re.match(
             r"https://errata.engineering.redhat.com/advisory/(\d+)$", id_or_url


### PR DESCRIPTION
This pull request:
 - Moves init_kerberos_ticket() to common/utils
 - Enhances it a bit:
      - If KEYTAB_FILE is not set, but a valid ticket exists, use it
      - Raise KerberosError rather than returning None on failure
      - Don't spew klist/kinit output on success
 - Calls it at initialization of the supervisor subcommands that need to talk to erratatool

