### PR TITLE
Remove error labels when agents succeed

### DIFF
--- a/agents/backport_agent.py
+++ b/agents/backport_agent.py
@@ -473,7 +473,11 @@ async def main() -> None:
                     await tasks.set_jira_labels(
                         jira_issue=backport_data.jira_issue,
                         labels_to_add=[JiraLabels.BACKPORTED.value],
-                        labels_to_remove=[JiraLabels.BACKPORT_IN_PROGRESS.value],
+                        labels_to_remove=[
+                            JiraLabels.BACKPORT_IN_PROGRESS.value,
+                            JiraLabels.BACKPORT_ERRORED.value,
+                            JiraLabels.BACKPORT_FAILED.value,
+                        ],
                         dry_run=dry_run
                     )
                     await redis.lpush(RedisQueues.COMPLETED_BACKPORT_LIST.value, state.backport_result.model_dump_json())

--- a/agents/rebase_agent.py
+++ b/agents/rebase_agent.py
@@ -454,7 +454,11 @@ async def main() -> None:
                     await tasks.set_jira_labels(
                         jira_issue=rebase_data.jira_issue,
                         labels_to_add=[JiraLabels.REBASED.value],
-                        labels_to_remove=[JiraLabels.REBASE_IN_PROGRESS.value],
+                        labels_to_remove=[
+                            JiraLabels.REBASE_IN_PROGRESS.value,
+                            JiraLabels.REBASE_ERRORED.value,
+                            JiraLabels.REBASE_FAILED.value,
+                        ],
                         dry_run=dry_run
                     )
                     await fix_await(redis.lpush(RedisQueues.COMPLETED_REBASE_LIST.value, state.rebase_result.model_dump_json()))


### PR DESCRIPTION
Ensure rebase and backport agents remove error and failure labels after successfully completing their tasks.
Resolves the confusing mix of labels (e.g. "jotnar_backported" and "jotnar_backport_failed") on issues where the agent succeeded after a prior failure.

Resolves: https://github.com/packit/jotnar/issues/157