### PR TITLE
supervisor: use a separate Containerfile

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -16,12 +16,9 @@ RUN dnf -y install --allowerasing \
       git \
       krb5-devel \
       python3 \
-      python3-beautifulsoup4 \
       python3-pip \
       python3-devel \
-      python3-requests-gssapi \
       python3-rpm \
-      python3-typer \
       python3-koji \
       rpm-build \
       rpmdevtools \

--- a/Containerfile.supervisor
+++ b/Containerfile.supervisor
@@ -1,0 +1,51 @@
+FROM quay.io/centos/centos:stream10
+
+RUN dnf -y install epel-release \
+    && dnf config-manager --set-enabled crb \
+    && dnf -y update
+
+# Install RH IT Root CAs for access to internal services
+COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
+
+RUN dnf -y install --allowerasing \
+      # Run time dependencies
+      krb5-workstation \
+      python3 \
+      python3-beautifulsoup4 \
+      python3-pip \
+      python3-requests-gssapi \
+      python3-rpm \
+      python3-typer \
+      python3-koji \
+      # Build dependencies
+      gcc \
+      gcc-c++ \
+      python3-devel \
+    && pip3 install -v --no-cache-dir \
+      beeai-framework[mcp,duckduckgo]==0.1.43 \
+      openinference-instrumentation-beeai \
+      arize-phoenix-otel \
+      redis \
+      specfile \
+    && dnf -y remove gcc gcc-c++ python3-devel \
+    && dnf clean all
+
+# Create user
+RUN useradd -m -G wheel beeai
+
+# Copy required directories
+# Individual directories are mounted as volumes in development
+COPY agents/ /home/beeai/agents/
+COPY common/ /home/beeai/common/
+COPY supervisor/ /home/beeai/supervisor/
+RUN chgrp -R root /home/beeai && chmod -R g+rX /home/beeai
+
+USER beeai
+ENV HOME=/home/beeai
+WORKDIR $HOME
+
+# Set PYTHONPATH so agents module can be imported
+ENV PYTHONPATH=$HOME:$PYTHONPATH
+
+CMD ["/bin/bash"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -53,10 +53,10 @@ x-supervisor: &supervisor
   depends_on:
     - valkey
     - phoenix
-  image: beeai-agent
+  image: supervisor
   build:
     context: .
-    dockerfile: Containerfile.c10s
+    dockerfile: Containerfile.supervisor
   environment:
     - REDIS_URL=redis://valkey:6379/0
     - COLLECTOR_ENDPOINT=http://phoenix:6006/v1/traces

--- a/compose.yaml
+++ b/compose.yaml
@@ -66,6 +66,7 @@ x-supervisor: &supervisor
     - .secrets/supervisor.env
   volumes:
     - ./agents:/home/beeai/agents:ro,z
+    - ./common:/home/beeai/common:ro,z
     - ./supervisor:/home/beeai/supervisor:ro,z
     - .secrets/ccache:/home/beeai/ccache:ro,z,U
   restart: unless-stopped


### PR DESCRIPTION
Reusing Containerfile.c10s for the supervisor process was a
bit messy - there are a lot of things that the supervisor didn't
need in the image (like the rpmbuild environment), and we were
also adding random divergences between Containerfile.c9s and
Containerfile.c10s to support the supervisor.
