### PR TITLE
Rename Jotnar to Ymir in user-visible text and Jira labels

### DIFF
--- a/Containerfile.c9s-tests
+++ b/Containerfile.c9s-tests
@@ -48,8 +48,8 @@ RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \
 # Make venv Python the default
 ENV PATH=/opt/beeai-venv/bin:$PATH
 
-RUN git config --global user.email "jotnar-tests@example.com" \
-      && git config --global user.name "Jotnar Tests"
+RUN git config --global user.email "ymir-tests@example.com" \
+      && git config --global user.name "Ymir Tests"
 
 # Set PYTHONPATH so agents module can be imported
 ENV PYTHONPATH=/src:$PYTHONPATH

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -22,8 +22,8 @@ RUN dnf -y install \
       python3-GitPython \
     && dnf clean all
 
-RUN git config --global user.email "jotnar-tests@example.com" \
-      && git config --global user.name "Jotnar Tests"
+RUN git config --global user.email "ymir-tests@example.com" \
+      && git config --global user.name "Ymir Tests"
 
 # Set PYTHONPATH so agents module can be imported
 ENV PYTHONPATH=/src:$PYTHONPATH

--- a/README-agents.md
+++ b/README-agents.md
@@ -123,19 +123,19 @@ For detailed information about queue routing, label state transitions, and workf
 
 ### Service triggering
 
-Jotnar bot processes issues assigned to `jotnar-project`.
+Ymir bot processes issues assigned to `jotnar-project`.
 
 Issues can be re-triggered through the workflow in two ways:
-1. **Remove any existing `jotnar_*` label** - allows the issue to re-enter the system on the next fetcher run
-2. **Add the `jotnar_retry_needed` label** - triggers workflow retry. Use cases include:
+1. **Remove any existing `ymir_*` label** - allows the issue to re-enter the system on the next fetcher run
+2. **Add the `ymir_retry_needed` label** - triggers workflow retry. Use cases include:
    - Package maintainers who have made changes (e.g., updated some fields, added links, commented)
-   - Jötnar team members after production code updates to resolve issues
+   - Ymir team members after production code updates to resolve issues
 
 ### Maintainer Review Process
 
-Some Jira issues will require a maintainer review by applying the `jotnar_needs_maintainer_review` label to an issue. This is currently agreed on for FuSa (Functional Safety) project packages.
+Some Jira issues will require a maintainer review by applying the `ymir_needs_maintainer_review` label to an issue. This is currently agreed on for FuSa (Functional Safety) project packages.
 
-The `jotnar_fusa` label will be automatically added by the triage agent to JIRA issues involving FuSa packages, and related merge requests will need to be reviewed and handled by subject matter experts.
+The `ymir_fusa` label will be automatically added by the triage agent to JIRA issues involving FuSa packages, and related merge requests will need to be reviewed and handled by subject matter experts.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-This repository is an AI-powered RHEL package maintenance automation system (codename "Jötnar") that triages Jira issues, creates merge requests for package rebases and backports, and can handle quality processes.
+This repository is an AI-powered RHEL package maintenance automation system (codename "Ymir", formerly "Jötnar") that triages Jira issues, creates merge requests for package rebases and backports, and can handle quality processes.
+
+> **Note on naming:** The project used the codename "Jötnar" during the pilot phase. "Ymir" is the name of our working group, and we adopted it as the project name to avoid confusion with other working groups. Some internal references still use "jotnar" (e.g. service accounts, bot usernames, Kerberos principals, container registry namespace, Slack channel) as those have not been migrated yet.
 
 ### Business Purpose
 The AI Workflows system automates RHEL package maintenance by triaging incoming Jira issues to determine if they can be automatically resolved through rebases or backports, then creating merge requests to the appropriate dist-git repositories. Once merge requests are merged and candidate builds are created, the system manages the testing and release workflow, moving builds through validation and the RHEL release process until they are ready for production deployment.

--- a/agents/backport_agent.py
+++ b/agents/backport_agent.py
@@ -40,7 +40,7 @@ from common.models import (
     ErrorData,
 )
 from common.utils import redis_client, fix_await, is_cs_branch
-from constants import I_AM_JOTNAR, CAREFULLY_REVIEW_CHANGES
+from constants import I_AM_YMIR, CAREFULLY_REVIEW_CHANGES
 from observability import setup_observability
 from tools.commands import RunShellCommandTool
 from tools.specfile import GetPackageInfoTool
@@ -1225,15 +1225,15 @@ async def main() -> None:
                             + (f"CVE: {state.cve_id}\n" if state.cve_id else "")
                             + "Upstream patches:\n" + formatted_patches + "\n"
                             + f"Resolves: {state.jira_issue}\n\n"
