### PR TITLE
Update custom Jira fields to the new Jira Cloud instance ids

### DIFF
--- a/mcp_server/jira_tools.py
+++ b/mcp_server/jira_tools.py
@@ -25,9 +25,9 @@ from common.constants import JIRA_SEARCH_PATH
 from common.utils import get_jira_auth_headers
 
 # Jira custom field IDs
-SEVERITY_CUSTOM_FIELD = "customfield_12316142"
-TARGET_END_CUSTOM_FIELD = "customfield_12313942"
-EMBARGO_CUSTOM_FIELD = "customfield_12324750"
+SEVERITY_CUSTOM_FIELD = "customfield_10840"
+TARGET_END_CUSTOM_FIELD = "customfield_10023"
+EMBARGO_CUSTOM_FIELD = "customfield_10860"
 
 
 RH_EMPLOYEE_GROUP = "Red Hat Employee"
@@ -143,15 +143,17 @@ async def set_jira_fields(
             return f"No fields needed updating in {issue_key}"
 
     async with aiohttpClientSession() as session:
-        try:
-            async with session.put(
-                urljoin(os.getenv("JIRA_URL"), f"rest/api/3/issue/{issue_key}"),
-                json={"fields": fields},
-                headers=get_jira_auth_headers(),
-            ) as response:
-                response.raise_for_status()
-        except aiohttp.ClientError as e:
-            raise ToolError(f"Failed to set the specified fields: {e}") from e
+        async with session.put(
+            urljoin(os.getenv("JIRA_URL"), f"rest/api/3/issue/{issue_key}"),
+            json={"fields": fields},
+            headers=get_jira_auth_headers(),
+        ) as response:
+            if not response.ok:
+                body = await response.text()
+                raise ToolError(
+                    f"Failed to set the specified fields on {issue_key} "
+                    f"(HTTP {response.status}): {body}"
+                )
 
     return f"Successfully updated {issue_key}"
 

--- a/mcp_server/jira_tools.py
+++ b/mcp_server/jira_tools.py
@@ -143,17 +143,20 @@ async def set_jira_fields(
             return f"No fields needed updating in {issue_key}"
 
     async with aiohttpClientSession() as session:
-        async with session.put(
-            urljoin(os.getenv("JIRA_URL"), f"rest/api/3/issue/{issue_key}"),
-            json={"fields": fields},
-            headers=get_jira_auth_headers(),
-        ) as response:
-            if not response.ok:
-                body = await response.text()
-                raise ToolError(
-                    f"Failed to set the specified fields on {issue_key} "
-                    f"(HTTP {response.status}): {body}"
-                )
+        try:
+            async with session.put(
+                urljoin(os.getenv("JIRA_URL"), f"rest/api/3/issue/{issue_key}"),
+                json={"fields": fields},
+                headers=get_jira_auth_headers(),
+            ) as response:
+                if not response.ok:
+                    body = await response.text()
+                    raise ToolError(
+                        f"Failed to set the specified fields on {issue_key} "
+                        f"(HTTP {response.status}): {body}"
+                    )
+        except aiohttp.ClientError as e:
+            raise ToolError(f"Failed to set the specified fields: {e}") from e
 
     return f"Successfully updated {issue_key}"
 

--- a/mcp_server/tests/unit/test_jira_tools.py
+++ b/mcp_server/tests/unit/test_jira_tools.py
@@ -74,18 +74,18 @@ async def test_get_jira_details():
         ),
         (
             dict(severity=Severity.LOW),
-            {"fields": {"customfield_12316142": {"value": None}}},
-            {"customfield_12316142": {"value": Severity.LOW.value}},
+            {"fields": {"customfield_10840": {"value": None}}},
+            {"customfield_10840": {"value": Severity.LOW.value}},
         ),
         (
             dict(target_end=datetime.date(2024, 12, 31)),
-            {"fields": {"customfield_12313942": {"value": None}}},
-            {"customfield_12313942": "2024-12-31"},
+            {"fields": {"customfield_10023": {"value": None}}},
+            {"customfield_10023": "2024-12-31"},
         ),
         (
             dict(fix_versions=["rhel-1.2.3"], severity=Severity.CRITICAL),
-            {"fields": {"fixVersions": [], "customfield_12316142": {"value": None}}},
-            {"fixVersions": [{"name": "rhel-1.2.3"}], "customfield_12316142": {"value": Severity.CRITICAL.value}},
+            {"fields": {"fixVersions": [], "customfield_10840": {"value": None}}},
+            {"fixVersions": [{"name": "rhel-1.2.3"}], "customfield_10840": {"value": Severity.CRITICAL.value}},
         ),
     ],
 )
@@ -106,7 +106,7 @@ async def test_set_jira_fields(args, current_fields, expected_fields):
     async def put(url, json, headers):
         assert url.endswith(f"rest/api/3/issue/{issue_key}")
         assert json.get("fields") == expected_fields
-        yield flexmock(raise_for_status=lambda: None)
+        yield flexmock(ok=True)
 
     flexmock(aiohttp.ClientSession).should_receive("get").replace_with(get)
     flexmock(aiohttp.ClientSession).should_receive("put").replace_with(put)


### PR DESCRIPTION
After migration to the new Jira Cloud instance there is been a change to custom Jira fields ids which this commit updates accordingly. There is also better error reporting if there are any further changes to those custom fields in the future to make troubleshooting easier.
 