### PR TITLE
archive TLD: set root archive dir as working dir

### DIFF
--- a/Containerfile.c9s-tests
+++ b/Containerfile.c9s-tests
@@ -24,7 +24,7 @@ RUN dnf -y install --allowerasing \
 RUN python3.11 -m venv --system-site-packages /opt/beeai-venv \
     && /opt/beeai-venv/bin/pip install --upgrade pip \
     && /opt/beeai-venv/bin/pip install --no-cache-dir \
-       beeai-framework[mcp,duckduckgo]==0.1.43 \
+       beeai-framework[vertexai,mcp,duckduckgo]==0.1.53 \
        openinference-instrumentation-beeai \
        arize-phoenix-otel \
        redis \

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -29,6 +29,8 @@ RUN git config --global user.email "jotnar-tests@example.com" \
 ENV PYTHONPATH=/src:$PYTHONPATH
 
 # Install BeeAI Framework and FastMCP
-RUN pip3 install --no-cache-dir beeai-framework fastmcp redis backoff
+RUN pip3 install --no-cache-dir \
+      beeai-framework[vertexai,mcp,duckduckgo]==0.1.53 \
+      fastmcp redis backoff
 
 WORKDIR /src

--- a/agents/backport_agent.py
+++ b/agents/backport_agent.py
@@ -161,8 +161,18 @@ def create_backport_agent(_: list[Tool], local_tool_options: dict[str, Any]) -> 
 
 
 def get_unpacked_sources(local_clone: Path, package: str) -> Path:
+    """
+    Get a path to the root of extracted archive directory tree (referenced as TLD
+    in RPM documentation) for a given package.
+
+    That's the place where we'll initiate the backporting process.
+    """
     with Specfile(local_clone / f"{package}.spec") as spec:
         buildsubdir = spec.expand("%{buildsubdir}")
+    if "/" in buildsubdir:
+        # Sooner or later we'll run into a package where this will break. Sorry.
+        # More details: https://github.com/packit/jotnar/issues/217
+        buildsubdir = buildsubdir.split("/")[0]
     sources_dir = local_clone / buildsubdir
 
     if not sources_dir.exists():

--- a/agents/tests/unit/conftest.py
+++ b/agents/tests/unit/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+from pathlib import Path
+from textwrap import dedent
+
+
+@pytest.fixture
+def minimal_spec(tmp_path) -> Path:
+    spec = tmp_path / "minimal.spec"
+    spec.write_text(
+        dedent(
+            """
+            Name:           test
+            Version:        0.1
+            Release:        2%{?dist}
+            Summary:        Test package
+
+            License:        MIT
+
+            %description
+            Test package
+
+            %changelog
+            * Thu Jun 07 2018 Nikola Forró <nforro@redhat.com> - 0.1-1
+            - first version
+            """
+        )
+    )
+    return spec

--- a/agents/tests/unit/test_backporting.py
+++ b/agents/tests/unit/test_backporting.py
@@ -1,0 +1,20 @@
+import pytest
+from flexmock import flexmock
+from specfile import Specfile
+
+from agents.backport_agent import get_unpacked_sources
+
+@pytest.mark.parametrize(
+    "buildsubdir",
+    [
+        "minimal",
+        "minimal/baz",
+    ],
+)
+def test_get_unpacked_sources(tmp_path, buildsubdir, minimal_spec):
+    assert minimal_spec.exists()
+    flexmock(Specfile).should_receive("expand").and_return(buildsubdir)
+    (tmp_path / buildsubdir).mkdir(parents=True)
+    result = get_unpacked_sources(tmp_path, "minimal")
+
+    assert result == tmp_path / "minimal"

--- a/agents/tests/unit/test_tools.py
+++ b/agents/tests/unit/test_tools.py
@@ -78,31 +78,6 @@ async def test_run_shell_command(command, exit_code, stdout, stderr):
     assert result.stderr == stderr
 
 
-@pytest.fixture
-def minimal_spec(tmp_path):
-    spec = tmp_path / "minimal.spec"
-    spec.write_text(
-        dedent(
-            """
-            Name:           test
-            Version:        0.1
-            Release:        2%{?dist}
-            Summary:        Test package
-
-            License:        MIT
-
-            %description
-            Test package
-
-            %changelog
-            * Thu Jun 07 2018 Nikola Forró <nforro@redhat.com> - 0.1-1
-            - first version
-            """
-        )
-    )
-    return spec
-
-
 @pytest.mark.asyncio
 async def test_add_changelog_entry(minimal_spec):
     content = ["- some change", "  second line"]


### PR DESCRIPTION
A typical upstream tarball has this kind of structure:
foobar-1.0.0/README
foobar-1.0.0/code.c

So the backporting agent would use foobar-1.0.0/ as a working directory
and the patches would be applied via `a/code.c` with `-p1`.

Some projects don't do this and instead add more layers, which then
require different levels of `-pN`. Example:
foobar-1.0.0/README
foobar-1.0.0/library/code.c

(i.e. here TLD would be `foobar-1.0.0/library/`)

The main problem here is that some packages utilize different techniques
when a patch does not apply with `-p1`, a common technique is to `pushd`
inside, apply patches, then `popd`.

Well, that's a big problem for us because there is no way to figure out
how we can mimic that in the backporting agent.

This simple patch goes the naive way of setting TLD to the top level of
the directory structure which will require higher `-pN` with the hope
the downstream patch will be applied the same way. Using the example
above, TLD will still be `foobar-1.0.0`, in both cases.

Fixes https://github.com/packit/jotnar/issues/217

Thanks @nforro for suggesting this solution.