-                            f"This commit was backported {I_AM_JOTNAR}\n\n"
-                            "Assisted-by: Jotnar\n"
+                            f"This commit was backported {I_AM_YMIR}\n\n"
+                            "Assisted-by: Ymir\n"
                         ),
                         fork_url=state.fork_url,
                         dist_git_branch=state.dist_git_branch,
                         update_branch=state.update_branch,
                         mr_title=state.log_result.title,
                         mr_description=(
-                            f"This merge request was created {I_AM_JOTNAR}\n"
+                            f"This merge request was created {I_AM_YMIR}\n"
                             f"{CAREFULLY_REVIEW_CHANGES}\n\n"
                             f"{state.log_result.description}\n\n"
                             + "Upstream patches:\n" + formatted_patches + "\n"

--- a/agents/constants.py
+++ b/agents/constants.py
@@ -6,10 +6,10 @@ BRANCH_PREFIX = "automated-package-update"
 AGENT_WARNING = (
     "Warning: This is an AI-Generated contribution and may contain mistakes. "
     "Please carefully review the contributions made by AI agents.\n"
-    "You can learn more about the Jotnar Pilot at https://docs.google.com/document/d/1mXTymiIe7MfjEDq6s4x0s3XnriC9db11DokdgZ5g9KU/edit"
+    "You can learn more about the Ymir project at https://docs.google.com/document/d/1mXTymiIe7MfjEDq6s4x0s3XnriC9db11DokdgZ5g9KU/edit"
 )
 
 JIRA_COMMENT_TEMPLATE = Template(f"""Output from $AGENT_TYPE Agent: \n\n$JIRA_COMMENT\n\n{AGENT_WARNING}""")
 
-I_AM_JOTNAR = "by Jotnar, a Red Hat Enterprise Linux software maintenance AI agent."
+I_AM_YMIR = "by Ymir, a Red Hat Enterprise Linux software maintenance AI agent."
 CAREFULLY_REVIEW_CHANGES = "Carefully review the changes and make sure they are correct."

--- a/agents/merge_request_agent.py
+++ b/agents/merge_request_agent.py
@@ -34,7 +34,7 @@ from common.models import (
     MergeRequestOutputSchema,
 )
 from common.utils import is_cs_branch
-from constants import I_AM_JOTNAR
+from constants import I_AM_YMIR
 from observability import setup_observability
 from tools.commands import RunShellCommandTool
 from tools.filesystem import GetCWDTool, RemoveTool
@@ -329,8 +329,8 @@ async def main() -> None:
                         commit_message=(
                             f"{state.mr_update_log[-1]}\n\n"
                             f"Related: {state.jira_issue}\n\n"
-                            f"This commit was created {I_AM_JOTNAR}\n\n"
-                            f"Assisted-by: Jotnar\n"
+                            f"This commit was created {I_AM_YMIR}\n\n"
+                            f"Assisted-by: Ymir\n"
                         ),
                         fork_url=state.fork_url,
                         update_branch=state.update_branch,

--- a/agents/package_update_steps.py
+++ b/agents/package_update_steps.py
@@ -86,7 +86,7 @@ class PackageUpdateStep():
 
   @staticmethod
   async def add_blocking_comment(state, next_step, dry_run, gateway_tools):
-      """Add a blocking comment to the MR to prevent merge until Jotnar members approve.
+      """Add a blocking comment to the MR to prevent merge until Ymir team members approve.
 
       Args:
           state: The state of the workflow.
@@ -103,7 +103,7 @@ class PackageUpdateStep():
       if state.merge_request_url:
           blocking_comment = """
               **⚠️ Do not merge this merge request ⚠️**\n\n
-              Anyone is welcome to review and approve the changes, but please leave the merging on Jötnar team members.\n
+              Anyone is welcome to review and approve the changes, but please leave the merging on Ymir team members.\n
               There are automated processes that run after merge, and this MR may need to wait
               before being merged to avoid conflicts with ongoing automation.
           """

--- a/agents/rebase_agent.py
+++ b/agents/rebase_agent.py
@@ -40,7 +40,7 @@ from common.models import (
     Task,
 )
 from common.utils import redis_client, fix_await, is_cs_branch
-from constants import I_AM_JOTNAR, CAREFULLY_REVIEW_CHANGES
+from constants import I_AM_YMIR, CAREFULLY_REVIEW_CHANGES
 from observability import setup_observability
 from tools.commands import RunShellCommandTool
 from tools.filesystem import GetCWDTool, RemoveTool
@@ -371,15 +371,15 @@ async def main() -> None:
                             f"{state.log_result.title}\n\n"
                             f"{state.log_result.description}\n\n"
                             f"Resolves: {state.jira_issue}\n\n"
-                            f"This commit was created {I_AM_JOTNAR}\n\n"
-                            f"Assisted-by: Jotnar\n"
+                            f"This commit was created {I_AM_YMIR}\n\n"
+                            f"Assisted-by: Ymir\n"
                         ),
                         fork_url=state.fork_url,
                         dist_git_branch=state.dist_git_branch,
                         update_branch=state.update_branch,
                         mr_title=state.log_result.title,
                         mr_description=(
-                            f"This merge request was created {I_AM_JOTNAR}\n"
+                            f"This merge request was created {I_AM_YMIR}\n"
                             f"{CAREFULLY_REVIEW_CHANGES}\n\n"
                             f"{state.log_result.description}\n\n"
                             f"Resolves: {state.jira_issue}\n\n"

--- a/brew_konflux_data_flow.md
+++ b/brew_konflux_data_flow.md
@@ -61,7 +61,7 @@ sequenceDiagram
 
     Agent->>MCP: open_merge_request()
     MCP->>MR: Create MR
-    MCP->>MR: Add label: jotnar_needs_attention
+    MCP->>MR: Add label: ymir_needs_attention
     Note over MR: MR created without build label
 
     Note over MR: Later, when ready for build...
@@ -173,7 +173,7 @@ flowchart TD
 
     AGENT --> CREATE["Create MR<br/>via open_merge_request()"]
 
-    CREATE --> ADD_LABEL_NOTE["Note: MR created with only<br/>jotnar_needs_attention label"]
+    CREATE --> ADD_LABEL_NOTE["Note: MR created with only<br/>ymir_needs_attention label"]
 
     ADD_LABEL_NOTE --> MANUAL_LABEL["When ready: Manually add<br/>feature::draft-builds::enabled<br/>via add_merge_request_labels()"]
 

--- a/common/constants.py
+++ b/common/constants.py
@@ -5,7 +5,7 @@ BREWHUB_URL = "https://brewhub.engineering.redhat.com/brewhub"
 JIRA_SEARCH_PATH = "rest/api/3/search/jql"
 
 class RedisQueues(Enum):
-    """Constants for Redis queue names used by Jotnar agents"""
+    """Constants for Redis queue names used by Ymir agents"""
     TRIAGE_QUEUE = "triage_queue"
     REBASE_QUEUE_C9S = "rebase_queue_c9s"
     REBASE_QUEUE_C10S = "rebase_queue_c10s"
@@ -61,36 +61,36 @@ class RedisQueues(Enum):
 
 
 class JiraLabels(Enum):
-    """Constants for Jira labels used by Jotnar agents"""
-    NEEDS_ATTENTION = "jotnar_needs_attention"
-    TRIAGED = "jotnar_triaged"
-    TRIAGE_IN_PROGRESS = "jotnar_triage_in_progress"
-    TRIAGED_BACKPORT = "jotnar_triaged_backport"
-    TRIAGED_REBASE = "jotnar_triaged_rebase"
+    """Constants for Jira labels used by Ymir agents"""
+    NEEDS_ATTENTION = "ymir_needs_attention"
+    TRIAGED = "ymir_triaged"
+    TRIAGE_IN_PROGRESS = "ymir_triage_in_progress"
+    TRIAGED_BACKPORT = "ymir_triaged_backport"
+    TRIAGED_REBASE = "ymir_triaged_rebase"
 
-    REBASED = "jotnar_rebased"
-    BACKPORTED = "jotnar_backported"
-    MERGED = "jotnar_merged"
+    REBASED = "ymir_rebased"
+    BACKPORTED = "ymir_backported"
+    MERGED = "ymir_merged"
 
-    REBASE_ERRORED = "jotnar_rebase_errored"
-    BACKPORT_ERRORED = "jotnar_backport_errored"
-    TRIAGE_ERRORED = "jotnar_triage_errored"
+    REBASE_ERRORED = "ymir_rebase_errored"
+    BACKPORT_ERRORED = "ymir_backport_errored"
+    TRIAGE_ERRORED = "ymir_triage_errored"
 
-    REBASE_FAILED = "jotnar_rebase_failed"
-    BACKPORT_FAILED = "jotnar_backport_failed"
+    REBASE_FAILED = "ymir_rebase_failed"
+    BACKPORT_FAILED = "ymir_backport_failed"
 
-    RETRY_NEEDED = "jotnar_retry_needed"
-    FUSA = "jotnar_fusa"
+    RETRY_NEEDED = "ymir_retry_needed"
+    FUSA = "ymir_fusa"
 
     @classmethod
     def all_labels(cls) -> set[str]:
-        """Return all Jotnar labels for cleanup operations"""
+        """Return all Ymir labels for cleanup operations"""
         return {label.value for label in cls}
 
 
-GITLAB_MR_CHECKLIST = """ # Jötnar MR Review Checklist
+GITLAB_MR_CHECKLIST = """ # Ymir MR Review Checklist
 
-> **⚠️ AI-Generated MR**: Created by Jötnar AI assistant. AI may make mistakes, select incorrect patches, or miss dependencies. **RHEL human maintainer needs to approve this contribution before merging.**
+> **⚠️ AI-Generated MR**: Created by Ymir AI assistant. AI may make mistakes, select incorrect patches, or miss dependencies. **RHEL human maintainer needs to approve this contribution before merging.**
 >
 > <ins>By merging this MR, you agree to follow the [Guidelines on Use of AI Generated Content](https://source.redhat.com/departments/legal/legal_compliance_ethics/compliance_folder/appendix_1_to_policy_on_the_use_of_ai_technologypdf) and [Guidelines for Responsible Use of AI Code Assistants](https://source.redhat.com/projects_and_programs/ai/wiki/code_assistants_guidelines_for_responsible_use_of_ai_code_assistants).</ins>
 
@@ -98,12 +98,12 @@ GITLAB_MR_CHECKLIST = """ # Jötnar MR Review Checklist
 
 ### 📋 Jira Fields Verification
 
-- [ ] **Fix Version/s**: Verify that the fix version chosen by Jötnar is correct
+- [ ] **Fix Version/s**: Verify that the fix version chosen by Ymir is correct
 - [ ] **Testing**
   - [ ] **Test Coverage**: Required for Release Pending status (Manual, Automated, or RegressionOnly)
   - [ ] **Preliminary Testing**: Set to "Pass" after pre-merge testing has been done by a team member according to the test coverage choice.
   - [ ] If **Preliminary Testing** was *Manual*, add a note to the issue that describes the justification for this value and any manual test done.
-- [ ] **Product Documentation Required**: Set to "Yes" or "No" (No if no user facing change  - use this value almost always for Project Jötnar)
+- [ ] **Product Documentation Required**: Set to "Yes" or "No" (No if no user facing change  - use this value almost always for Project Ymir)
 - [ ] **Release Note Fields**: If documentation is required, ensure Release Note Type, Text, and Status are set.
 
 ### Automated Checks
@@ -120,7 +120,7 @@ GITLAB_MR_CHECKLIST = """ # Jötnar MR Review Checklist
 
 ### 🔍 MR Code Review
 
-- [ ] **Upstream Patch Verification** (Jötnar-specific):
+- [ ] **Upstream Patch Verification** (Ymir-specific):
   - [ ] Source of upstream patch is trustworthy and patch is correct
   - [ ] Patch is applied correctly (does it capture the important parts of the change, and not add anything)
   - [ ] Patch picked by triaging is complete (e.g. not just one commit from pull request addressing the issue)
@@ -132,7 +132,7 @@ GITLAB_MR_CHECKLIST = """ # Jötnar MR Review Checklist
   - [ ] are added/removed patches from specfile also added/removed as files in dist-git
   - [ ] new %changelog entry is valid
 - [ ] If any patch is removed it has to be removed both from the specfile and the dist-git
-- [ ] For FuSa packages (related Jira issues have `jotnar_fusa` label) request review and wait for approval from a package maintainer.
+- [ ] For FuSa packages (related Jira issues have `ymir_fusa` label) request review and wait for approval from a package maintainer.
 
 ## ✅ Post-Merge Tasks
 
@@ -144,10 +144,10 @@ GITLAB_MR_CHECKLIST = """ # Jötnar MR Review Checklist
 - [ ] **Errata Tool**: errata created (requires Preliminary Testing: Pass)
   - [ ] **Release Date**: check the errata `Release Date` which in case of important or critical CVE should be ASAP (medium or low severity CVEs should be set to Batch that respects the Due date set in Jira), if not ask in [#forum-rhel-program](https://redhat.enterprise.slack.com/archives/C04S8PHPXH7)
 
-## 🤖 Jötnar specific tasks
+## 🤖 Ymir specific tasks
 
 If everything went well:
-- [ ] Remove `jotnar_needs_inspection` label from issue and merge request if any
+- [ ] Remove `ymir_needs_inspection` label from issue and merge request if any
 - [ ] Remove the issue from the [jotnar todo list](https://issues.redhat.com/issues/?filter=12480549)
 - [ ] Add the issue to the [jotnar handpicked list](https://issues.redhat.com/browse/RHEL-118425?filter=12481077 )
 
@@ -178,7 +178,7 @@ If everything went well:
   - [ ] **verify**: after the build is complete, you need to **manually create an Errata Advisory**
 
 ### [RHEL Hotfix Build](https://source.redhat.com/groups/public/release-engineering/release_engineering_rcm_wiki/rhel_hotfix_build_process_description)
-Jötnar shouldn’t create hotfixes. If it happens follow linked document.
+Ymir shouldn’t create hotfixes. If it happens follow linked document.
 
 ---
 
@@ -188,6 +188,6 @@ Jötnar shouldn’t create hotfixes. If it happens follow linked document.
 
 ### 💡 Feedback Welcome
 
-If the quality of this MR does not meet your expectations or you have suggestions for improvement, please reach out to us. Your feedback helps us continuously improve Jötnar's capabilities and deliver better results.
+If the quality of this MR does not meet your expectations or you have suggestions for improvement, please reach out to us. Your feedback helps us continuously improve Ymir's capabilities and deliver better results.
 
 """

--- a/common/models.py
+++ b/common/models.py
@@ -184,14 +184,14 @@ class ErrorData(BaseModel):
 
 
 TRIAGE_DISCLAIMER = (
-    "_By following Jötnar suggestions, you agree to comply with the "
+    "_By following Ymir suggestions, you agree to comply with the "
     "[Guidelines on Use of AI Generated Content|https://source.redhat.com/departments/legal/legal_compliance_ethics/compliance_folder/appendix_1_to_policy_on_the_use_of_ai_technologypdf] "
     "and [Guidelines for Responsible Use of AI Code Assistants|https://source.redhat.com/projects_and_programs/ai/wiki/code_assistants_guidelines_for_responsible_use_of_ai_code_assistants]._\n\n"
 )
 
 AUTOMATED_RESOLUTION_NOT_SUPPORTED = (
     "\n\n_Note: Automated resolution for this resolution type "
-    "is not yet supported by Jötnar. Manual action is required._"
+    "is not yet supported by Ymir. Manual action is required._"
 )
 
 

--- a/gitlab_distgit_data_flow.md
+++ b/gitlab_distgit_data_flow.md
@@ -135,7 +135,7 @@ sequenceDiagram
 
     Agent->>MCP_Git: open_merge_request(fork_url, title, desc, target, source)
     MCP_Git->>Upstream: Create MR or update existing
-    MCP_Git->>Upstream: Add label: jotnar_needs_attention
+    MCP_Git->>Upstream: Add label: ymir_needs_attention
     Upstream-->>MCP_Git: MR URL
     MCP_Git-->>Agent: MR URL, is_brand_new
 
@@ -268,8 +268,8 @@ ssh://{username}@pkgs.devel.redhat.com/rpms/{package}
 
 | Label | Applied By | Meaning |
 |-------|------------|---------|
-| `jotnar_needs_attention` | open_merge_request (auto) | MR needs human review |
-| `jotnar_needs_inspection` | Agents | Specific attention required |
+| `ymir_needs_attention` | open_merge_request (auto) | MR needs human review |
+| `ymir_needs_inspection` | Agents | Specific attention required |
 | `target::latest` | GitLab CI (auto) | Y-stream build |
 | `target::zstream` | GitLab CI (auto) | Z-stream build |
 | `feature::draft-builds::enabled` | Manual (when ready) | Enables Konflux draft builds when added |

--- a/jira_data_flow.md
+++ b/jira_data_flow.md
@@ -85,7 +85,7 @@ sequenceDiagram
 
     Fetcher->>Jira: POST /rest/api/2/search<br/>JQL: "project=RHEL and assignee=jotnar-project"
     Jira-->>Fetcher: Issues [{key, labels}]
-    Fetcher->>Fetcher: Deduplicate & Filter<br/>(skip if jötnar labels exist)
+    Fetcher->>Fetcher: Deduplicate & Filter<br/>(skip if Ymir labels exist)
     Fetcher->>Redis: Push Task to triage_queue<br/>{metadata: {issue: "RHEL-12345"}}
 ```
 
@@ -159,7 +159,7 @@ sequenceDiagram
 flowchart TD
     START([Jira Issue Created])
     FETCH[Jira Issue Fetcher<br/>Queries Jira]
-    FILTER{Has jötnar<br/>labels?}
+    FILTER{Has Ymir<br/>labels?}
     REDIS[(Redis<br/>triage_queue)]
     TRIAGE[Triage Agent]
     DECIDE{Resolution<br/>Type?}

--- a/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/jira_issue_fetcher/jira_issue_fetcher.py
@@ -266,23 +266,23 @@ class JiraIssueFetcher:
             existing_keys = await self._get_existing_issue_keys(redis_conn)
 
             remove_issues_for_retry = set()
-            # Extend existing_keys with issues that have jötnar labels (except jotnar_retry_needed)
+            # Extend existing_keys with issues that have Ymir labels (except ymir_retry_needed)
             for issue in issues:
                 issue_key = issue.get("key")
                 if issue_key:
                     fields = issue.get("fields", {})
                     labels = fields.get("labels", [])
-                    jotnar_labels = [label for label in labels if label.startswith('jotnar_')]
+                    ymir_labels = [label for label in labels if label.startswith('ymir_')]
 
-                    # If issue has jötnar labels and there is no jotnar_retry_needed label, mark as existing
-                    if jotnar_labels and JiraLabels.RETRY_NEEDED.value not in jotnar_labels:
+                    # If issue has Ymir labels and there is no ymir_retry_needed label, mark as existing
+                    if ymir_labels and JiraLabels.RETRY_NEEDED.value not in ymir_labels:
                         existing_keys.add(issue_key)
-                        logger.info(f"Issue {issue_key} has jötnar labels {jotnar_labels} - marking as existing")
-                    elif JiraLabels.RETRY_NEEDED.value in jotnar_labels:
-                        logger.info(f"Issue {issue_key} has jotnar_retry_needed label - marking for retry")
+                        logger.info(f"Issue {issue_key} has Ymir labels {ymir_labels} - marking as existing")
+                    elif JiraLabels.RETRY_NEEDED.value in ymir_labels:
+                        logger.info(f"Issue {issue_key} has ymir_retry_needed label - marking for retry")
                         remove_issues_for_retry.add(issue_key)
-                    elif not jotnar_labels:
-                        logger.info(f"Issue {issue_key} has no jötnar labels - marking for retry")
+                    elif not ymir_labels:
+                        logger.info(f"Issue {issue_key} has no Ymir labels - marking for retry")
                         remove_issues_for_retry.add(issue_key)
 
             pushed_count = 0

--- a/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -253,7 +253,7 @@ async def test_push_issues_to_queue_skip_existing(fetcher, mock_redis_context):
 
 @pytest.mark.asyncio
 async def test_push_issues_to_queue_skip_labeled_issues(fetcher, mock_redis_context):
-    """Test that issues with jotnar labels (except retry_needed) are skipped."""
+    """Test that issues with ymir labels (except retry_needed) are skipped."""
     mock_redis, _ = mock_redis_context
 
     issues = [
@@ -301,11 +301,11 @@ async def test_run_full_workflow_with_labeled_issues(fetcher, mock_redis_context
     # Create test issues with different label states
     mock_issues = [
         {'key': 'ISSUE-1', 'fields': {'labels': []}},  # No labels - should be pushed
-        {'key': 'ISSUE-2', 'fields': {'labels': ['jotnar_rebase_in_progress']}},  # Has jotnar label - should be skipped
-        {'key': 'ISSUE-3', 'fields': {'labels': ['jotnar_backport_in_progress']}},  # Has jotnar label - should be skipped
-        {'key': 'ISSUE-4', 'fields': {'labels': ['jotnar_retry_needed']}},  # Has retry label - should be pushed
+        {'key': 'ISSUE-2', 'fields': {'labels': ['ymir_rebase_in_progress']}},  # Has ymir label - should be skipped
+        {'key': 'ISSUE-3', 'fields': {'labels': ['ymir_backport_in_progress']}},  # Has ymir label - should be skipped
+        {'key': 'ISSUE-4', 'fields': {'labels': ['ymir_retry_needed']}},  # Has retry label - should be pushed
         {'key': 'ISSUE-5', 'fields': {'labels': []}},  # No labels - should be pushed
-        {'key': 'ISSUE-6', 'fields': {'labels': ['jotnar_completed']}},  # Has jotnar label - should be skipped
+        {'key': 'ISSUE-6', 'fields': {'labels': ['ymir_completed']}},  # Has ymir label - should be skipped
     ]
 
     # Create existing issues that are already in Redis queues using the correct data structures
@@ -386,7 +386,7 @@ async def test_run_full_workflow_with_labeled_issues(fetcher, mock_redis_context
 
     # Mock lpush calls for issues that should be pushed despite already existing
     # ISSUE-1, ISSUE-4, and ISSUE-5 should be pushed (no labels or retry_needed)
-    # ISSUE-2, ISSUE-3, and ISSUE-6 should be skipped (have jotnar labels)
+    # ISSUE-2, ISSUE-3, and ISSUE-6 should be skipped (have ymir labels)
     # The actual code pushes JSON strings, not just issue keys
     task1 = Task.from_issue("ISSUE-1")
     task4 = Task.from_issue("ISSUE-4")

--- a/jira_label_workflow_routing.md
+++ b/jira_label_workflow_routing.md
@@ -7,18 +7,18 @@ This document describes how Jira labels control workflow routing through the pro
 ```mermaid
 stateDiagram-v2
     [*] --> New: Issue Created
-    New --> TriagedBackport: jotnar_triaged_backport
-    New --> TriagedRebase: jotnar_triaged_rebase
-    New --> Triaged: jotnar_triaged
-    TriagedBackport --> Success: jotnar_backported
-    TriagedBackport --> Failed: jotnar_backport_failed
-    TriagedBackport --> Errored: jotnar_backport_errored
-    TriagedRebase --> Success: jotnar_rebased
-    TriagedRebase --> Failed: jotnar_rebase_failed
-    TriagedRebase --> Errored: jotnar_rebase_errored
-    Success --> Merged: jotnar_merged
-    Failed --> Retry: jotnar_retry_needed
-    Errored --> Attention: jotnar_needs_attention
+    New --> TriagedBackport: ymir_triaged_backport
+    New --> TriagedRebase: ymir_triaged_rebase
+    New --> Triaged: ymir_triaged
+    TriagedBackport --> Success: ymir_backported
+    TriagedBackport --> Failed: ymir_backport_failed
+    TriagedBackport --> Errored: ymir_backport_errored
+    TriagedRebase --> Success: ymir_rebased
+    TriagedRebase --> Failed: ymir_rebase_failed
+    TriagedRebase --> Errored: ymir_rebase_errored
+    Success --> Merged: ymir_merged
+    Failed --> Retry: ymir_retry_needed
+    Errored --> Attention: ymir_needs_attention
     Retry --> New: Retry Processing
     Merged --> [*]
     Triaged --> [*]
@@ -30,7 +30,7 @@ stateDiagram-v2
 flowchart TD
     FETCH[Jira Issue Fetcher]
 
-    FETCH -->|No jötnar labels<br/>OR jotnar_retry_needed| TRIAGE[triage_queue]
+    FETCH -->|No Ymir labels<br/>OR ymir_retry_needed| TRIAGE[triage_queue]
 
     TRIAGE --> TRIAGE_AGENT[Triage Agent]
 
@@ -68,58 +68,58 @@ flowchart TD
 
 | Label | Added When | Removed When | Next State |
 |-------|------------|--------------|------------|
-| `jotnar_triaged_rebase` | Triage resolves as rebase | On retry (all labels cleared) | `jotnar_rebased` or `jotnar_rebase_failed` |
-| `jotnar_triaged_backport` | Triage resolves as backport | On retry (all labels cleared) | `jotnar_backported` or `jotnar_backport_failed` |
-| `jotnar_triaged` | Triage resolves as open-ended-analysis | On retry (all labels cleared) | Terminal state |
-| `jotnar_rebased` | Rebase success | Never | `jotnar_merged` |
-| `jotnar_backported` | Backport success | Never | `jotnar_merged` |
-| `jotnar_merged` | MR merged | Never | Final state |
+| `ymir_triaged_rebase` | Triage resolves as rebase | On retry (all labels cleared) | `ymir_rebased` or `ymir_rebase_failed` |
+| `ymir_triaged_backport` | Triage resolves as backport | On retry (all labels cleared) | `ymir_backported` or `ymir_backport_failed` |
+| `ymir_triaged` | Triage resolves as open-ended-analysis | On retry (all labels cleared) | Terminal state |
+| `ymir_rebased` | Rebase success | Never | `ymir_merged` |
+| `ymir_backported` | Backport success | Never | `ymir_merged` |
+| `ymir_merged` | MR merged | Never | Final state |
 
 ### Error Labels
 
 | Label | Meaning | Blocks Retry? | Action |
 |-------|---------|---------------|--------|
-| `jotnar_needs_attention` | Human intervention needed | ✅ Yes | Fix issue, remove label, add `jotnar_retry_needed` |
-| `jotnar_triage_errored` | Triage failed | ✅ Yes | Check error_list |
-| `jotnar_rebase_errored` | Rebase error | ✅ Yes | Check Jira comment |
-| `jotnar_backport_errored` | Backport error | ✅ Yes | Check Jira comment |
-| `jotnar_rebase_failed` | Rebase unsuccessful | ❌ No | May auto-retry |
-| `jotnar_backport_failed` | Backport unsuccessful | ❌ No | May auto-retry |
+| `ymir_needs_attention` | Human intervention needed | ✅ Yes | Fix issue, remove label, add `ymir_retry_needed` |
+| `ymir_triage_errored` | Triage failed | ✅ Yes | Check error_list |
+| `ymir_rebase_errored` | Rebase error | ✅ Yes | Check Jira comment |
+| `ymir_backport_errored` | Backport error | ✅ Yes | Check Jira comment |
+| `ymir_rebase_failed` | Rebase unsuccessful | ❌ No | May auto-retry |
+| `ymir_backport_failed` | Backport unsuccessful | ❌ No | May auto-retry |
 
 ### Control Labels
 
 | Label | Purpose | Effect |
 |-------|---------|--------|
-| `jotnar_retry_needed` | Trigger retry | Forces reprocessing |
-| `jotnar_triaged` | Triage completed, no automated follow-up | Terminal state |
-| `jotnar_fusa` | Functional Safety | Requires maintainer review |
+| `ymir_retry_needed` | Trigger retry | Forces reprocessing |
+| `ymir_triaged` | Triage completed, no automated follow-up | Terminal state |
+| `ymir_fusa` | Functional Safety | Requires maintainer review |
 
 ## Queue Types Summary
 
 | Queue | Type | Triggers | Labels Added | Status |
 |-------|------|----------|--------------|--------|
 | `triage_queue` | Input | No labels OR retry_needed | - | Active |
-| `rebase_queue_c9s` | Input | Resolution=REBASE, RHEL 8/9 | `jotnar_triaged_rebase` | Active (AUTO_CHAIN only) |
-| `rebase_queue_c10s` | Input | Resolution=REBASE, RHEL 10+ | `jotnar_triaged_rebase` | Active (AUTO_CHAIN only) |
-| `backport_queue_c9s` | Input | Resolution=BACKPORT, RHEL 8/9 | `jotnar_triaged_backport` | Active (AUTO_CHAIN only) |
-| `backport_queue_c10s` | Input | Resolution=BACKPORT, RHEL 10+ | `jotnar_triaged_backport` | Active (AUTO_CHAIN only) |
-| `rebase_queue` | Input | (Not actively enqueued) | `jotnar_triaged_rebase` | Legacy (checked for deduplication) |
-| `backport_queue` | Input | (Not actively enqueued) | `jotnar_triaged_backport` | Legacy (checked for deduplication) |
-| `clarification_needed_queue` | Input | Resolution=CLARIFICATION | `jotnar_needs_attention` | Active (AUTO_CHAIN only) |
-| `error_list` | Output | Any error | `jotnar_*_errored` | Active |
-| `open_ended_analysis_list` | Output | Resolution=OPEN_ENDED_ANALYSIS | `jotnar_triaged` | Active (AUTO_CHAIN only) |
-| `completed_rebase_list` | Output | Rebase success | `jotnar_rebased` | Active |
-| `completed_backport_list` | Output | Backport success | `jotnar_backported` | Active |
+| `rebase_queue_c9s` | Input | Resolution=REBASE, RHEL 8/9 | `ymir_triaged_rebase` | Active (AUTO_CHAIN only) |
+| `rebase_queue_c10s` | Input | Resolution=REBASE, RHEL 10+ | `ymir_triaged_rebase` | Active (AUTO_CHAIN only) |
+| `backport_queue_c9s` | Input | Resolution=BACKPORT, RHEL 8/9 | `ymir_triaged_backport` | Active (AUTO_CHAIN only) |
+| `backport_queue_c10s` | Input | Resolution=BACKPORT, RHEL 10+ | `ymir_triaged_backport` | Active (AUTO_CHAIN only) |
+| `rebase_queue` | Input | (Not actively enqueued) | `ymir_triaged_rebase` | Legacy (checked for deduplication) |
+| `backport_queue` | Input | (Not actively enqueued) | `ymir_triaged_backport` | Legacy (checked for deduplication) |
+| `clarification_needed_queue` | Input | Resolution=CLARIFICATION | `ymir_needs_attention` | Active (AUTO_CHAIN only) |
+| `error_list` | Output | Any error | `ymir_*_errored` | Active |
+| `open_ended_analysis_list` | Output | Resolution=OPEN_ENDED_ANALYSIS | `ymir_triaged` | Active (AUTO_CHAIN only) |
+| `completed_rebase_list` | Output | Rebase success | `ymir_rebased` | Active |
+| `completed_backport_list` | Output | Backport success | `ymir_backported` | Active |
 
 ## Deduplication Logic
 
-**Note:** The Jira Issue Fetcher only decides whether to queue an issue for processing based on labels. The actual label cleanup (including removal of `jotnar_retry_needed`) happens in the Triage Agent after it consumes the task from the queue.
+**Note:** The Jira Issue Fetcher only decides whether to queue an issue for processing based on labels. The actual label cleanup (including removal of `ymir_retry_needed`) happens in the Triage Agent after it consumes the task from the queue.
 
 ```mermaid
 flowchart TD
     START[Jira Issue Fetcher<br/>Found issue]
-    CHECK{Has any<br/>jötnar_* label?}
-    RETRY{Has<br/>jotnar_retry_needed?}
+    CHECK{Has any<br/>ymir_* label?}
+    RETRY{Has<br/>ymir_retry_needed?}
 
     START --> CHECK
     CHECK -->|No| ADD[Add to triage_queue]
@@ -128,7 +128,7 @@ flowchart TD
     RETRY -->|No| SKIP[Skip - already processed]
 
     ADD --> TRIAGE_PROCESS[Triage Agent processes issue]
-    TRIAGE_PROCESS --> CLEANUP[Triage Agent removes<br/>all jötnar_* labels]
+    TRIAGE_PROCESS --> CLEANUP[Triage Agent removes<br/>all ymir_* labels]
 
     style ADD fill:#c8e6c9
     style SKIP fill:#ffcdd2

--- a/mcp_server/gitlab_tools.py
+++ b/mcp_server/gitlab_tools.py
@@ -194,14 +194,14 @@ async def open_merge_request(
             # It can take some time for the MR to be available via API
             pr = await asyncio.to_thread(project.parent.get_pr, pr.id)
             # by default, set this label on a newly created MR so we can inspect it ASAP
-            await asyncio.to_thread(pr.add_label, "jotnar_needs_attention")
+            await asyncio.to_thread(pr.add_label, "ymir_needs_attention")
             break
         except OgrException as ex:
             logger.info("Failed to add label on attempt %d/5, retrying. Error: %s", attempt + 1, ex)
             await asyncio.sleep(0.5 * (2 ** attempt))
     else:
         logger.error("MR %s does not appear to exist after creation", pr)
-        logger.error("Unable to set label 'jotnar_needs_attention' on the MR")
+        logger.error("Unable to set label 'ymir_needs_attention' on the MR")
     return pr.url, is_brand_new_mr
 
 

--- a/mcp_server/tests/unit/test_gitlab_tools.py
+++ b/mcp_server/tests/unit/test_gitlab_tools.py
@@ -84,7 +84,7 @@ async def test_open_merge_request():
     flexmock(GitlabService).should_receive("get_project_from_url").with_args(
         url=fork_url
     ).and_return(flexmock(create_pr=lambda title, body, target, source: pr_mock, parent=flexmock(get_pr=lambda id: pr_mock)))
-    pr_mock.should_receive("add_label").with_args("jotnar_needs_attention").once()
+    pr_mock.should_receive("add_label").with_args("ymir_needs_attention").once()
     assert (
         await open_merge_request(
             fork_url=fork_url,
@@ -121,7 +121,7 @@ async def test_open_merge_request_with_existing_mr():
             parent=flexmock(get_pr_list=lambda: [pr_mock], get_pr=lambda id: pr_mock),
         )
     )
-    pr_mock.should_receive("add_label").with_args("jotnar_needs_attention").once()
+    pr_mock.should_receive("add_label").with_args("ymir_needs_attention").once()
     assert (
         await open_merge_request(
             fork_url=fork_url,
@@ -192,11 +192,11 @@ async def test_push_to_remote_repository():
 )
 @pytest.mark.asyncio
 async def test_add_merge_request_labels(merge_request_url, expected_project_path):
-    labels = ["jotnar_fusa", "test-label"]
+    labels = ["ymir_fusa", "test-label"]
 
     # Mock the merge request object
     mr_mock = flexmock()
-    mr_mock.should_receive("add_label").with_args("jotnar_fusa").once()
+    mr_mock.should_receive("add_label").with_args("ymir_fusa").once()
     mr_mock.should_receive("add_label").with_args("test-label").once()
 
     # Mock the project object
@@ -374,7 +374,7 @@ async def test_create_merge_request_checklist_duplicate():
     merge_request_url = "https://gitlab.com/redhat/rhel/rpms/bash/-/merge_requests/123"
 
     # Mock an existing note with the checklist identifier
-    existing_note = flexmock(body="# Jötnar MR Review Checklist\n\nSome checklist content")
+    existing_note = flexmock(body="# Ymir MR Review Checklist\n\nSome checklist content")
 
     flexmock(GitlabService).should_receive("get_project_from_url").with_args(
         url=merge_request_url.rsplit("/-/merge_requests/", 1)[0],

--- a/monitoring.md
+++ b/monitoring.md
@@ -1,4 +1,4 @@
-# Jötnar Agent Monitoring and Performance Review
+# Ymir Agent Monitoring and Performance Review
 
 ## Overview
 
@@ -28,7 +28,7 @@ Weekly rotating role ([definition](https://github.com/packit/agile/issues/972)) 
 ### Weekly Review Artifacts
 The team primarily tracks these items using Jira dashboards:
 - Newly triaged issues and CVEs
-- Issues with `jotnar_needs_attention` or `jotnar_*_errored` labels
+- Issues with `ymir_needs_attention` or `ymir_*_errored` labels
 - Z-stream issues in current batches
 - MR quality, correctness, and completeness
 - Agent decision accuracy (triage, patch selection, severity)
@@ -40,7 +40,7 @@ The team primarily tracks these items using Jira dashboards:
 ## Anomaly Detection
 
 ### Automated Signals
-- **Labels**: `jotnar_needs_attention`, `jotnar_*_errored`, `jotnar_cant_do`
+- **Labels**: `ymir_needs_attention`, `ymir_*_errored`, `ymir_cant_do`
 - **Build/Test**: CI failures, ROG gating failures, test regressions
 
 ### Manual Review Focus
@@ -86,10 +86,10 @@ The team reviews agent results during weekly sessions, identifies failing use ca
 ### Common Labels
 | Label | Meaning | Action |
 |-------|---------|--------|
-| `jotnar_needs_attention` | Requires team review | Weekly priority |
-| `jotnar_*_errored` | Workflow failed | Review if >3 attempts |
-| `jotnar_cant_do` | Agent cannot handle | Human takeover |
-| `jotnar_fusa` | RHIVOS FuSa package | Maintainer approval |
+| `ymir_needs_attention` | Requires team review | Weekly priority |
+| `ymir_*_errored` | Workflow failed | Review if >3 attempts |
+| `ymir_cant_do` | Agent cannot handle | Human takeover |
+| `ymir_fusa` | RHIVOS FuSa package | Maintainer approval |
 
 ### Links
 - [Skald Role](https://github.com/packit/agile/issues/972)

--- a/scripts/test_jira_cloud_uat.py
+++ b/scripts/test_jira_cloud_uat.py
@@ -159,29 +159,29 @@ Reproduced failed tests with previous build libtiff-4.4.0-13.el9:
             print(f"Comment update verified")
 
     # Test 15: Test get_issue_by_jotnar_tag
-    print("\n[15/15] Testing Jotnar tag search")
-    # create an issue with a Jotnar tag from the start
+    print("\n[15/15] Testing Ymir tag search")
+    # create an issue with a Ymir tag from the start
     tag = JotnarTag(type="needs_attention", resource="erratum", id="TEST-456")
     tag_str = str(tag)
 
     tagged_issue_key = create_issue(
         project=project,
-        summary="[TEST] UAT - Issue with Jotnar Tag",
-        description=f"Test issue for Jotnar tag search\n\n{tag_str}",
+        summary="[TEST] UAT - Issue with Ymir Tag",
+        description=f"Test issue for Ymir tag search\n\n{tag_str}",
         labels=["uat_test", "jotnar_tag_test"],
         components=["jotnar-package-automation"]
     )
-    print(f"Created issue with Jotnar tag: {tagged_issue_key}")
+    print(f"Created issue with Ymir tag: {tagged_issue_key}")
 
     # wait for Jira to index
     time.sleep(3)
 
-    # try to find jotnar issue by tag
+    # try to find Ymir issue by tag
     found_issue = get_issue_by_jotnar_tag(project, tag, with_label="jotnar_tag_test")
     if found_issue:
-        print(f" Found issue with jotnar tag: {found_issue.key}")
+        print(f" Found issue with Ymir tag: {found_issue.key}")
     else:
-        print(f"issue not found by jotnar tag")
+        print(f"issue not found by Ymir tag")
 
 
 if __name__ == "__main__":

--- a/supervisor/collect.py
+++ b/supervisor/collect.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 CURRENT_ISSUES_JQL = """
 project = RHEL AND AssignedTeam = rhel-jotnar
 AND status in ('New', 'In Progress', 'Integration', 'Release Pending')
-AND ('Errata Link' is not EMPTY OR labels in ('ymir_backported', 'ymir_rebased', 'ymir_merged'))
-AND labels != ymir_needs_attention
+AND ('Errata Link' is not EMPTY OR labels in ('ymir_backported', 'ymir_rebased', 'ymir_merged', 'jotnar_backported', 'jotnar_rebased', 'jotnar_merged'))
+AND labels != ymir_needs_attention AND labels != jotnar_needs_attention
 """
 
 

--- a/supervisor/collect.py
+++ b/supervisor/collect.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 CURRENT_ISSUES_JQL = """
 project = RHEL AND AssignedTeam = rhel-jotnar
 AND status in ('New', 'In Progress', 'Integration', 'Release Pending')
-AND ('Errata Link' is not EMPTY OR labels in ('jotnar_backported', 'jotnar_rebased', 'jotnar_merged'))
-AND labels != jotnar_needs_attention
+AND ('Errata Link' is not EMPTY OR labels in ('ymir_backported', 'ymir_rebased', 'ymir_merged'))
+AND labels != ymir_needs_attention
 """
 
 

--- a/supervisor/constants.py
+++ b/supervisor/constants.py
@@ -7,7 +7,7 @@ GITLAB_GROUPS = ["rhel/rpms", "centos-stream/rpms"]
 # Timeout for post-push testing (e.g., CAT tests) after stage push completes
 POST_PUSH_TESTING_TIMEOUT = timedelta(hours=3)
 POST_PUSH_TESTING_TIMEOUT_STR = "3 hours"
-# Defines the Jotnar bot's user identity for Errata and Jira
+# Defines the Ymir bot's user identity for Errata and Jira
 ERRATA_JOTNAR_BOT_EMAIL = "jotnar-bot@IPA.REDHAT.COM"
 JIRA_JOTNAR_BOT_EMAIL = "jotnar+bot@redhat.com"
 JIRA_JOTNAR_TEAM = "rhel-jotnar"

--- a/supervisor/erratum_handler.py
+++ b/supervisor/erratum_handler.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 # If there is an existing issue for the tag and it's not closed, we'll reuse
 # it, but if the existing issue is closed, we'll create a new one.
 #
-# The string form of the tag is "::: JOTNAR needs_attention E: 123456 :::"
+# The string form of the tag is "::: YMIR needs_attention E: 123456 :::"
 
 
 def _needs_attention_tag(erratum_id: int) -> JotnarTag:
@@ -97,7 +97,7 @@ def compare_file_lists(
     is_matched = current_build.package_file_list == previous_build.package_file_list
 
     comment = (
-        f"jotnar-product-listings-checked({current_build.nvr})\n\n"
+        f"ymir-product-listings-checked({current_build.nvr})\n\n"
         f"Compared the file lists for {current_build.nvr} to the file lists for\n"
         f"{previous_build.nvr} in {get_erratum_advisory_url(previous_erratum_id)} -\n"
     )
@@ -215,7 +215,7 @@ class ErratumHandler(WorkItemHandler):
                 for package, cur_build in cur_build_map.root.items():
                     nvr = cur_build.nvr
                     if not erratum_has_magic_string_in_comments(
-                        self.erratum.id, f"jotnar-product-listings-checked({nvr})"
+                        self.erratum.id, f"ymir-product-listings-checked({nvr})"
                     ):
                         prev_erratum_id, _ = get_previous_erratum(
                             self.erratum.id, package
@@ -240,7 +240,7 @@ class ErratumHandler(WorkItemHandler):
                         else:
                             erratum_add_comment(
                                 self.erratum.id,
-                                f"jotnar-product-listings-checked({nvr})\n\n"
+                                f"ymir-product-listings-checked({nvr})\n\n"
                                 "No previous erratum for this package - no need to check package file list change.",
                                 dry_run=self.dry_run,
                             )
@@ -319,7 +319,7 @@ class ErratumHandler(WorkItemHandler):
             )
 
         related_issues = erratum_get_issues(erratum)
-        # Try to change the ownership to Jotnar if the erratum was not owned by Jotnar
+        # Try to change the ownership to Ymir if the erratum was not owned by Ymir
         if (
             erratum.assigned_to_email != ERRATA_JOTNAR_BOT_EMAIL
             or erratum.package_owner_email != ERRATA_JOTNAR_BOT_EMAIL
@@ -327,14 +327,14 @@ class ErratumHandler(WorkItemHandler):
             if jotnar_owns_all_issues(related_issues):
                 erratum_change_ownership(erratum.id, ERRATA_JOTNAR_BOT_EMAIL)
                 return WorkflowResult(
-                    status=f"Changed ownership of erratum {erratum.id} to Jotnar bot, re-processing",
+                    status=f"Changed ownership of erratum {erratum.id} to Ymir bot, re-processing",
                     reschedule_in=0,
                 )
             else:
                 return self.resolve_flag_attention(
-                    "Erratum has issues not owned by Project Jötnar. Please coordinate with QA Contact for these "
+                    "Erratum has issues not owned by Project Ymir. Please coordinate with QA Contact for these "
                     "issues to move those issues to Release Pending or change the Assigned Team for the issue to "
-                    "rhel-jotnar. No further action will be taken on the erratum until jotnar_needs_attention is "
+                    "rhel-jotnar. No further action will be taken on the erratum until ymir_needs_attention is "
                     "cleared on this issue."
                 )
 

--- a/supervisor/erratum_handler.py
+++ b/supervisor/erratum_handler.py
@@ -214,8 +214,15 @@ class ErratumHandler(WorkItemHandler):
                 mismatch_packages = []
                 for package, cur_build in cur_build_map.root.items():
                     nvr = cur_build.nvr
-                    if not erratum_has_magic_string_in_comments(
-                        self.erratum.id, f"ymir-product-listings-checked({nvr})"
+                    if not (
+                        erratum_has_magic_string_in_comments(
+                            self.erratum.id,
+                            f"ymir-product-listings-checked({nvr})",
+                        )
+                        or erratum_has_magic_string_in_comments(
+                            self.erratum.id,
+                            f"jotnar-product-listings-checked({nvr})",
+                        )
                     ):
                         prev_erratum_id, _ = get_previous_erratum(
                             self.erratum.id, package

--- a/supervisor/issue_handler.py
+++ b/supervisor/issue_handler.py
@@ -109,7 +109,7 @@ class IssueHandler(WorkItemHandler):
 
         add_issue_label(
             self.issue.key,
-            "jotnar_reproducing_tests",
+            "ymir_reproducing_tests",
             issue_comment,
             dry_run=self.dry_run,
         )
@@ -120,7 +120,7 @@ class IssueHandler(WorkItemHandler):
         baseline_tests = BaselineTests.load_from_issue(self.issue)
         if baseline_tests is None:
             return self.resolve_flag_attention(
-                "Issue has jotnar_reproducing_tests label but cannot parse baseline tests from comments"
+                "Issue has ymir_reproducing_tests label but cannot parse baseline tests from comments"
             )
 
         if not baseline_tests.settled():
@@ -133,7 +133,7 @@ class IssueHandler(WorkItemHandler):
         issue_comment = baseline_tests.format_issue_comment(include_attachments=True)
         remove_issue_label(
             self.issue.key,
-            "jotnar_reproducing_tests",
+            "ymir_reproducing_tests",
             dry_run=self.dry_run,
         )
 
@@ -153,12 +153,12 @@ class IssueHandler(WorkItemHandler):
         )
 
     def label_merge_if_needed(self):
-        """Add the jotnar_merged label to the issue
+        """Add the ymir_merged label to the issue
 
-        This function will only add jotnar_merged label to the issue if it matches
+        This function will only add ymir_merged label to the issue if it matches
         all the following requirements:
-            1. Issue has either jotnar_backported or jotnar_rebased label.
-            2. Issue doesn't have jotnar_merged label.
+            1. Issue has either ymir_backported or ymir_rebased label.
+            2. Issue doesn't have ymir_merged label.
             3. A merged MR is found on Gitlab.
 
         Returns:
@@ -272,7 +272,7 @@ class IssueHandler(WorkItemHandler):
                 "happened before the gitlab pull request was merged"
             )
 
-        # We still want the jotnar_merged label for JIRA dashboards even if we never saw
+        # We still want the ymir_merged label for JIRA dashboards even if we never saw
         # the merged merge request in the pre-errata-creation state.
         self.label_merge_if_needed()
 
@@ -283,7 +283,7 @@ class IssueHandler(WorkItemHandler):
                     "Preliminary testing has passed, moving to Integration",
                 )
             case IssueStatus.INTEGRATION:
-                if "jotnar_reproducing_tests" in issue.labels:
+                if "ymir_reproducing_tests" in issue.labels:
                     return await self.resolve_check_reproduction()
 
                 related_erratum = get_erratum_for_link(issue.errata_link, full=True)
@@ -362,13 +362,13 @@ class IssueHandler(WorkItemHandler):
             and not self.ignore_needs_attention
         ):
             return self.resolve_remove_work_item(
-                "Issue has the jotnar_needs_attention label"
+                "Issue has the ymir_needs_attention label"
             )
 
         if len(issue.components) != 1:
             return self.resolve_flag_attention(
                 "This issue has multiple components. "
-                "Jotnar only handles issues with single component currently."
+                "Ymir only handles issues with single component currently."
             )
 
         if issue.errata_link is None:

--- a/supervisor/jira_utils.py
+++ b/supervisor/jira_utils.py
@@ -419,7 +419,11 @@ def get_issue_by_jotnar_tag(
     project: str, tag: JotnarTag, full: bool = False, with_label: str | None = None
 ) -> Issue | FullIssue | None:
     max_results = 2
-    jql = f'project = {project} AND status NOT IN (Done, Closed) AND description ~ "\\"{tag}\\""'
+    # Match both current (YMIR) and legacy (JOTNAR) tag formats
+    description_filter = " OR ".join(
+        f'description ~ "\\"{t}\\""' for t in tag.all_formats()
+    )
+    jql = f"project = {project} AND status NOT IN (Done, Closed) AND ({description_filter})"
     if with_label is not None:
         jql += f' AND labels = "{with_label}"'
 

--- a/supervisor/jira_utils.py
+++ b/supervisor/jira_utils.py
@@ -591,10 +591,10 @@ def change_issue_status(
 
 def format_attention_message(why: str) -> str:
     return (
-        "{panel:title=Project Jötnar: ATTENTION NEEDED|"
+        "{panel:title=Project Ymir: ATTENTION NEEDED|"
         "borderStyle=solid|borderColor=#CC0000|titleBGColor=#FFF5F5|bgColor=#FFFEF0}\n"
         f"{why}\n\n"
-        "Please resolve this and remove the {{jotnar_needs_attention}} flag.\n"
+        "Please resolve this and remove the {{ymir_needs_attention}} flag.\n"
         "{panel}"
     )
 

--- a/supervisor/main.py
+++ b/supervisor/main.py
@@ -256,7 +256,7 @@ def main(
     debug: bool = typer.Option(False, help="Enable debug mode."),
     dry_run: bool = typer.Option(False, help="Don't actually change anything."),
     ignore_needs_attention: bool = typer.Option(
-        False, help="Process issues or errata flagged with jotnar_needs_attention."
+        False, help="Process issues or errata flagged with ymir_needs_attention."
     ),
 ):
     if debug:

--- a/supervisor/supervisor_types.py
+++ b/supervisor/supervisor_types.py
@@ -188,8 +188,17 @@ class JotnarTag(BaseModel):
     resource: Literal["erratum"]
     id: str
 
+    _LEGACY_PREFIXES = ("JOTNAR",)
+
     def __str__(self) -> str:
         return f"::: YMIR {self.type} E: {self.id.strip()} :::"
+
+    def all_formats(self) -> list[str]:
+        """Current and legacy tag strings for backwards-compatible search."""
+        return [str(self)] + [
+            f"::: {p} {self.type} E: {self.id.strip()} :::"
+            for p in self._LEGACY_PREFIXES
+        ]
 
 
 class TestingState(StrEnum):

--- a/supervisor/supervisor_types.py
+++ b/supervisor/supervisor_types.py
@@ -189,7 +189,7 @@ class JotnarTag(BaseModel):
     id: str
 
     def __str__(self) -> str:
-        return f"::: JOTNAR {self.type} E: {self.id.strip()} :::"
+        return f"::: YMIR {self.type} E: {self.id.strip()} :::"
 
 
 class TestingState(StrEnum):

--- a/supervisor/testing_analyst.py
+++ b/supervisor/testing_analyst.py
@@ -41,8 +41,8 @@ class OutputSchema(BaseModel):
 
 
 TEMPLATE_COMMON = """\
-You are the testing analyst agent for Project Jötnar. Comments that tag
-[~jotnar-project] in JIRA issues are directed to you and other Jötnar agents
+You are the testing analyst agent for Project Ymir. Comments that tag
+[~jotnar-project] in JIRA issues are directed to you and other Ymir agents
 sharing the same account—pay close attention to these.
 
 Your task is to analyze a RHEL JIRA issue with a fix attached and determine


### PR DESCRIPTION
Replace all user-facing references from "Jotnar"/"Jötnar" to "Ymir" across 29 files. This covers:

- Jira label values: jotnar_* → ymir_* (14 labels in common/constants.py, propagated to all code and tests referencing them)
- MR checklist, commit messages, agent prompts, log messages, CLI help
- Documentation: README, workflow routing, data flow diagrams, monitoring
- Containerfile test identity: email and user name
- JotnarTag format string: ::: JOTNAR → ::: YMIR
- I_AM_JOTNAR → I_AM_YMIR constant rename

Other Python identifiers (JotnarTag, etc.) and external system references (accounts, emails, Slack, registry, keytabs) are unchanged.


TODO:

- [x] confirm that supervisor changes don't have impact
