### PR TITLE
Add jotnar_triage_in_progress label that acts as fence

### DIFF
--- a/agents/triage_agent.py
+++ b/agents/triage_agent.py
@@ -747,6 +747,7 @@ async def main() -> None:
                     await tasks.set_jira_labels(
                         jira_issue=input.issue,
                         labels_to_add=[JiraLabels.TRIAGE_ERRORED.value],
+                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
                         dry_run=dry_run
                     )
                     await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
@@ -754,7 +755,8 @@ async def main() -> None:
             try:
                 await tasks.set_jira_labels(
                     jira_issue=input.issue,
-                    labels_to_remove=list(JiraLabels.all_labels()),
+                    labels_to_add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                    labels_to_remove=[l for l in JiraLabels.all_labels() if l != JiraLabels.TRIAGE_IN_PROGRESS.value],
                     dry_run=dry_run
                 )
                 logger.info(f"Cleaned up existing labels for {input.issue}")
@@ -780,6 +782,7 @@ async def main() -> None:
                     await tasks.set_jira_labels(
                         jira_issue=input.issue,
                         labels_to_add=[JiraLabels.TRIAGED_REBASE.value],
+                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
                         dry_run=dry_run
                     )
                     if auto_chain:
@@ -794,6 +797,7 @@ async def main() -> None:
                     await tasks.set_jira_labels(
                         jira_issue=input.issue,
                         labels_to_add=[JiraLabels.TRIAGED_BACKPORT.value],
+                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
                         dry_run=dry_run
                     )
                     if auto_chain:
@@ -808,6 +812,7 @@ async def main() -> None:
                     await tasks.set_jira_labels(
                         jira_issue=input.issue,
                         labels_to_add=[JiraLabels.NEEDS_ATTENTION.value],
+                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
                         dry_run=dry_run
                     )
                     if auto_chain:
@@ -821,6 +826,7 @@ async def main() -> None:
                     await tasks.set_jira_labels(
                         jira_issue=input.issue,
                         labels_to_add=[JiraLabels.TRIAGED.value],
+                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
                         dry_run=dry_run
                     )
                     if auto_chain:
@@ -833,6 +839,7 @@ async def main() -> None:
                     await tasks.set_jira_labels(
                         jira_issue=input.issue,
                         labels_to_add=[JiraLabels.TRIAGE_ERRORED.value],
+                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
                         dry_run=dry_run
                     )
                     await retry(task, output.data.model_dump_json())

--- a/common/constants.py
+++ b/common/constants.py
@@ -64,6 +64,7 @@ class JiraLabels(Enum):
     """Constants for Jira labels used by Jotnar agents"""
     NEEDS_ATTENTION = "jotnar_needs_attention"
     TRIAGED = "jotnar_triaged"
+    TRIAGE_IN_PROGRESS = "jotnar_triage_in_progress"
     TRIAGED_BACKPORT = "jotnar_triaged_backport"
     TRIAGED_REBASE = "jotnar_triaged_rebase"
 


### PR DESCRIPTION
When the triage agent pops an issue the item is removed from Redis however if triage workflow is not completed before the Jira issue fetcher runs again this can lead to duplicates. The new label acts as fence to block any issues still under triage from arriving on the queue again.