### PR TITLE
Enable Anthropic prompt caching for all agents

### DIFF
--- a/openshift/configmap-agents-env.yml
+++ b/openshift/configmap-agents-env.yml
@@ -10,6 +10,9 @@ data:
   # The maximum number of iterations for the agent execution.
   # This was increased from 140 to handle complex rebases and backports.
   BEEAI_MAX_ITERATIONS: "255"
+  # Anthropic prompt caching is enabled by default for Claude models.
+  # Set to "true" to disable if needed.
+  # DISABLE_PROMPT_CACHING: "true"
 immutable: false
 kind: ConfigMap
 metadata:

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -32,6 +32,7 @@ from ymir.agents.observability import setup_observability
 from ymir.agents.package_update_steps import PackageUpdateState, PackageUpdateStep
 from ymir.agents.utils import (
     check_subprocess,
+    enable_prompt_caching,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -960,6 +961,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
+    enable_prompt_caching()
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     max_build_attempts = int(os.getenv("MAX_BUILD_ATTEMPTS", "10"))

--- a/ymir/agents/merge_request_agent.py
+++ b/ymir/agents/merge_request_agent.py
@@ -29,6 +29,7 @@ from ymir.agents.build_agent import get_prompt as get_build_prompt
 from ymir.agents.constants import I_AM_YMIR
 from ymir.agents.observability import setup_observability
 from ymir.agents.utils import (
+    enable_prompt_caching,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -190,6 +191,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
+    enable_prompt_caching()
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     max_build_attempts = int(os.getenv("MAX_BUILD_ATTEMPTS", "10"))

--- a/ymir/agents/preliminary_testing_agent.py
+++ b/ymir/agents/preliminary_testing_agent.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 
 from ymir.agents.observability import setup_observability
 from ymir.agents.utils import (
+    enable_prompt_caching,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -448,6 +449,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
+    enable_prompt_caching()
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     ignore_needs_attention = os.getenv("IGNORE_NEEDS_ATTENTION", "false").lower() == "true"

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -30,6 +30,7 @@ from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
 from ymir.agents.package_update_steps import PackageUpdateState, PackageUpdateStep
 from ymir.agents.utils import (
+    enable_prompt_caching,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -210,6 +211,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
+    enable_prompt_caching()
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     max_build_attempts = int(os.getenv("MAX_BUILD_ATTEMPTS", "10"))

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -15,6 +15,7 @@ from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
 from ymir.agents.package_update_steps import PackageUpdateState
 from ymir.agents.utils import (
+    enable_prompt_caching,
     get_agent_execution_config,
     mcp_tools,
     render_prompt,
@@ -38,6 +39,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
+    enable_prompt_caching()
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
 

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 import ymir.agents.tasks as tasks
 from ymir.agents.observability import setup_observability
 from ymir.agents.utils import (
+    enable_prompt_caching,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -845,6 +846,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
+    enable_prompt_caching()
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     auto_chain = os.getenv("AUTO_CHAIN", "true").lower() == "true"

--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+import beeai_framework.adapters.litellm.chat as _chat_adapter
 from beeai_framework.agents.tool_calling.utils import ToolCallCheckerConfig
 from beeai_framework.backend import ChatModel, ChatModelParameters
 from beeai_framework.template import PromptTemplate
@@ -15,6 +16,8 @@ from ymir.common.utils import (  # noqa: F401 — re-exported for backward compa
 )
 
 logger = logging.getLogger(__name__)
+
+_prompt_caching_applied = False
 
 
 def get_chat_model() -> ChatModel:
@@ -61,6 +64,59 @@ def get_tool_call_checker_config() -> ToolCallCheckerConfig:
 def render_prompt(template: str, input: BaseModel) -> str:
     """Renders a prompt template with the specified input, according to its schema."""
     return PromptTemplate(template=template, schema=type(input)).render(input)
+
+
+def enable_prompt_caching() -> None:
+    """Inject Anthropic prompt caching on system messages.
+
+    Patches the ``acompletion`` reference inside BeeAI's LiteLLM adapter
+    so that every request to a Claude model carries ``cache_control`` on
+    its system message.  Enabled by default; set ``DISABLE_PROMPT_CACHING=true``
+    to turn off.
+
+    TODO: Remove after upgrading to BeeAI >= 0.1.79, which natively supports
+    cache_control_injection_points in RequirementAgent.
+    """
+    global _prompt_caching_applied
+    if _prompt_caching_applied:
+        return
+    if os.getenv("DISABLE_PROMPT_CACHING", "").lower() == "true":
+        return
+
+    _original_acompletion = _chat_adapter.acompletion
+
+    async def _acompletion_with_caching(*args, **kwargs):
+        model = str(kwargs.get("model") or (args[0] if args else ""))
+        if "claude" in model.lower():
+            for msg in kwargs.get("messages", []):
+                if msg.get("role") == "system":
+                    content = msg.get("content")
+                    if isinstance(content, str):
+                        msg["content"] = [
+                            {
+                                "type": "text",
+                                "text": content,
+                                "cache_control": {"type": "ephemeral"},
+                            }
+                        ]
+                    elif isinstance(content, list) and content and isinstance(content[-1], dict):
+                        content[-1]["cache_control"] = {"type": "ephemeral"}
+                    break
+        response = await _original_acompletion(*args, **kwargs)
+        if "claude" in model.lower():
+            usage = getattr(response, "usage", None)
+            if usage:
+                logger.info(
+                    "Prompt caching usage: prompt=%s, cache_creation=%s, cache_read=%s",
+                    getattr(usage, "prompt_tokens", None),
+                    getattr(usage, "cache_creation_input_tokens", None),
+                    getattr(usage, "cache_read_input_tokens", None),
+                )
+        return response
+
+    _chat_adapter.acompletion = _acompletion_with_caching
+    _prompt_caching_applied = True
+    logger.info("Prompt caching enabled for Anthropic models")
 
 
 def set_litellm_debug() -> None:


### PR DESCRIPTION
BeeAI 0.1.55 does not expose Anthropic's cache_control through its ChatModelParameters, and the native cache_control_injection_points support was only added in later versions (0.1.79+).  As a stopgap, we monkey-patch the acompletion reference that BeeAI's LiteLLM adapter calls at runtime to inject cache_control on system messages.

The patch targets beeai_framework.adapters.litellm.chat.acompletion specifically — not litellm.acompletion — because the adapter does `from litellm import acompletion` at import time, copying the function reference into its own module namespace.  Patching litellm's module dict would have no effect on the adapter's already-resolved reference.

The wrapper injects cache_control: {"type": "ephemeral"} on system messages for Claude models only, converting string content to the content-block format that Anthropic's API requires for cache markers. A module-level guard (_prompt_caching_applied) prevents double-wrapping if enable_prompt_caching() is called more than once.

Confirmed working via Vertex AI: cache_creation_input_tokens=5114 on first call, cache_read_input_tokens=5114 on subsequent calls within the same agent run.  This gives a 90% cost reduction on cached input tokens (~34% of total input per call for triage).

Enabled by default; opt out with DISABLE_PROMPT_CACHING=true.

This patch becomes redundant after upgrading to BeeAI >= 0.1.79, which natively injects cache_control_injection_points in RequirementAgent (caching both the system prompt and the last stable conversation message).  Remove this code after the bump.

Assisted-by: Claude Opus 4.6

