### PR TITLE
Allow build-and-push workflow to be triggered manually

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow-dispatch:
 jobs:
   build-and-push-goose-container:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is useful for rebuilding the images if there was some problem with the repository setup, or if some dependency changed.

[ No real way to test this in advance, but hopefully simple enough that I got it right! ]
