### PR TITLE
Feat: Add utility function for getting previous errata

### DIFF
--- a/supervisor/supervisor_types.py
+++ b/supervisor/supervisor_types.py
@@ -55,6 +55,8 @@ class Erratum(BaseModel):
     synopsis: str
     status: ErrataStatus
     jira_issues: list[str]
+    release_id: int
+    publish_date: datetime | None
     last_status_transition_timestamp: datetime
 
 


### PR DESCRIPTION
This utility function finds the previous errata with given errata ID (current)
and package name. The output will be a errata with the closest RHEL release
version. Here we pick REL_PREP over SHIPPED_ALIVE.