### PR TITLE
Feat: Add status transition timestamp to Erratum

### DIFF
--- a/supervisor/errata_utils.py
+++ b/supervisor/errata_utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from enum import StrEnum
 from functools import cache
 import logging
@@ -77,6 +78,10 @@ def get_erratum(erratum_id: str | int):
         for jira_issue_data in jira_issues
     )
 
+    last_status_transition_timestamp = datetime.strptime(
+        details["status_updated_at"], "%Y-%m-%dT%H:%M:%SZ"
+    ).replace(tzinfo=timezone.utc)
+
     return Erratum(
         id=details["id"],
         full_advisory=details["fulladvisory"],
@@ -84,6 +89,7 @@ def get_erratum(erratum_id: str | int):
         synopsis=details["synopsis"],
         status=ErrataStatus(details["status"]),
         all_issues_release_pending=all_issues_release_pending,
+        last_status_transition_timestamp=last_status_transition_timestamp,
     )
 
 

--- a/supervisor/supervisor_types.py
+++ b/supervisor/supervisor_types.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from enum import StrEnum
 from typing import Optional
-from typing_extensions import Literal
+
 from pydantic import BaseModel, Field
+from typing_extensions import Literal
 
 
 class IssueStatus(StrEnum):
@@ -47,6 +48,7 @@ class Erratum(BaseModel):
     synopsis: str
     status: ErrataStatus
     all_issues_release_pending: bool
+    last_status_transition_timestamp: datetime
 
 
 class MergeRequestState(StrEnum):


### PR DESCRIPTION
Add the latest status transition timestamp to Erratum so the agent can use this infomation to decide whether the erratum needs human attention due to long pending time.
