### PR TITLE
Add rebuild agent and triage rebuild resolution

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -276,6 +276,24 @@
         "line_number": 83
       }
     ],
+    "openshift/deployment-rebuild-agent-c10s.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "openshift/deployment-rebuild-agent-c10s.yml",
+        "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
+        "is_verified": false,
+        "line_number": 79
+      }
+    ],
+    "openshift/deployment-rebuild-agent-c9s.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "openshift/deployment-rebuild-agent-c9s.yml",
+        "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
+        "is_verified": false,
+        "line_number": 79
+      }
+    ],
     "openshift/deployment-rebase-agent-c10s.yml": [
       {
         "type": "Secret Keyword",

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ IMAGE_NAME ?= beeai-agent
 COMPOSE_FILE ?= compose.yaml
 DRY_RUN ?= false
 MOCK_JIRA ?= false
+JIRA_DRY_RUN ?= false
 AUTO_CHAIN ?= true
 FORCE_CVE_TRIAGE ?= false
 LOKI_URL ?= http://loki.tft.osci.redhat.com/
@@ -162,11 +163,11 @@ build-jira-issue-fetcher:
 
 .PHONY: start
 start:
-	DRY_RUN=$(DRY_RUN) MOCK_JIRA=$(MOCK_JIRA) AUTO_CHAIN=$(AUTO_CHAIN) $(COMPOSE_AGENTS) up
+	DRY_RUN=$(DRY_RUN) MOCK_JIRA=$(MOCK_JIRA) JIRA_DRY_RUN=$(JIRA_DRY_RUN) AUTO_CHAIN=$(AUTO_CHAIN) $(COMPOSE_AGENTS) up
 
 .PHONY: start-detached
 start-detached:
-	DRY_RUN=$(DRY_RUN) MOCK_JIRA=$(MOCK_JIRA) AUTO_CHAIN=$(AUTO_CHAIN) $(COMPOSE_AGENTS) up -d
+	DRY_RUN=$(DRY_RUN) MOCK_JIRA=$(MOCK_JIRA) JIRA_DRY_RUN=$(JIRA_DRY_RUN) AUTO_CHAIN=$(AUTO_CHAIN) $(COMPOSE_AGENTS) up -d
 
 .PHONY: stop
 stop:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ COMPOSE_FILE ?= compose.yaml
 DRY_RUN ?= false
 MOCK_JIRA ?= false
 AUTO_CHAIN ?= true
+FORCE_CVE_TRIAGE ?= false
 LOKI_URL ?= http://loki.tft.osci.redhat.com/
 LOKI_SINCE ?= 24h
 LOKI_LIMIT ?= 3000
@@ -26,6 +27,7 @@ run-triage-agent-standalone:
 		-e JIRA_ISSUE=$(JIRA_ISSUE) \
 		-e DRY_RUN=$(DRY_RUN) \
 		-e MOCK_JIRA=$(MOCK_JIRA) \
+		-e FORCE_CVE_TRIAGE=$(FORCE_CVE_TRIAGE) \
 		triage-agent
 
 .PHONY: run-triage-agent-e2e-tests
@@ -225,11 +227,11 @@ logs-loki:
 .PHONY: trigger-pipeline
 trigger-pipeline:
 	@if [ -z "$(JIRA_ISSUE)" ]; then \
-		echo "Usage: make trigger-pipeline JIRA_ISSUE=RHEL-12345"; \
+		echo "Usage: make trigger-pipeline JIRA_ISSUE=RHEL-12345 [FORCE_CVE_TRIAGE=true]"; \
 		exit 1; \
 	fi
-	@echo "Triggering pipeline for issue: $(JIRA_ISSUE)"
-	$(COMPOSE_AGENTS) exec valkey redis-cli LPUSH triage_queue '{"metadata": {"issue": "$(JIRA_ISSUE)"}}'
+	@echo "Triggering pipeline for issue: $(JIRA_ISSUE) (force_cve_triage=$(FORCE_CVE_TRIAGE))"
+	$(COMPOSE_AGENTS) exec valkey redis-cli LPUSH triage_queue '{"metadata": {"issue": "$(JIRA_ISSUE)", "force_cve_triage": $(FORCE_CVE_TRIAGE)}}'
 
 
 # Testing and Release Supervisor

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,33 @@ run-backport-agent-c10s-standalone:
 run-backport-agent-standalone: run-backport-agent-c10s-standalone
 
 
+.PHONY: run-rebuild-agent-c9s-standalone
+run-rebuild-agent-c9s-standalone:
+	$(COMPOSE_AGENTS) run --rm \
+		-e PACKAGE=$(PACKAGE) \
+		-e JIRA_ISSUE=$(JIRA_ISSUE) \
+		-e BRANCH=$(BRANCH) \
+		-e DRY_RUN=$(DRY_RUN) \
+		-e MOCK_JIRA=$(MOCK_JIRA) \
+		-e DEPENDENCY_ISSUE=$(DEPENDENCY_ISSUE) \
+		-e DEPENDENCY_COMPONENT=$(DEPENDENCY_COMPONENT) \
+		rebuild-agent-c9s
+
+.PHONY: run-rebuild-agent-c10s-standalone
+run-rebuild-agent-c10s-standalone:
+	$(COMPOSE_AGENTS) run --rm \
+		-e PACKAGE=$(PACKAGE) \
+		-e JIRA_ISSUE=$(JIRA_ISSUE) \
+		-e BRANCH=$(BRANCH) \
+		-e DRY_RUN=$(DRY_RUN) \
+		-e MOCK_JIRA=$(MOCK_JIRA) \
+		-e DEPENDENCY_ISSUE=$(DEPENDENCY_ISSUE) \
+		-e DEPENDENCY_COMPONENT=$(DEPENDENCY_COMPONENT) \
+		rebuild-agent-c10s
+
+.PHONY: run-rebuild-agent-standalone
+run-rebuild-agent-standalone: run-rebuild-agent-c10s-standalone
+
 .PHONY: run-mr-agent-c9s-standalone
 run-mr-agent-c9s-standalone:
 	$(COMPOSE_AGENTS)  run --rm \
@@ -160,6 +187,10 @@ logs-backport:
 logs-rebase:
 	$(COMPOSE_AGENTS) logs -f rebase-agent
 
+.PHONY: logs-rebuild
+logs-rebuild:
+	$(COMPOSE_AGENTS) logs -f rebuild-agent
+
 .PHONY: logs-jira-issue-fetcher
 logs-jira-issue-fetcher:
 	$(COMPOSE) -f $(COMPOSE_FILE) --profile manual logs -f jira-issue-fetcher
@@ -179,6 +210,8 @@ logs-loki-help:
 	@echo "  - backport-agent-c10s"
 	@echo "  - rebase-agent-c9s"
 	@echo "  - rebase-agent-c10s"
+	@echo "  - rebuild-agent-c9s"
+	@echo "  - rebuild-agent-c10s"
 	@echo "  - supervisor-collector"
 	@echo "  - supervisor-processor"
 	@echo "  - mcp-gateway"

--- a/README-agents.md
+++ b/README-agents.md
@@ -106,6 +106,7 @@ make trigger-pipeline JIRA_ISSUE=RHEL-12345
 make JIRA_ISSUE=RHEL-12345 run-triage-agent-standalone
 make PACKAGE=httpd VERSION=2.4.62 JIRA_ISSUE=RHEL-12345 BRANCH=c10s run-rebase-agent-standalone
 make PACKAGE=httpd UPSTREAM_PATCHES=https://github.com/... JIRA_ISSUE=RHEL-12345 BRANCH=c10s run-backport-agent-standalone
+make PACKAGE=httpd JIRA_ISSUE=RHEL-12345 BRANCH=c10s run-rebuild-agent-standalone
 
 # Or with dry-run
 DRY_RUN=true make JIRA_ISSUE=RHEL-12345 run-triage-agent-standalone

--- a/README-agents.md
+++ b/README-agents.md
@@ -102,6 +102,7 @@ make trigger-pipeline JIRA_ISSUE=RHEL-12345 FORCE_CVE_TRIAGE=true
 | `DRY_RUN` | `false` | Skip Jira writes, git pushes, and MR creation |
 | `AUTO_CHAIN` | `true` | Route triaged issues to downstream backport/rebase queues. Set to `false` to disable routing. |
 | `MOCK_JIRA` | `false` | Use mock Jira API instead of real Jira |
+| `JIRA_DRY_RUN` | `false` | Skip all Jira write operations (status, comments, labels, fields) while keeping reads working |
 | `FORCE_CVE_TRIAGE` | `false` | Force triage of CVE issues that would normally be skipped (e.g. Y-stream CVEs) |
 
 ### Individual Agents Runs

--- a/README-agents.md
+++ b/README-agents.md
@@ -91,6 +91,9 @@ make start DRY_RUN=true AUTO_CHAIN=false   # Combine both
 
 # Process a JIRA issue
 make trigger-pipeline JIRA_ISSUE=RHEL-12345
+
+# Force triage of Y-stream CVEs (normally skipped)
+make trigger-pipeline JIRA_ISSUE=RHEL-12345 FORCE_CVE_TRIAGE=true
 ```
 
 **Environment variables:**
@@ -99,6 +102,7 @@ make trigger-pipeline JIRA_ISSUE=RHEL-12345
 | `DRY_RUN` | `false` | Skip Jira writes, git pushes, and MR creation |
 | `AUTO_CHAIN` | `true` | Route triaged issues to downstream backport/rebase queues. Set to `false` to disable routing. |
 | `MOCK_JIRA` | `false` | Use mock Jira API instead of real Jira |
+| `FORCE_CVE_TRIAGE` | `false` | Force triage of CVE issues that would normally be skipped (e.g. Y-stream CVEs) |
 
 ### Individual Agents Runs
 ```bash
@@ -110,6 +114,9 @@ make PACKAGE=httpd JIRA_ISSUE=RHEL-12345 BRANCH=c10s run-rebuild-agent-standalon
 
 # Or with dry-run
 DRY_RUN=true make JIRA_ISSUE=RHEL-12345 run-triage-agent-standalone
+
+# Force triage of a Y-stream CVE
+make JIRA_ISSUE=RHEL-12345 FORCE_CVE_TRIAGE=true run-triage-agent-standalone
 ```
 
 Use commas to delimit multiple patch/commit URLs in `UPSTREAM_PATCHES`.

--- a/agents/rebuild_agent.py
+++ b/agents/rebuild_agent.py
@@ -1,0 +1,352 @@
+import asyncio
+import logging
+import os
+import sys
+import traceback
+
+from pydantic import Field
+
+from beeai_framework.errors import FrameworkError
+from beeai_framework.workflows import Workflow
+
+import tasks
+from agents.log_agent import create_log_agent, get_prompt as get_log_prompt
+from agents.package_update_steps import PackageUpdateState
+from common.constants import JiraLabels, RedisQueues
+from common.models import (
+    LogInputSchema,
+    LogOutputSchema,
+    Task,
+    RebuildData,
+    RebuildOutputSchema,
+    ErrorData,
+)
+from common.utils import redis_client, fix_await
+from constants import I_AM_JOTNAR, CAREFULLY_REVIEW_CHANGES
+from observability import setup_observability
+from utils import get_agent_execution_config, mcp_tools, render_prompt, run_subprocess
+
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+
+    setup_observability(os.environ["COLLECTOR_ENDPOINT"])
+
+    dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
+
+    local_tool_options = {"working_directory": None}
+
+    class State(PackageUpdateState):
+        rebuild_success: bool = Field(default=False)
+        rebuild_error: str | None = Field(default=None)
+        dependency_issue: str | None = Field(default=None)
+        dependency_component: str | None = Field(default=None)
+
+    async def run_workflow(package, dist_git_branch, jira_issue, dependency_issue=None, dependency_component=None):
+        local_tool_options["working_directory"] = None
+
+        async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
+            log_agent = create_log_agent(gateway_tools, local_tool_options)
+
+            workflow = Workflow(State, name="RebuildWorkflow")
+
+            async def change_jira_status(state):
+                if not dry_run:
+                    try:
+                        await tasks.change_jira_status(
+                            jira_issue=state.jira_issue,
+                            status="In Progress",
+                            available_tools=gateway_tools,
+                        )
+                    except Exception as status_error:
+                        logger.warning(f"Failed to change status for {state.jira_issue}: {status_error}")
+                else:
+                    logger.info(f"Dry run: would change status of {state.jira_issue} to In Progress")
+                return "fork_and_prepare_dist_git"
+
+            async def fork_and_prepare_dist_git(state):
+                state.local_clone, state.update_branch, state.fork_url, _ = await tasks.fork_and_prepare_dist_git(
+                    jira_issue=state.jira_issue,
+                    package=state.package,
+                    dist_git_branch=state.dist_git_branch,
+                    available_tools=gateway_tools,
+                )
+                local_tool_options["working_directory"] = state.local_clone
+                return "update_release"
+
+            async def update_release(state):
+                try:
+                    await tasks.update_release(
+                        local_clone=state.local_clone,
+                        package=state.package,
+                        dist_git_branch=state.dist_git_branch,
+                        rebase=False,
+                    )
+                except Exception as e:
+                    logger.warning(f"Error updating release: {e}")
+                    state.rebuild_success = False
+                    state.rebuild_error = f"Could not update release: {e}"
+                    return "comment_in_jira"
+                return "run_log_agent"
+
+            async def run_log_agent(state):
+                if state.dependency_component:
+                    summary = (
+                        f"Rebuild of {state.package} for {state.jira_issue} against updated {state.dependency_component}. "
+                        f"The changelog entry and commit title MUST mention {state.dependency_component}."
+                    )
+                elif state.dependency_issue:
+                    summary = (
+                        f"Rebuild of {state.package} for {state.jira_issue} against updated dependency "
+                        f"({state.dependency_issue})."
+                    )
+                else:
+                    summary = f"Rebuild of {state.package} against updated dependencies for {state.jira_issue}."
+
+                response = await log_agent.run(
+                    render_prompt(
+                        template=get_log_prompt(),
+                        input=LogInputSchema(
+                            jira_issue=state.jira_issue,
+                            changes_summary=summary,
+                        ),
+                    ),
+                    expected_output=LogOutputSchema,
+                    **get_agent_execution_config(),
+                )
+                state.log_result = LogOutputSchema.model_validate_json(response.last_message.text)
+                return "stage_changes"
+
+            async def stage_changes(state):
+                try:
+                    await tasks.stage_changes(
+                        local_clone=state.local_clone,
+                        files_to_commit=[f"{state.package}.spec"],
+                    )
+                except Exception as e:
+                    logger.warning(f"Error staging changes: {e}")
+                    state.rebuild_success = False
+                    state.rebuild_error = f"Could not stage changes: {e}"
+                    return "comment_in_jira"
+                return "commit_push_and_open_mr"
+
+            async def commit_push_and_open_mr(state):
+                try:
+                    # Check if anything is actually staged
+                    exit_code, _, _ = await run_subprocess(
+                        ["git", "diff", "--cached", "--quiet"],
+                        cwd=state.local_clone,
+                    )
+                    is_empty_commit = exit_code == 0  # exit code 0 means no staged changes, so commit would be empty
+
+                    dep_lines = []
+                    if state.dependency_component:
+                        dep_lines.append(f"Dependency: {state.dependency_component}")
+                    if state.dependency_issue:
+                        dep_lines.append(f"Dependency issue: {state.dependency_issue}")
+                    dep_text = "\n".join(dep_lines) + "\n" if dep_lines else ""
+                    state.merge_request_url, state.merge_request_newly_created = await tasks.commit_push_and_open_mr(
+                        local_clone=state.local_clone,
+                        commit_message=(
+                            f"{state.log_result.title}\n\n"
+                            f"{state.log_result.description}\n\n"
+                            f"{dep_text}"
+                            f"Resolves: {state.jira_issue}\n\n"
+                            f"This commit was created {I_AM_JOTNAR}\n\n"
+                            "Assisted-by: Jotnar\n"
+                        ),
+                        fork_url=state.fork_url,
+                        dist_git_branch=state.dist_git_branch,
+                        update_branch=state.update_branch,
+                        mr_title=state.log_result.title,
+                        mr_description=(
+                            f"This merge request was created {I_AM_JOTNAR}\n"
+                            f"{CAREFULLY_REVIEW_CHANGES}\n\n"
+                            f"{state.log_result.description}\n\n"
+                            f"{dep_text}"
+                            f"Resolves: {state.jira_issue}\n"
+                        ),
+                        available_tools=gateway_tools,
+                        commit_only=dry_run,
+                        allow_empty=is_empty_commit,
+                    )
+                    state.rebuild_success = True
+                except Exception as e:
+                    logger.warning(f"Error committing and opening MR: {e}")
+                    state.merge_request_url = None
+                    state.rebuild_success = False
+                    state.rebuild_error = f"Could not commit and open MR: {e}"
+                return "comment_in_jira"
+
+            async def comment_in_jira(state):
+                if dry_run:
+                    return Workflow.END
+                if state.rebuild_success:
+                    comment_text = (
+                        state.merge_request_url
+                        if state.merge_request_url
+                        else "Rebuild completed successfully"
+                    )
+                else:
+                    comment_text = f"Agent failed to perform a rebuild: {state.rebuild_error}"
+                logger.info(f"Result to be put in Jira comment: {comment_text}")
+                await tasks.comment_in_jira(
+                    jira_issue=state.jira_issue,
+                    agent_type="Rebuild",
+                    comment_text=comment_text,
+                    available_tools=gateway_tools,
+                )
+                return Workflow.END
+
+            workflow.add_step("change_jira_status", change_jira_status)
+            workflow.add_step("fork_and_prepare_dist_git", fork_and_prepare_dist_git)
+            workflow.add_step("update_release", update_release)
+            workflow.add_step("run_log_agent", run_log_agent)
+            workflow.add_step("stage_changes", stage_changes)
+            workflow.add_step("commit_push_and_open_mr", commit_push_and_open_mr)
+            workflow.add_step("comment_in_jira", comment_in_jira)
+
+            response = await workflow.run(
+                State(
+                    package=package,
+                    dist_git_branch=dist_git_branch,
+                    jira_issue=jira_issue,
+                    dependency_issue=dependency_issue,
+                    dependency_component=dependency_component,
+                ),
+            )
+            return response.state
+
+    # Direct mode: run with environment variables
+    if (
+        (package := os.getenv("PACKAGE", None))
+        and (branch := os.getenv("BRANCH", None))
+        and (jira_issue := os.getenv("JIRA_ISSUE", None))
+    ):
+        dependency_issue = os.getenv("DEPENDENCY_ISSUE", None)
+        dependency_component = os.getenv("DEPENDENCY_COMPONENT", None)
+        logger.info("Running in direct mode with environment variables")
+        state = await run_workflow(
+            package=package,
+            dist_git_branch=branch,
+            jira_issue=jira_issue,
+            dependency_issue=dependency_issue,
+            dependency_component=dependency_component,
+        )
+        logger.info(f"Direct run completed: success={state.rebuild_success}")
+        return
+
+    # Queue mode
+    logger.info("Starting rebuild agent in queue mode")
+    async with redis_client(os.environ["REDIS_URL"]) as redis:
+        max_retries = int(os.getenv("MAX_RETRIES", 3))
+        container_version = os.getenv("CONTAINER_VERSION", "c10s")
+        rebuild_queue = RedisQueues.REBUILD_QUEUE_C9S.value if container_version == "c9s" else RedisQueues.REBUILD_QUEUE_C10S.value
+        logger.info(f"Connected to Redis, max retries set to {max_retries}, listening to queue: {rebuild_queue}")
+
+        while True:
+            logger.info(f"Waiting for tasks from {rebuild_queue} (timeout: 30s)...")
+            element = await fix_await(redis.brpop([rebuild_queue], timeout=30))
+            if element is None:
+                logger.info("No tasks received, continuing to wait...")
+                continue
+
+            _, payload = element
+            logger.info("Received task from queue.")
+
+            try:
+                task = Task.model_validate_json(payload)
+                triage_state = task.metadata
+                rebuild_data = RebuildData.model_validate(triage_state["triage_result"]["data"])
+                dist_git_branch = triage_state["target_branch"]
+            except Exception as e:
+                logger.error(f"Failed to parse task payload, skipping: {e}")
+                await fix_await(redis.lpush(
+                    RedisQueues.ERROR_LIST.value,
+                    ErrorData(details=f"Malformed task payload: {e}", jira_issue="unknown").model_dump_json()
+                ))
+                continue
+
+            logger.info(
+                f"Processing rebuild for package: {rebuild_data.package}, "
+                f"JIRA: {rebuild_data.jira_issue}, branch: {dist_git_branch}, "
+                f"attempt: {task.attempts + 1}"
+            )
+
+            async def retry(task, error):
+                task.attempts += 1
+                if task.attempts < max_retries:
+                    logger.warning(
+                        f"Task failed (attempt {task.attempts}/{max_retries}), "
+                        f"re-queuing for retry: {rebuild_data.jira_issue}"
+                    )
+                    await fix_await(redis.lpush(rebuild_queue, task.model_dump_json()))
+                else:
+                    logger.error(
+                        f"Task failed after {max_retries} attempts, "
+                        f"moving to error list: {rebuild_data.jira_issue}"
+                    )
+                    await tasks.set_jira_labels(
+                        jira_issue=rebuild_data.jira_issue,
+                        labels_to_add=[JiraLabels.REBUILD_ERRORED.value],
+                        labels_to_remove=[JiraLabels.TRIAGED_REBUILD.value],
+                        dry_run=dry_run
+                    )
+                    await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
+
+            try:
+                state = await run_workflow(
+                    package=rebuild_data.package,
+                    dist_git_branch=dist_git_branch,
+                    jira_issue=rebuild_data.jira_issue,
+                    dependency_issue=rebuild_data.dependency_issue,
+                    dependency_component=rebuild_data.dependency_component,
+                )
+                logger.info(
+                    f"Rebuild processing completed for {rebuild_data.jira_issue}, "
+                    f"success: {state.rebuild_success}"
+                )
+
+            except Exception as e:
+                error = "".join(traceback.format_exception(e))
+                logger.error(f"Exception during rebuild processing for {rebuild_data.jira_issue}: {error}")
+                await retry(task, ErrorData(details=error, jira_issue=rebuild_data.jira_issue).model_dump_json())
+            else:
+                if state.rebuild_success:
+                    logger.info(f"Rebuild successful for {rebuild_data.jira_issue}, adding to completed list")
+                    await tasks.set_jira_labels(
+                        jira_issue=rebuild_data.jira_issue,
+                        labels_to_add=[JiraLabels.REBUILT.value],
+                        labels_to_remove=[
+                            JiraLabels.TRIAGED_REBUILD.value,
+                            JiraLabels.REBUILD_ERRORED.value,
+                            JiraLabels.REBUILD_FAILED.value,
+                        ],
+                        dry_run=dry_run
+                    )
+                    await fix_await(redis.lpush(
+                        RedisQueues.COMPLETED_REBUILD_LIST.value,
+                        RebuildOutputSchema(
+                            success=True,
+                            merge_request_url=state.merge_request_url,
+                        ).model_dump_json()
+                    ))
+                else:
+                    logger.warning(f"Rebuild failed for {rebuild_data.jira_issue}: {state.rebuild_error}")
+                    await tasks.set_jira_labels(
+                        jira_issue=rebuild_data.jira_issue,
+                        labels_to_add=[JiraLabels.REBUILD_FAILED.value],
+                        labels_to_remove=[JiraLabels.TRIAGED_REBUILD.value],
+                        dry_run=dry_run
+                    )
+                    await retry(task, ErrorData(details=state.rebuild_error, jira_issue=rebuild_data.jira_issue).model_dump_json())
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except FrameworkError as e:
+        traceback.print_exception(e)
+        sys.exit(1)

--- a/agents/tasks.py
+++ b/agents/tasks.py
@@ -148,6 +148,7 @@ async def commit_and_push(
     update_branch: str,
     available_tools: list[Tool],
     commit_only: bool = False,
+    allow_empty: bool = False,
 ) -> bool:
     """
     Commits the changes to the local clone.
@@ -156,16 +157,21 @@ async def commit_and_push(
         - str: The URL of the merge request if it was created successfully
         - bool: True if the merge request was created, False otherwise (i.e. MR was reused)
     """
-    # Check if any files are staged before committing, if none, bail
-    exit_code, _, _ = await run_subprocess(
-        ["git", "diff", "--cached", "--quiet"],
-        cwd=local_clone,
-    )
-    # 1 = staged, 0 = none staged
-    if exit_code == 0:
-        logger.info("No files staged for commit, halting.")
-        raise RuntimeError("No files staged for commit, halting.")
-    await check_subprocess(["git", "commit", "-m", commit_message], cwd=local_clone)
+    if not allow_empty:
+        # Check if any files are staged before committing, if none, bail
+        exit_code, _, _ = await run_subprocess(
+            ["git", "diff", "--cached", "--quiet"],
+            cwd=local_clone,
+        )
+        # 1 = staged, 0 = none staged
+        if exit_code == 0:
+            logger.info("No files staged for commit, halting.")
+            raise RuntimeError("No files staged for commit, halting.")
+    commit_cmd = ["git", "commit"]
+    if allow_empty:
+        commit_cmd.append("--allow-empty")
+    commit_cmd.extend(["-m", commit_message])
+    await check_subprocess(commit_cmd, cwd=local_clone)
     if commit_only:
         return False
     await run_tool(
@@ -189,6 +195,7 @@ async def commit_push_and_open_mr(
     mr_description: str,
     available_tools: list[Tool],
     commit_only: bool = False,
+    allow_empty: bool = False,
 ) -> Tuple[str | None, bool]:
     """
     Commits the changes to the local clone and opens a merge request.
@@ -204,6 +211,7 @@ async def commit_push_and_open_mr(
         update_branch,
         available_tools,
         commit_only,
+        allow_empty,
     ):
         return None, False
     return await run_tool(

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -535,7 +535,7 @@ def create_triage_agent(gateway_tools):
     )
 
 
-async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=False):
+async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=False, force_cve_triage=False):
     async with mcp_tools(os.getenv("MCP_GATEWAY_URL")) as gateway_tools:
         triage_agent = triage_agent_factory(gateway_tools)
 
@@ -553,8 +553,15 @@ async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=Fal
 
             logger.info(f"CVE eligibility result: {state.cve_eligibility_result}")
 
-            # If not eligible for triage, end workflow
+            # If not eligible for triage, end workflow (unless forced)
             if not state.cve_eligibility_result.is_eligible_for_triage:
+                if force_cve_triage and not state.cve_eligibility_result.error:
+                    logger.info(
+                        f"Issue {state.jira_issue} not eligible for triage "
+                        f"({state.cve_eligibility_result.reason}), but force_cve_triage is set — proceeding"
+                    )
+                    return "run_triage_analysis"
+
                 logger.info(f"Issue {state.jira_issue} not eligible for triage: {state.cve_eligibility_result.reason}")
                 if state.cve_eligibility_result.error:
                     state.triage_result = OutputSchema(
@@ -734,10 +741,11 @@ async def main() -> None:
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     auto_chain = os.getenv("AUTO_CHAIN", "true").lower() == "true"
+    force_cve_triage = os.getenv("FORCE_CVE_TRIAGE", "false").lower() == "true"
 
     if jira_issue := os.getenv("JIRA_ISSUE", None):
         logger.info("Running in direct mode with environment variable")
-        state = await run_workflow(jira_issue, dry_run, create_triage_agent, auto_chain=auto_chain)
+        state = await run_workflow(jira_issue, dry_run, create_triage_agent, auto_chain=auto_chain, force_cve_triage=force_cve_triage)
         logger.info(f"Direct run completed: {state.triage_result.model_dump_json(indent=4)}")
         if state.cve_eligibility_result:
             logger.info(f"CVE eligibility result: {state.cve_eligibility_result}")
@@ -794,7 +802,7 @@ async def main() -> None:
                 logger.info(f"Cleaned up existing labels for {input.issue}")
 
                 logger.info(f"Starting triage processing for {input.issue}")
-                state = await run_workflow(input.issue, dry_run, create_triage_agent, auto_chain=auto_chain)
+                state = await run_workflow(input.issue, dry_run, create_triage_agent, auto_chain=auto_chain, force_cve_triage=input.force_cve_triage)
                 output = state.triage_result
                 logger.info(
                     f"Triage processing completed for {input.issue}, " f"resolution: {output.resolution.value}"

--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -253,18 +253,49 @@ TRIAGE_PROMPT = """
          * If the content is not a proper patch or doesn't fix the issue, continue searching for other fixes
 
          2.4. Decide the Outcome
-         * If your investigation successfully identifies a specific fix that passes both validations in step 2.3, your decision is backport
-         * You must be able to justify why the patch is correct and how it addresses the issue
+         * **CRITICAL — Check if the fix belongs to the package or a dependency:**
+           Before deciding on backport, verify that the patch you found modifies the package's OWN source
+           code, not the source code of a dependency. Watch for these signs that the fix is in a DEPENDENCY:
+           - The patch comes from a different upstream repository than the package (e.g., a Go standard
+             library or Go module patch for a Go application, a C library patch for an application that
+             links to it, etc.)
+           - The package bundles or vendors dependencies. Check the spec file for indicators like:
+             * `Provides: bundled(golang(...))` or `Provides: bundled(...)` entries
+             * Vendor tarballs like `Source1: *-vendor.tar.gz` or `Source1: *-vendor-*.tar.*`
+           - The CVE describes a vulnerability in a library, runtime, or language (e.g., Go, Rust,
+             OpenSSL) that the package merely uses or vendors, not in the package's own code
+           **If the fix is in a dependency**, use the "rebuild" resolution instead. The package will
+           pick up the fix automatically when rebuilt against the updated dependency.
+         * If the patch IS for the package's own code and passes both validations in step 2.3, your
+           decision is backport. You must justify why the patch is correct and how it addresses the issue.
          * If your investigation confirms a valid bug/CVE but fails to locate a specific fix, your decision
            is clarification-needed
          * This is the correct choice when you are sure a problem exists but cannot find the solution yourself
 
          2.5 Set the Jira fields as per the instructions below.
 
-      3. **Open-Ended Analysis**
-         This is the catch-all for issues that don't fit rebase, backport, or clarification-needed. Use this when:
+      3. **Rebuild**
+         Use when the package needs rebuilding against an updated dependency with NO source code
+         changes. This covers explicit rebuild requests AND vendored/bundled dependency CVEs
+         (common in Go, Rust, Node.js packages — see step 2.4 which redirects here).
+
+         3.1. Confirm no source code changes are needed for the package itself.
+         3.2. Check dependency readiness — search thoroughly:
+         * Look for linked Jira issues in fields.issuelinks representing the dependency update
+         * If no linked issue found, use search_jira_issues to find it. Try JQL queries like:
+           - project = RHEL AND summary ~ "<CVE-ID>" AND component != "<this-package>"
+           Include fields ["key", "summary", "fixVersions", "status"] in the search
+         * Once found, call get_jira_details on the dependency issue to check its status
+         * If the dependency issue has a `Fixed in Build` field set → resolution is "rebuild"
+           Set dependency_issue to the issue key AND dependency_component to the component name
+           (e.g., "golang", "openssl") from the dependency issue's component field
+         * Otherwise → resolution is "open-ended-analysis"
+           with a recommendation to rebuild once the dependency is ready
+         3.3. If rebuild: set Jira fields as per the instructions below.
+
+      4. **Open-Ended Analysis**
+         This is the catch-all for issues that don't fit rebase, backport, rebuild, or clarification-needed. Use this when:
          * The issue requires specfile adjustments, dependency updates, or other packaging-level work
-         * The issue requires rebuilding against an updated dependency without source changes
          * The issue is a QE task, feature request, documentation change, or other non-bug
          * The issue is a duplicate, misassigned, or otherwise needs no work
          * The issue is a legitimate problem but doesn't cleanly fit other categories
@@ -272,14 +303,14 @@ TRIAGE_PROMPT = """
          * Provide a thorough summary of your findings and a clear recommendation for what action
            should be taken (or explicitly state that no action is needed and why)
 
-      4. **Error**
+      5. **Error**
          An Error decision is appropriate when there are processing issues that prevent proper analysis, e.g.:
          * The package mentioned in the issue cannot be found or identified
          * The issue cannot be accessed
 
-      **Final Step: Set JIRA Fields (for Rebase and Backport decisions only)**
+      **Final Step: Set JIRA Fields (for Rebase, Backport, and Rebuild decisions only)**
 
-         If your decision is rebase or backport, use set_jira_fields tool to update JIRA fields (Severity, Fix Version):
+         If your decision is rebase, backport, or rebuild, use set_jira_fields tool to update JIRA fields (Severity, Fix Version):
          1. Check all of the mentioned fields in the JIRA issue and don't modify those that are already set
          2. Extract the affected RHEL major version from the JIRA issue (look in Affects Version/s field or issue description)
          3. If the Fix Version field is set, do not change it and use its value in the output.
@@ -475,7 +506,7 @@ def create_triage_agent(gateway_tools):
         tool_call_checker=get_tool_call_checker_config(),
         tools=[ThinkTool(), RunShellCommandTool(), PatchValidatorTool(),
                 VersionMapperTool(), UpstreamSearchTool(), ZStreamSearchTool()]
-        + [t for t in gateway_tools if t.name in ["get_jira_details", "set_jira_fields"]],
+        + [t for t in gateway_tools if t.name in ["get_jira_details", "set_jira_fields", "search_jira_issues"]],
         memory=UnconstrainedMemory(),
         requirements=[
             ConditionalRequirement(
@@ -491,6 +522,7 @@ def create_triage_agent(gateway_tools):
             ConditionalRequirement(RunShellCommandTool, only_after="get_jira_details"),
             ConditionalRequirement(PatchValidatorTool, only_after="get_jira_details"),
             ConditionalRequirement("set_jira_fields", only_after="get_jira_details"),
+            ConditionalRequirement("search_jira_issues", only_after="get_jira_details"),
         ],
         middlewares=[GlobalTrajectoryMiddleware(pretty=True)],
         role="Red Hat Enterprise Linux developer",
@@ -613,7 +645,7 @@ async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=Fal
 
             if state.triage_result.resolution == Resolution.REBASE:
                 return "verify_rebase_author"
-            elif state.triage_result.resolution == Resolution.BACKPORT:
+            elif state.triage_result.resolution in [Resolution.BACKPORT, Resolution.REBUILD]:
                 return "determine_target_branch"
             elif state.triage_result.resolution in [Resolution.CLARIFICATION_NEEDED, Resolution.OPEN_ENDED_ANALYSIS]:
                 return "comment_in_jira"
@@ -805,6 +837,20 @@ async def main() -> None:
                         backport_queue = RedisQueues.get_backport_queue_for_branch(state.target_branch)
                         await fix_await(redis.lpush(backport_queue, task.model_dump_json()))
                         logger.info(f"Pushed {input.issue} to {backport_queue}")
+                    else:
+                        logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
+                elif output.resolution == Resolution.REBUILD:
+                    logger.info(f"Triage resolved as REBUILD for {input.issue}")
+                    await tasks.set_jira_labels(
+                        jira_issue=input.issue,
+                        labels_to_add=[JiraLabels.TRIAGED_REBUILD.value],
+                        dry_run=dry_run
+                    )
+                    if auto_chain:
+                        task = Task(metadata=state.model_dump())
+                        rebuild_queue = RedisQueues.get_rebuild_queue_for_branch(state.target_branch)
+                        await fix_await(redis.lpush(rebuild_queue, task.model_dump_json()))
+                        logger.info(f"Pushed {input.issue} to {rebuild_queue}")
                     else:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
                 elif output.resolution == Resolution.CLARIFICATION_NEEDED:

--- a/common/constants.py
+++ b/common/constants.py
@@ -16,6 +16,9 @@ class RedisQueues(Enum):
     OPEN_ENDED_ANALYSIS_LIST = "open_ended_analysis_list"
     COMPLETED_REBASE_LIST = "completed_rebase_list"
     COMPLETED_BACKPORT_LIST = "completed_backport_list"
+    REBUILD_QUEUE_C9S = "rebuild_queue_c9s"
+    REBUILD_QUEUE_C10S = "rebuild_queue_c10s"
+    COMPLETED_REBUILD_LIST = "completed_rebuild_list"
     REBASE_QUEUE = "rebase_queue"
     BACKPORT_QUEUE = "backport_queue"
 
@@ -28,7 +31,9 @@ class RedisQueues(Enum):
     def input_queues(cls) -> set[str]:
         """Return input queue names that contain Task objects with metadata"""
         return {cls.TRIAGE_QUEUE.value, cls.REBASE_QUEUE_C9S.value, cls.REBASE_QUEUE_C10S.value,
-                cls.BACKPORT_QUEUE_C9S.value, cls.BACKPORT_QUEUE_C10S.value, cls.CLARIFICATION_NEEDED_QUEUE.value,
+                cls.BACKPORT_QUEUE_C9S.value, cls.BACKPORT_QUEUE_C10S.value,
+                cls.REBUILD_QUEUE_C9S.value, cls.REBUILD_QUEUE_C10S.value,
+                cls.CLARIFICATION_NEEDED_QUEUE.value,
                 cls.REBASE_QUEUE.value, cls.BACKPORT_QUEUE.value}
 
     @classmethod
@@ -36,7 +41,7 @@ class RedisQueues(Enum):
         """Return data queue names that contain schema objects"""
         return {cls.ERROR_LIST.value,
                 cls.OPEN_ENDED_ANALYSIS_LIST.value, cls.COMPLETED_REBASE_LIST.value,
-                cls.COMPLETED_BACKPORT_LIST.value}
+                cls.COMPLETED_BACKPORT_LIST.value, cls.COMPLETED_REBUILD_LIST.value}
 
     @classmethod
     def get_rebase_queue_for_branch(cls, target_branch: str | None) -> str:
@@ -51,6 +56,13 @@ class RedisQueues(Enum):
         if target_branch and cls._use_c9s_branch(target_branch):
             return cls.BACKPORT_QUEUE_C9S.value
         return cls.BACKPORT_QUEUE_C10S.value
+
+    @classmethod
+    def get_rebuild_queue_for_branch(cls, target_branch: str | None) -> str:
+        """Return appropriate rebuild queue based on target branch"""
+        if target_branch and cls._use_c9s_branch(target_branch):
+            return cls.REBUILD_QUEUE_C9S.value
+        return cls.REBUILD_QUEUE_C10S.value
 
     @classmethod
     def _use_c9s_branch(cls, branch: str) -> bool:
@@ -68,16 +80,21 @@ class JiraLabels(Enum):
     TRIAGED_BACKPORT = "ymir_triaged_backport"
     TRIAGED_REBASE = "ymir_triaged_rebase"
 
+    TRIAGED_REBUILD = "ymir_triaged_rebuild"
+
     REBASED = "ymir_rebased"
     BACKPORTED = "ymir_backported"
+    REBUILT = "ymir_rebuilt"
     MERGED = "ymir_merged"
 
     REBASE_ERRORED = "ymir_rebase_errored"
     BACKPORT_ERRORED = "ymir_backport_errored"
+    REBUILD_ERRORED = "ymir_rebuild_errored"
     TRIAGE_ERRORED = "ymir_triage_errored"
 
     REBASE_FAILED = "ymir_rebase_failed"
     BACKPORT_FAILED = "ymir_backport_failed"
+    REBUILD_FAILED = "ymir_rebuild_failed"
 
     RETRY_NEEDED = "ymir_retry_needed"
     FUSA = "ymir_fusa"

--- a/common/models.py
+++ b/common/models.py
@@ -42,6 +42,10 @@ class CVEEligibilityResult(BaseModel):
 class TriageInputSchema(BaseModel):
     """Input schema for the triage agent - metadata for a JIRA issue task."""
     issue: str = Field(description="JIRA issue key (e.g., RHEL-12345)")
+    force_cve_triage: bool = Field(
+        default=False,
+        description="Force triage of CVE issues that would normally be skipped (e.g. Y-stream CVEs)",
+    )
 
 
 class Task(BaseModel):

--- a/common/models.py
+++ b/common/models.py
@@ -111,6 +111,13 @@ class BackportOutputSchema(BaseModel):
     error: str | None = Field(description="Specific details about an error")
 
 
+class RebuildOutputSchema(BaseModel):
+    """Output schema for the rebuild agent."""
+    success: bool = Field(description="Whether the rebuild was successfully completed")
+    merge_request_url: str | None = Field(default=None, description="URL of the opened merge request")
+    error: str | None = Field(default=None, description="Specific details about an error")
+
+
 # ============================================================================
 # Triage Agent Schemas
 # ============================================================================
@@ -119,6 +126,7 @@ class Resolution(Enum):
     """Triage resolution types."""
     REBASE = "rebase"
     BACKPORT = "backport"
+    REBUILD = "rebuild"
     CLARIFICATION_NEEDED = "clarification-needed"
     OPEN_ENDED_ANALYSIS = "open-ended-analysis"
     ERROR = "error"
@@ -140,6 +148,21 @@ class BackportData(BaseModel):
     justification: str = Field(description="Clear explanation of why this patch fixes the issue, linking it to the root cause")
     jira_issue: str = Field(description="Jira issue identifier")
     cve_id: str | None = Field(description="CVE identifier", default=None)
+    fix_version: str | None = Field(description="Fix version in Jira (e.g., 'rhel-9.8')", default=None)
+
+
+class RebuildData(BaseModel):
+    """Data for rebuild resolution."""
+    package: str = Field(description="Package name")
+    jira_issue: str = Field(description="Jira issue identifier")
+    dependency_issue: str | None = Field(
+        description="Key of the dependency Jira issue that triggered the rebuild",
+        default=None,
+    )
+    dependency_component: str | None = Field(
+        description="Name of the dependency component that triggered the rebuild (e.g., 'golang', 'openssl')",
+        default=None,
+    )
     fix_version: str | None = Field(description="Fix version in Jira (e.g., 'rhel-9.8')", default=None)
 
 
@@ -198,8 +221,8 @@ AUTOMATED_RESOLUTION_NOT_SUPPORTED = (
 class TriageOutputSchema(BaseModel):
     """Output schema for the triage agent."""
     resolution: Resolution = Field(
-        description="Triage resolution, one of rebase, backport, clarification-needed, open-ended-analysis, error")
-    data: Union[RebaseData, BackportData, ClarificationNeededData, OpenEndedAnalysisData, ErrorData] = Field(
+        description="Triage resolution, one of rebase, backport, rebuild, clarification-needed, open-ended-analysis, error")
+    data: Union[RebaseData, BackportData, RebuildData, ClarificationNeededData, OpenEndedAnalysisData, ErrorData] = Field(
         description="Associated data"
     )
 
@@ -232,6 +255,21 @@ class TriageOutputSchema(BaseModel):
                     f"{resolution}"
                     f"*Package*: {self.data.package}\n"
                     f"*Version*: {self.data.version}{fix_version_text}"
+                    f"{follow_up_note}"
+                )
+
+            case RebuildData():
+                fix_version_text = f"\n*Fix Version*: {self.data.fix_version}" if self.data.fix_version else ""
+                dep_text = f"\n*Dependency Issue*: {self.data.dependency_issue}" if self.data.dependency_issue else ""
+                dep_comp_text = f"\n*Dependency Component*: {self.data.dependency_component}" if self.data.dependency_component else ""
+
+                return (
+                    f"{TRIAGE_DISCLAIMER}"
+                    f"{resolution}"
+                    f"*Package*: {self.data.package}"
+                    f"{dep_comp_text}"
+                    f"{dep_text}"
+                    f"{fix_version_text}"
                     f"{follow_up_note}"
                 )
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -85,6 +85,7 @@ services:
       - KRB5CCNAME=FILE:/tmp/krb5cc
       - DRY_RUN=${DRY_RUN:-false}
       - MOCK_JIRA=${MOCK_JIRA:-false}
+      - JIRA_DRY_RUN=${JIRA_DRY_RUN:-false}
       - GIT_REPO_BASEPATH=/git-repos
       - JIRA_MOCK_FILES=mcp_server/tests/data
     env_file:

--- a/compose.yaml
+++ b/compose.yaml
@@ -165,6 +165,16 @@ services:
     command: ["python", "agents/rebase_agent.py"]
     profiles: ["agents"]
 
+  rebuild-agent-c9s:
+    <<: *beeai-agent-c9s
+    command: ["python", "agents/rebuild_agent.py"]
+    profiles: ["agents"]
+
+  rebuild-agent-c10s:
+    <<: *beeai-agent-c10s
+    command: ["python", "agents/rebuild_agent.py"]
+    profiles: ["agents"]
+
   mr-agent-c9s:
     <<: *beeai-agent-c9s
     command: ["python", "agents/merge_request_agent.py"]

--- a/mcp_server/jira_tools.py
+++ b/mcp_server/jira_tools.py
@@ -24,6 +24,10 @@ from common import CVEEligibilityResult, load_rhel_config
 from common.constants import JIRA_SEARCH_PATH
 from common.utils import get_jira_auth_headers
 
+def _skip_jira_writes() -> bool:
+    return os.getenv("JIRA_DRY_RUN", "False").lower() == "true"
+
+
 # Jira custom field IDs
 SEVERITY_CUSTOM_FIELD = "customfield_10840"
 TARGET_END_CUSTOM_FIELD = "customfield_10023"
@@ -106,6 +110,8 @@ async def set_jira_fields(
         return "Skipping of setting Jira fields requested, not doing anything (this is expected, not an error)"
     if os.getenv("DRY_RUN", "False").lower() == "true":
         return "Dry run, not updating Jira fields (this is expected, not an error)"
+    if _skip_jira_writes():
+        return f"JIRA_DRY_RUN is set, not updating fields on {issue_key} (this is expected, not an error)"
 
     async with aiohttpClientSession() as session:
         # First, get the current issue to check existing field values
@@ -171,6 +177,8 @@ async def add_jira_comment(
     """
     if os.getenv("DRY_RUN", "False").lower() == "true":
         return f"Dry run, not adding comment to {issue_key} (this is expected, not an error)"
+    if _skip_jira_writes():
+        return f"JIRA_DRY_RUN is set, not adding comment to {issue_key} (this is expected, not an error)"
 
     # Jira REST API v3 does not support markdown or wiki markup in comments.
     jira_url = urljoin(os.getenv("JIRA_URL"), f"rest/api/2/issue/{issue_key}/comment")
@@ -286,6 +294,8 @@ async def change_jira_status(
 ) -> str:
     if os.getenv("DRY_RUN", "False").lower() == "true":
         return f"Dry run, not changing status of {issue_key} to {status}  (this is expected, not an error)"
+    if _skip_jira_writes():
+        return f"JIRA_DRY_RUN is set, not changing status of {issue_key} (this is expected, not an error)"
 
     headers = get_jira_auth_headers()
     jira_url = urljoin(os.getenv("JIRA_URL"), f"rest/api/3/issue/{issue_key}/transitions")
@@ -349,6 +359,8 @@ async def edit_jira_labels(
 
     if os.getenv("DRY_RUN", "False").lower() == "true":
         return f"Dry run, not editing labels on {issue_key} (this is expected, not an error)"
+    if _skip_jira_writes():
+        return f"JIRA_DRY_RUN is set, not editing labels on {issue_key} (this is expected, not an error)"
 
     jira_url = urljoin(os.getenv("JIRA_URL"), f"rest/api/3/issue/{issue_key}")
     logger.info(f"Connecting to JIRA API to edit labels: {jira_url}")

--- a/mcp_server/tests/unit/test_jira_tools.py
+++ b/mcp_server/tests/unit/test_jira_tools.py
@@ -15,6 +15,7 @@ def mocked_env():
     flexmock(os).should_receive("getenv").with_args("JIRA_URL").and_return("http://jira")
     flexmock(os).should_receive("getenv").with_args("DRY_RUN", "False").and_return("false")
     flexmock(os).should_receive("getenv").with_args("SKIP_SETTING_JIRA_FIELDS", "False").and_return("false")
+    flexmock(os).should_receive("getenv").with_args("JIRA_DRY_RUN", "False").and_return("false")
     flexmock(jira_tools).should_receive("get_jira_auth_headers").and_return({
         "Authorization": "Basic dGVzdEBleGFtcGxlLmNvbToxMjM0NQ==",
         "Content-Type": "application/json",

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rebuild-agent-c10s
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: rebuild-agent-c10s
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: rebuild-agent-c10s
+        deployment: rebuild-agent-c10s
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ip-10-30-34-89.us-east-1.compute.internal
+      containers:
+      - args:
+        - agents/rebuild_agent.py
+        command:
+        - /usr/bin/python
+        env:
+        - name: CONTAINER_VERSION
+          value: "c10s"
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/pki/tls/certs/ca-bundle.crt
+        envFrom:
+        - configMapRef:
+            name: agents-env
+        - configMapRef:
+            name: chat-env
+        - configMapRef:
+            name: endpoints-env
+        image: 'beeai-agent:c10s'
+        imagePullPolicy: Always
+        name: rebuild-agent-c10s
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources:
+          limits:
+            memory: 1Gi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /git-repos  # NOTE: This path must match GIT_REPO_BASEPATH in configmap/agents-env
+          name: mcp-server-git-repos
+        - mountPath: /home/beeai/rhel-config.json
+          name: rhel-config
+          subPath: rhel-config.json
+        - mountPath: /etc/secrets/jotnar-vertex-prod.json
+          name: vertex-key
+          subPath: jotnar-vertex-prod.json
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: mcp-server-git-repos
+        persistentVolumeClaim:
+          claimName: mcp-server-git-repos
+      - name: rhel-config
+        configMap:
+          name: rhel-config
+      - name: vertex-key
+        secret:
+          secretName: vertex-key

--- a/openshift/deployment-rebuild-agent-c9s.yml
+++ b/openshift/deployment-rebuild-agent-c9s.yml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rebuild-agent-c9s
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: rebuild-agent-c9s
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: rebuild-agent-c9s
+        deployment: rebuild-agent-c9s
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: ip-10-30-34-89.us-east-1.compute.internal
+      containers:
+      - args:
+        - agents/rebuild_agent.py
+        command:
+        - python
+        env:
+        - name: CONTAINER_VERSION
+          value: "c9s"
+        - name: REQUESTS_CA_BUNDLE
+          value: /etc/pki/tls/certs/ca-bundle.crt
+        envFrom:
+        - configMapRef:
+            name: agents-env
+        - configMapRef:
+            name: chat-env
+        - configMapRef:
+            name: endpoints-env
+        image: 'beeai-agent:c9s'
+        imagePullPolicy: Always
+        name: rebuild-agent-c9s
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources:
+          limits:
+            memory: 1Gi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /git-repos  # NOTE: This path must match GIT_REPO_BASEPATH in configmap/agents-env
+          name: mcp-server-git-repos
+        - mountPath: /home/beeai/rhel-config.json
+          name: rhel-config
+          subPath: rhel-config.json
+        - mountPath: /etc/secrets/jotnar-vertex-prod.json
+          name: vertex-key
+          subPath: jotnar-vertex-prod.json
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: mcp-server-git-repos
+        persistentVolumeClaim:
+          claimName: mcp-server-git-repos
+      - name: rhel-config
+        configMap:
+          name: rhel-config
+      - name: vertex-key
+        secret:
+          secretName: vertex-key


### PR DESCRIPTION
Introduce a rebuild workflow for packages that need rebuilding against updated dependencies without source code changes (e.g., vendored dependency CVEs in Go/Rust/Node.js packages). The triage agent detects
rebuild scenarios by checking dependency issue status via issuelinks                                                                                                                                         or JQL search.

Also adds JIRA_DRY_RUN, FORCE_CVE_TRIAGE, and DEPENDENCY_COMPONENT options for flexible standalone testing.

Assisted-by: Claude

Tests I ran so far:
```
make run-triage-agent-standalone JIRA_ISSUE=RHEL-158765 DRY_RUN=true FORCE_CVE_TRIAGE=true

INFO:__main__:Direct run completed: {
    "resolution": "rebuild",
    "data": {
        "package": "git-lfs",
        "jira_issue": "RHEL-158765",
        "dependency_issue": "RHEL-156572",
        "dependency_component": "golang",
        "fix_version": "rhel-9.8"
    }
}
```

```
make run-rebuild-agent-c9s-debug PACKAGE=git-lfs JIRA_ISSUE=RHEL-158765 BRANCH=c9s SKIP_JIRA=true DEPENDENCY_COMPONENT=golang
```
resulting in https://gitlab.com/redhat/centos-stream/rpms/git-lfs/-/merge_requests/41
