### PR TITLE
Add CVE applicability check to triage workflow

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -39,6 +39,11 @@ RUN dnf -y install --allowerasing \
       gawk \
       rsync \
       python3-tabulate \
+      go-srpm-macros \
+      python-srpm-macros \
+      pyproject-srpm-macros \
+      rust-toolset-srpm-macros \
+      perl-srpm-macros \
     && dnf clean all
 
 RUN pip3 install --no-cache-dir \

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -38,6 +38,11 @@ RUN dnf -y install --allowerasing \
       sed \
       gawk \
       rsync \
+      go-srpm-macros \
+      python-srpm-macros \
+      pyproject-srpm-macros \
+      rust-srpm-macros \
+      perl-srpm-macros \
     && dnf clean all
 
 # Create Python 3.11 virtual environment and install Python packages

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -925,37 +925,6 @@ async def create_backport_agent(
     )
 
 
-def get_unpacked_sources(local_clone: Path, package: str) -> Path:
-    """
-    Get a path to the root of extracted archive directory tree (referenced as TLD
-    in RPM documentation) for a given package.
-
-    That's the place where we'll initiate the backporting process.
-    """
-    with Specfile(local_clone / f"{package}.spec") as spec:
-        name = spec.expand("%{name}")
-        version = spec.expand("%{version}")
-        buildsubdir = spec.expand("%{buildsubdir}")
-    if "/" in buildsubdir:
-        # When %setup -n uses a nested path (e.g. libexpat-R_2_6_4/expat),
-        # use the archive root because some specs apply patches at that level
-        # via pushd/popd.  More details: https://github.com/packit/jotnar/issues/217
-        buildsubdir = buildsubdir.split("/")[0]
-
-    # RPM 4.20+ uses a per-build directory named %{NAME}-%{VERSION}-build
-    per_build_dir = local_clone / f"{name}-{version}-build"
-    sources_dir = per_build_dir / buildsubdir
-    if sources_dir.is_dir():
-        return sources_dir
-
-    # Older RPM versions unpack directly under _builddir
-    sources_dir = local_clone / buildsubdir
-    if sources_dir.is_dir():
-        return sources_dir
-
-    raise ValueError(f"Unpacked source directory does not exist: {sources_dir}")
-
-
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
@@ -1048,7 +1017,7 @@ async def main() -> None:
                     ]
                 await check_subprocess([*pkg_cmd, "sources"], cwd=state.local_clone)
                 await check_subprocess([*pkg_cmd, "prep"], cwd=state.local_clone)
