### PR TITLE
drop `-3`, fix apply_patch_finish when `--skip` yields more conflicts

### DIFF
--- a/agents/backport_agent.py
+++ b/agents/backport_agent.py
@@ -86,7 +86,8 @@ def get_instructions() -> str:
          Use `rpmlint <PACKAGE>.spec` to validate your changes and fix any new issues.
 
       6. Run `centpkg --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep` to see if the new patch
-         applies cleanly.
+         applies cleanly. When `prep` command finishes with "exit 0", it's a success. Ignore errors from
+         libtoolize that warn about newer files: "use '--force' to overwrite".
 
       7. Generate a SRPM using `centpkg --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
 
@@ -97,8 +98,10 @@ def get_instructions() -> str:
       - Never change anything in the spec file changelog.
       - Preserve existing formatting and style conventions in spec files and patch headers.
       - Prefer native tools, if available, the `run_shell_command` tool should be the last resort.
-      - When resolving conflicts, ignore all changes in .github/ workflows and .gitignore.
+      - Ignore all changes in .github/ workflows, .gitignore, news, changes that cause conflicts.
       - Never apply the patches yourself, always use the `git_patch_apply` tool.
+      - Never run `git am --skip`, always use the `git_patch_apply` tool.
+      - Never abort the existing git am session.
     """
 
 

--- a/agents/backport_agent.py
+++ b/agents/backport_agent.py
@@ -493,6 +493,9 @@ async def main() -> None:
 
 if __name__ == "__main__":
     try:
+        # uncomment for debugging
+        # from utils import set_litellm_debug
+        # set_litellm_debug()
         asyncio.run(main())
     except FrameworkError as e:
         traceback.print_exc()

--- a/agents/rebase_agent.py
+++ b/agents/rebase_agent.py
@@ -471,6 +471,9 @@ async def main() -> None:
 
 if __name__ == "__main__":
     try:
+        # uncomment for debugging
+        # from utils import set_litellm_debug
+        # set_litellm_debug()
         asyncio.run(main())
     except FrameworkError as e:
         traceback.print_exc()

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -602,6 +602,9 @@ async def main() -> None:
 
 if __name__ == "__main__":
     try:
+        # uncomment for debugging
+        # from utils import set_litellm_debug
+        # set_litellm_debug()
         asyncio.run(main())
     except FrameworkError as e:
         traceback.print_exc()

--- a/agents/utils.py
+++ b/agents/utils.py
@@ -130,3 +130,13 @@ async def mcp_tools(
         if filter:
             tools = [t for t in tools if filter(t.name)]
         yield tools
+
+
+def set_litellm_debug() -> None:
+    """Set litellm to print collosal amount of debug information. This CAN LEAK TOKENS to the logs."""
+    # the following two modules call `litellm_debug(False)` on import
+    # import them explicitly now to ensure our call to `litellm_debug()` is not negated later
+    import beeai_framework.adapters.litellm.chat
+    import beeai_framework.adapters.litellm.embedding
+    from beeai_framework.adapters.litellm.utils import litellm_debug
+    litellm_debug(True)


### PR DESCRIPTION
I suggest going commit by commit in review.

This mainly fixes the apply_patch_finish logic and drops `-3` because it confuses agents with errors saying there are no parent commits