### PR TITLE
Support Jira user group verification for Server and Cloud

### DIFF
--- a/mcp_server/jira_tools.py
+++ b/mcp_server/jira_tools.py
@@ -369,11 +369,11 @@ async def verify_issue_author(
             raise ToolError(f"Failed to get Jira data: {e}") from e
 
         reporter = issue_data.get("fields", {}).get("reporter", {})
-        
+
         # Try both Jira Server (key) and Jira Cloud (accountId)
         author_key = reporter.get("key")
         author_account_id = reporter.get("accountId")
-        
+
         if not author_key and not author_account_id:
             return False
 
@@ -396,6 +396,6 @@ async def verify_issue_author(
             raise ToolError(f"Failed to get user groups: {e}") from e
 
         return any(
-            group.get("name") == RH_EMPLOYEE_GROUP 
+            group.get("name") == RH_EMPLOYEE_GROUP
             for group in user_data.get("groups", {}).get("items", [])
         )

--- a/mcp_server/tests/unit/test_jira_tools.py
+++ b/mcp_server/tests/unit/test_jira_tools.py
@@ -244,7 +244,7 @@ async def test_verify_issue_author(user_groups, expected_result, use_account_id)
     reporter = {}
     expected_param_key = None
     expected_param_value = None
-    
+
     if use_account_id:
         reporter["accountId"] = "test-account-id-123"
         expected_param_key = "accountId"


### PR DESCRIPTION
Previous API endpoint didn't exist on current Jira Server instance. This commit switches the code to try call both Cloud and Server syntaxes.

Assisted-by: Cursor(Claude)

I've hit this issue when trying to parse RHEL-118155 created by me. Turns out, Jira Cloud API calls are different to the Jira Server calls. As we are currently on Jira Server instance, and we are going to migrate to Cloud at some point, this commit tries to get the RH_EMPLOYEE_GROUP in both cases.

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