-                state.unpacked_sources = get_unpacked_sources(state.local_clone, state.package)
+                state.unpacked_sources = tasks.get_unpacked_sources(state.local_clone, state.package)
                 for idx, upstream_patch in enumerate(state.upstream_patches):
                     patch_name = f"{state.jira_issue}-{idx}.patch"
                     content = await run_tool(

--- a/ymir/agents/cve_applicability_agent.py
+++ b/ymir/agents/cve_applicability_agent.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+from textwrap import dedent
+
+from beeai_framework.agents.requirement import RequirementAgent
+from beeai_framework.agents.requirement.requirements.conditional import (
+    ConditionalRequirement,
+)
+from beeai_framework.memory import UnconstrainedMemory
+from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
+from beeai_framework.tools import Tool
+from beeai_framework.tools.think import ThinkTool
+
+from ymir.agents.utils import get_chat_model, get_tool_call_checker_config
+from ymir.common.models import Resolution
+from ymir.tools.unprivileged.commands import RunShellCommandTool
+from ymir.tools.unprivileged.text import SearchTextTool, ViewTool
+
+
+def create_applicability_agent(
+    gateway_tools: list[Tool],
+    local_tool_options: dict,
+) -> RequirementAgent:
+    jira_tool = [t for t in gateway_tools if t.name == "get_jira_details"]
+    return RequirementAgent(
+        name="ApplicabilityAgent",
+        llm=get_chat_model(),
+        tool_call_checker=get_tool_call_checker_config(),
+        tools=[
+            ThinkTool(),
+            ViewTool(options=local_tool_options),
+            SearchTextTool(options=local_tool_options),
+            RunShellCommandTool(options=local_tool_options),
+            *jira_tool,
+        ],
+        memory=UnconstrainedMemory(),
+        requirements=[
+            ConditionalRequirement(
+                ThinkTool,
+                force_at_step=1,
+                force_after=Tool,
+                consecutive_allowed=False,
+                only_success_invocations=False,
+            ),
+        ],
+        middlewares=[GlobalTrajectoryMiddleware(pretty=True)],
+        role="Red Hat security analyst",
+    )
+
+
+def build_applicability_prompt(
+    *,
+    jira_issue: str,
+    package: str,
+    target_branch: str,
+    resolution: Resolution,
+    cve_id: str | None,
+    dep_component: str | None,
+    dep_issue_key: str | None,
+    patch_files: list[str],
+    unpacked_sources: Path,
+    local_clone: Path,
+) -> str:
+    cve_label = cve_id or "the CVE"
+
+    rebuild_context = ""
+    if resolution == Resolution.REBUILD and dep_component:
+        rebuild_context = f"\nThis is a dependency rebuild against updated '{dep_component}'."
+        if dep_issue_key:
+            rebuild_context += (
+                f"\nDependency Jira issue: {dep_issue_key} "
+                f"(use get_jira_details for context on what was fixed)."
+            )
+        rebuild_context += (
+            f"\nCheck whether '{package}' actually uses the affected API/module "
+            f"of '{dep_component}' (e.g. check Go imports, C includes, "
+            f"Python imports, linked libraries).\n"
+        )
+
+    sources_rel = unpacked_sources.relative_to(local_clone)
+    if patch_files:
+        patch_info = "Upstream fix patches are available at: " + ", ".join(patch_files)
+    else:
+        patch_info = "No upstream fix patch available."
+
+    return dedent(f"""\
+        Analyze whether {cve_label} affects package '{package}'
+        at the version shipped in branch '{target_branch}'.
+
+        Jira issue: {jira_issue}
+        Triage resolution: {resolution.value}
+        {rebuild_context}
+        {patch_info}
+
+        The unpacked package source is at: {sources_rel}
+
+        Steps:
+        1. Use get_jira_details on {jira_issue} to understand the
+           CVE context and what is affected.
+        2. If upstream fix patches are available, read them to identify
+           the specific files and functions modified by the fix.
+        3. Search for those files/functions in the package source.
+        4. If the vulnerable code is not present, determine why — older
+           version that predates the vulnerability? Patched downstream?
+        5. For dependency rebuilds: check if the package actually uses
+           the affected API/module of the dependency.
+
+        Classify using Red Hat justification categories:
+        - "Component not Present" — the affected component/subcomponent
+          is not included in this package build
+        - "Vulnerable Code not Present" — the package includes the
+          component but the specific vulnerable code was introduced in
+          a later version or is patched/removed downstream
+        - "Vulnerable Code not in Execute Path" — the vulnerable code
+          exists but is not reachable in normal execution (unused import,
+          dead code, dependency API not called by this package)
+        - "Vulnerable Code cannot be Controlled by Adversary" — the
+          vulnerable code is present and reachable, but the input that
+          triggers the vulnerability cannot be supplied by an attacker
+        - "Inline Mitigations already Exist" — additional hardening or
+          security measures exist that prevent exploitation
+
+        If affected or cannot determine with confidence, classify as
+        "Inconclusive". Be conservative: default to "Inconclusive"
+        when unsure.
+    """)

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from beeai_framework.tools import Tool
+from specfile import Specfile
 
 from ymir.agents.constants import BRANCH_PREFIX, JIRA_COMMENT_TEMPLATE
 from ymir.agents.utils import check_subprocess, mcp_tools, run_subprocess, run_tool
@@ -341,3 +342,122 @@ async def cache_mr_metadata(
     logger.info(f"MR metadata cache stored for {operation_type}/{package}/{details} (key: {cache_key})")
 
     return log_output
+
+
+def get_unpacked_sources(local_clone: Path, package: str) -> Path:
+    """
+    Get a path to the root of extracted archive directory tree (referenced as TLD
+    in RPM documentation) for a given package.
+    """
+    with Specfile(local_clone / f"{package}.spec") as spec:
+        name = spec.expand("%{name}")
+        version = spec.expand("%{version}")
+        buildsubdir = spec.expand("%{buildsubdir}")
+    if "/" in buildsubdir:
+        # When %setup -n uses a nested path (e.g. libexpat-R_2_6_4/expat),
+        # use the archive root because some specs apply patches at that level
+        # via pushd/popd.  More details: https://github.com/packit/jotnar/issues/217
+        buildsubdir = buildsubdir.split("/")[0]
+
+    # RPM 4.20+ uses a per-build directory named %{NAME}-%{VERSION}-build
+    per_build_dir = local_clone / f"{name}-{version}-build"
+    sources_dir = per_build_dir / buildsubdir
+    if sources_dir.is_dir():
+        return sources_dir
+
+    # Older RPM versions unpack directly under _builddir
+    sources_dir = local_clone / buildsubdir
+    if sources_dir.is_dir():
+        return sources_dir
+
+    raise ValueError(f"Unpacked source directory does not exist: {sources_dir}")
+
+
+async def _fallback_extract_sources(local_clone: Path, package: str) -> Path:
+    """
+    Fallback when centpkg/rhpkg prep fails: extract the primary source
+    archive using Source0 from the spec file.
+    """
+    try:
+        with Specfile(local_clone / f"{package}.spec") as spec, spec.sources() as sources:
+            if not sources:
+                raise ValueError(f"No sources defined in {package}.spec")
+            archive = local_clone / sources[0].expanded_filename
+            if not archive.is_file():
+                raise ValueError(f"Source0 '{sources[0].expanded_filename}' not found on disk")
+    except Exception as e:
+        raise ValueError(f"Could not determine source archive for {package}: {e}") from e
+    logger.info(f"Using Source0 from spec: {archive.name}")
+
+    extract_dir = local_clone / "_extracted"
+    extract_dir.mkdir(exist_ok=True)
+
+    cmd = ["/usr/lib/rpm/rpmuncompress", "-x", str(archive)]
+    logger.info(f"Extracting {archive.name} to {extract_dir}")
+
+    exit_code, _, stderr = await run_subprocess(cmd, cwd=extract_dir)
+    if exit_code != 0:
+        raise ValueError(f"Failed to extract {archive.name}: {stderr}")
+
+    subdirs = [d for d in extract_dir.iterdir() if d.is_dir()]
+    if len(subdirs) == 1:
+        return subdirs[0]
+    return extract_dir
+
+
+async def clone_and_prep_sources(
+    package: str,
+    dist_git_branch: str,
+    available_tools: list[Tool],
+    jira_issue: str,
+) -> tuple[Path, Path]:
+    """
+    Clone dist-git repo and run centpkg/rhpkg sources + prep.
+    Returns (local_clone, unpacked_sources) paths.
+    Read-only: no fork, no push — just for source analysis.
+
+    Falls back to manual archive extraction if prep fails (e.g. missing
+    language-specific RPM macros).
+    """
+    working_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / "applicability" / jira_issue
+    working_dir.mkdir(parents=True, exist_ok=True)
+    local_clone = working_dir / package
+    if local_clone.is_dir():
+        shutil.rmtree(local_clone)
+
+    namespace = "centos-stream" if is_cs_branch(dist_git_branch) else "rhel"
+    repository = f"https://gitlab.com/redhat/{namespace}/rpms/{package}"
+    await run_tool(
+        "clone_repository",
+        repository=repository,
+        branch=dist_git_branch,
+        clone_path=str(local_clone),
+        available_tools=available_tools,
+    )
+
+    if is_cs_branch(dist_git_branch):
+        pkg_cmd = [
+            "centpkg",
+            f"--name={package}",
+            "--namespace=rpms",
+            f"--release={dist_git_branch}",
+        ]
+    else:
+        pkg_cmd = [
+            "rhpkg",
+            f"--name={package}",
+            "--namespace=rpms",
+            f"--release={dist_git_branch}",
+            "--offline",
+            "--released",
+        ]
+    await check_subprocess([*pkg_cmd, "sources"], cwd=local_clone)
+
+    exit_code, _, stderr = await run_subprocess([*pkg_cmd, "prep"], cwd=local_clone)
+    if exit_code == 0:
+        unpacked = get_unpacked_sources(local_clone, package)
+        return local_clone, unpacked
+
+    logger.warning(f"prep failed for {package}, falling back to manual extraction: {stderr}")
+    unpacked = await _fallback_extract_sources(local_clone, package)
+    return local_clone, unpacked

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
 import os
+import shutil
 import sys
 import traceback
+from pathlib import Path
 from textwrap import dedent
 
 from beeai_framework.agents.requirement import RequirementAgent
@@ -20,6 +22,7 @@ from beeai_framework.workflows import Workflow
 from pydantic import BaseModel, Field
 
 import ymir.agents.tasks as tasks
+from ymir.agents.cve_applicability_agent import build_applicability_prompt, create_applicability_agent
 from ymir.agents.observability import setup_observability
 from ymir.agents.utils import (
     get_agent_execution_config,
@@ -31,9 +34,11 @@ from ymir.agents.utils import (
 from ymir.common.config import load_rhel_config
 from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.models import (
+    ApplicabilityResult,
     ClarificationNeededData,
     CVEEligibilityResult,
     ErrorData,
+    NotAffectedData,
     OpenEndedAnalysisData,
     PostponedData,
     Resolution,
@@ -732,6 +737,21 @@ async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=Fal
                     }}
                     ```
 
+                    **Correct example for a 'rebuild' resolution:**
+                    ```json
+                    {{
+                        "resolution": "rebuild",
+                        "data": {{
+                        "package": "some-package",
+                        "jira_issue": "RHEL-12345",
+                        "cve_id": "CVE-1234-98765",
+                        "dependency_issue": "RHEL-67890",
+                        "dependency_component": "golang",
+                        "fix_version": "rhel-X.Y.Z"
+                        }}
+                    }}
+                    ```
+
                     ```json
                     {output_schema_json}
                     ```
@@ -772,6 +792,13 @@ async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=Fal
                 logger.info(f"Target branch determined: {state.target_branch}")
             else:
                 logger.warning(f"Could not determine target branch for {state.jira_issue}")
+
+            if (
+                state.cve_eligibility_result
+                and state.cve_eligibility_result.is_cve
+                and state.triage_result.resolution in (Resolution.BACKPORT, Resolution.REBUILD)
+            ):
+                return "check_cve_applicability"
 
             return "comment_in_jira"
 
@@ -818,6 +845,122 @@ async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=Fal
 
             return "determine_target_branch"
 
+        async def check_cve_applicability(state):
+            """Check if a CVE actually affects the package by analyzing source code."""
+            resolution = state.triage_result.resolution
+            package = state.triage_result.data.package
+            logger.info(
+                f"Checking CVE applicability for {state.jira_issue} ({resolution.value} of {package})"
+            )
+
+            if not state.target_branch:
+                logger.warning("No target branch — skipping applicability check")
+                return "comment_in_jira"
+
+            data = state.triage_result.data
+            cve_id = getattr(data, "cve_id", None)
+            dep_component = getattr(data, "dependency_component", None)
+            dep_issue_key = getattr(data, "dependency_issue", None)
+
+            patch_urls = getattr(data, "patch_urls", None) or []
+
+            # For z-stream branches, check if the branch actually exists;
+            # fall back to CentOS Stream for source analysis since we only
+            # need to read the source, not push to the branch.
+            clone_branch = state.target_branch
+            parsed = parse_rhel_version(state.target_branch)
+            if parsed:
+                major_version = parsed[0]
+                try:
+                    available_branches = await run_tool(
+                        "get_internal_rhel_branches",
+                        available_tools=gateway_tools,
+                        package=package,
+                    )
+                    if state.target_branch not in available_branches:
+                        clone_branch = f"c{major_version}s"
+                        logger.info(
+                            f"Branch {state.target_branch} not found for {package}, "
+                            f"using {clone_branch} for applicability analysis"
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to check branches for {package}: {e}")
+
+            working_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / "applicability" / state.jira_issue
+            try:
+                local_clone, unpacked_sources = await tasks.clone_and_prep_sources(
+                    package=package,
+                    dist_git_branch=clone_branch,
+                    available_tools=gateway_tools,
+                    jira_issue=state.jira_issue,
+                )
+            except Exception as e:
+                logger.warning(f"Could not prep sources for applicability check: {e}")
+                shutil.rmtree(working_dir, ignore_errors=True)
+                return "comment_in_jira"
+
+            try:
+                # Download patches as files (same layout as backport agent)
+                patch_files = []
+                for idx, url in enumerate(patch_urls):
+                    try:
+                        content = await run_tool(
+                            "get_patch_from_url",
+                            patch_url=url,
+                            available_tools=gateway_tools,
+                        )
+                        patch_name = f"{state.jira_issue}-{idx}.patch"
+                        (local_clone / patch_name).write_text(content)
+                        patch_files.append(patch_name)
+                    except Exception:
+                        logger.warning(f"Could not fetch patch from {url}")
+
+                local_tool_options = {"working_directory": local_clone}
+                applicability_agent = create_applicability_agent(gateway_tools, local_tool_options)
+                prompt = build_applicability_prompt(
+                    jira_issue=state.jira_issue,
+                    package=package,
+                    target_branch=state.target_branch,
+                    resolution=resolution,
+                    cve_id=cve_id,
+                    dep_component=dep_component,
+                    dep_issue_key=dep_issue_key,
+                    patch_files=patch_files,
+                    unpacked_sources=unpacked_sources,
+                    local_clone=local_clone,
+                )
+
+                response = await applicability_agent.run(
+                    prompt,
+                    expected_output=ApplicabilityResult,
+                    **get_agent_execution_config(),
+                )
+                applicability = ApplicabilityResult.model_validate_json(response.last_message.text)
+
+                if not applicability.is_affected:
+                    logger.info(
+                        f"CVE not applicable for {state.jira_issue}: {applicability.justification_category}"
+                    )
+                    state.triage_result = OutputSchema(
+                        resolution=Resolution.NOT_AFFECTED,
+                        data=NotAffectedData(
+                            justification_category=applicability.justification_category,
+                            explanation=applicability.explanation,
+                            jira_issue=state.jira_issue,
+                        ),
+                    )
+                    return "comment_in_jira"
+
+                logger.info(
+                    f"CVE confirmed applicable for {state.jira_issue}: {applicability.explanation[:100]}"
+                )
+            except Exception as e:
+                logger.warning(f"Applicability check failed: {e}")
+            finally:
+                shutil.rmtree(working_dir, ignore_errors=True)
+
+            return "comment_in_jira"
+
         async def comment_in_jira(state):
             comment_text = state.triage_result.format_for_comment(auto_chain=auto_chain)
             logger.info(f"Result to be put in Jira comment: {comment_text}")
@@ -835,6 +978,7 @@ async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=Fal
         workflow.add_step("run_triage_analysis", run_triage_analysis)
         workflow.add_step("verify_rebase_author", verify_rebase_author)
         workflow.add_step("determine_target_branch", determine_target_branch_step)
+        workflow.add_step("check_cve_applicability", check_cve_applicability)
         workflow.add_step("comment_in_jira", comment_in_jira)
 
         response = await workflow.run(TriageState(jira_issue=jira_issue))
@@ -1039,6 +1183,14 @@ async def main() -> None:
                         )
                     )
                     logger.info(f"Pushed {input.issue} to {RedisQueues.POSTPONED_LIST.value}")
+                elif output.resolution == Resolution.NOT_AFFECTED:
+                    logger.info(f"Triage resolved as NOT_AFFECTED for {input.issue}")
+                    await tasks.set_jira_labels(
+                        jira_issue=input.issue,
+                        labels_to_add=[JiraLabels.TRIAGED_NOT_AFFECTED.value],
+                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                        dry_run=dry_run,
+                    )
                 elif output.resolution == Resolution.ERROR:
                     logger.warning(f"Triage resolved as ERROR for {input.issue}, retrying")
                     await tasks.set_jira_labels(

--- a/ymir/common/constants.py
+++ b/ymir/common/constants.py
@@ -117,6 +117,7 @@ class JiraLabels(Enum):
     REBUILD_FAILED = "ymir_rebuild_failed"
 
     TRIAGED_POSTPONED = "ymir_triaged_postponed"
+    TRIAGED_NOT_AFFECTED = "ymir_triaged_not_affected"
 
     RETRY_NEEDED = "ymir_retry_needed"
     FUSA = "ymir_fusa"

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -164,6 +164,7 @@ class Resolution(Enum):
     CLARIFICATION_NEEDED = "clarification-needed"
     OPEN_ENDED_ANALYSIS = "open-ended-analysis"
     POSTPONED = "postponed"
+    NOT_AFFECTED = "not-affected"
     ERROR = "error"
 
 
@@ -197,6 +198,7 @@ class RebuildData(BaseModel):
 
     package: str = Field(description="Package name")
     jira_issue: str = Field(description="Jira issue identifier")
+    cve_id: str | None = Field(description="CVE identifier", default=None)
     dependency_issue: str | None = Field(
         description="Key of the dependency Jira issue that triggered the rebuild",
         default=None,
@@ -250,6 +252,28 @@ class PostponedData(BaseModel):
     jira_issue: str = Field(description="Jira issue identifier")
 
 
+class NotAffectedData(BaseModel):
+    """Data for not-affected resolution (CVE does not apply to this package)."""
+
+    justification_category: str | None = Field(
+        description="Red Hat justification category, e.g. 'Vulnerable Code not Present'",
+        default=None,
+    )
+    explanation: str = Field(description="Detailed explanation of why the CVE does not affect this package")
+    jira_issue: str = Field(description="Jira issue identifier")
+
+
+class ApplicabilityResult(BaseModel):
+    """Output schema for the CVE applicability check agent."""
+
+    is_affected: bool = Field(description="True if affected or inconclusive, False if clearly not affected")
+    justification_category: str | None = Field(
+        description="Red Hat justification category when not affected, None if affected",
+        default=None,
+    )
+    explanation: str = Field(description="Detailed reasoning for the determination")
+
+
 class ErrorData(BaseModel):
     """Data for error resolution."""
 
@@ -291,6 +315,7 @@ class TriageOutputSchema(BaseModel):
         | ClarificationNeededData
         | OpenEndedAnalysisData
         | PostponedData
+        | NotAffectedData
         | ErrorData
     ) = Field(description="Associated data")
 
@@ -389,6 +414,12 @@ class TriageOutputSchema(BaseModel):
                     f"*Summary*: {self.data.summary}\n"
                     f"{heading}\n{pending_text}"
                     f"{TRIAGE_DISCLAIMER}"
+                )
+
+            case NotAffectedData():
+                category = self.data.justification_category or "Not Affected"
+                return (
+                    f"*Recommendation: Not a Bug / {category}*\n\n{self.data.explanation}{TRIAGE_DISCLAIMER}"
                 )
 
             case ErrorData():

--- a/ymir/common/tests/unit/test_models.py
+++ b/ymir/common/tests/unit/test_models.py
@@ -1,9 +1,11 @@
 from ymir.common.models import (
     AUTOMATED_RESOLUTION_NOT_SUPPORTED,
     TRIAGE_DISCLAIMER,
+    ApplicabilityResult,
     BackportData,
     ClarificationNeededData,
     ErrorData,
+    NotAffectedData,
     OpenEndedAnalysisData,
     PostponedData,
     RebaseData,
@@ -160,3 +162,83 @@ def test_error_formatting():
     assert result.format_for_comment() == (
         f"*Resolution*: error\n*Details*: Package 'invalid-pkg' not found in repository{TRIAGE_DISCLAIMER}"
     )
+
+
+# --- NotAffectedData formatting tests ---
+
+
+def test_not_affected_formatting():
+    data = NotAffectedData(
+        justification_category="Vulnerable Code not Present",
+        explanation="The vulnerable function foo_parse() was introduced in version 3.2. "
+        "This package ships version 3.1, which does not contain the affected code path.",
+        jira_issue="RHEL-44444",
+    )
+    result = TriageOutputSchema(resolution=Resolution.NOT_AFFECTED, data=data)
+
+    assert result.format_for_comment() == (
+        "*Recommendation: Not a Bug / Vulnerable Code not Present*\n\n"
+        "The vulnerable function foo_parse() was introduced in version 3.2. "
+        "This package ships version 3.1, which does not contain the affected code path."
+        f"{TRIAGE_DISCLAIMER}"
+    )
+
+
+def test_not_affected_formatting_no_category():
+    data = NotAffectedData(
+        explanation="Could not conclusively determine the category.",
+        jira_issue="RHEL-66666",
+    )
+    result = TriageOutputSchema(resolution=Resolution.NOT_AFFECTED, data=data)
+
+    comment = result.format_for_comment()
+    assert "*Recommendation: Not a Bug / Not Affected*" in comment
+    assert "None" not in comment
+
+
+def test_not_affected_formatting_component_not_present():
+    data = NotAffectedData(
+        justification_category="Component not Present",
+        explanation="The affected subcomponent libfoo-xml is not included in this package build.",
+        jira_issue="RHEL-55555",
+    )
+    result = TriageOutputSchema(resolution=Resolution.NOT_AFFECTED, data=data)
+
+    comment = result.format_for_comment()
+    assert "*Recommendation: Not a Bug / Component not Present*" in comment
+    assert "libfoo-xml is not included" in comment
+    assert TRIAGE_DISCLAIMER in comment
+
+
+# --- ApplicabilityResult tests ---
+
+
+def test_applicability_result_not_affected():
+    result = ApplicabilityResult(
+        is_affected=False,
+        justification_category="Vulnerable Code not Present",
+        explanation="Function introduced in v3.2, package ships v3.1.",
+    )
+    assert not result.is_affected
+    assert result.justification_category == "Vulnerable Code not Present"
+
+
+def test_applicability_result_affected():
+    result = ApplicabilityResult(
+        is_affected=True,
+        explanation="The vulnerable code path is present and reachable.",
+    )
+    assert result.is_affected
+    assert result.justification_category is None
+
+
+def test_applicability_result_roundtrip():
+    result = ApplicabilityResult(
+        is_affected=False,
+        justification_category="Vulnerable Code not in Execute Path",
+        explanation="The affected API is imported but never called.",
+    )
+    json_str = result.model_dump_json()
+    restored = ApplicabilityResult.model_validate_json(json_str)
+    assert not restored.is_affected
+    assert restored.justification_category == "Vulnerable Code not in Execute Path"


### PR DESCRIPTION
After triage determines a backport/rebuild resolution, a new workflow step clones the package source, unpacks it, and runs a dedicated LLM agent to verify whether the vulnerable code actually exists in the shipped version. If not applicable, the resolution is overridden to NOT_AFFECTED with a Red Hat justification category, and no downstream work is queued.

Changes:
- Add Resolution.NOT_AFFECTED, NotAffectedData, ApplicabilityResult models
- Add cve_id field to RebuildData with rebuild output example in prompt
- Add TRIAGED_NOT_AFFECTED Jira label
- Move get_unpacked_sources to tasks.py, add clone_and_prep_sources with fallback tarball extraction when prep fails
- Add check_cve_applicability workflow step with ApplicabilityAgent (has access to source files, shell, and get_jira_details)
- Handle NOT_AFFECTED in queue mode (label update, no queue push)
- Install srpm-macros packages in both container images
- Fall back to CentOS Stream branch when z-stream branch doesn't exist

Assisted-by: Claude Opus 4.6

Example output: https://redhat.atlassian.net/browse/RHEL-167657?focusedCommentId=16798248
