### PR TITLE
Remove the no-longer-needed GITLAB_USER env var

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -7,7 +7,6 @@
   `gitlab-env`:
   ```
   GITLAB_TOKEN
-  GITLAB_USER
   ```
 
   `jira-env`:

--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -30,12 +30,6 @@ spec:
         env:
         - name: CONTAINER_VERSION
           value: "c10s"
-        - name: GITLAB_USER
-          # Not envFrom to avoid importing GITLAB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: gitlab-env
-              key: GITLAB_USER
         - name: REQUESTS_CA_BUNDLE
           value: /etc/pki/tls/certs/ca-bundle.crt
         envFrom:

--- a/openshift/deployment-backport-agent-c9s.yml
+++ b/openshift/deployment-backport-agent-c9s.yml
@@ -30,12 +30,6 @@ spec:
         env:
         - name: CONTAINER_VERSION
           value: "c9s"
-        - name: GITLAB_USER
-          # Not envFrom to avoid importing GITLAB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: gitlab-env
-              key: GITLAB_USER
         - name: REQUESTS_CA_BUNDLE
           value: /etc/pki/tls/certs/ca-bundle.crt
         envFrom:

--- a/openshift/deployment-rebase-agent-c10s.yml
+++ b/openshift/deployment-rebase-agent-c10s.yml
@@ -30,12 +30,6 @@ spec:
         env:
         - name: CONTAINER_VERSION
           value: "c10s"
-        - name: GITLAB_USER
-          # Not envFrom to avoid importing GITLAB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: gitlab-env
-              key: GITLAB_USER
         - name: REQUESTS_CA_BUNDLE
           value: /etc/pki/tls/certs/ca-bundle.crt
         envFrom:

--- a/openshift/deployment-rebase-agent-c9s.yml
+++ b/openshift/deployment-rebase-agent-c9s.yml
@@ -30,12 +30,6 @@ spec:
         env:
         - name: CONTAINER_VERSION
           value: "c9s"
-        - name: GITLAB_USER
-          # Not envFrom to avoid importing GITLAB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: gitlab-env
-              key: GITLAB_USER
         - name: REQUESTS_CA_BUNDLE
           value: /etc/pki/tls/certs/ca-bundle.crt
         envFrom:

--- a/openshift/deployment-triage-agent.yml
+++ b/openshift/deployment-triage-agent.yml
@@ -28,12 +28,6 @@ spec:
         command:
         - /usr/bin/python
         env:
-        - name: GITLAB_USER
-          # Not envFrom to avoid importing GITLAB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: gitlab-env
-              key: GITLAB_USER
         - name: REQUESTS_CA_BUNDLE
           value: /etc/pki/tls/certs/ca-bundle.crt
         envFrom:


### PR DESCRIPTION
We're no longer referencing this anywhere in the code for the agents.
