### PR TITLE
Triage agent upgrade

### DIFF
--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -203,6 +203,23 @@ You must decide between one of 5 actions. Follow these guidelines to make your d
      - If you run out of commits to check, use different approach, do not give up. Inability
        of the tool to find proper fix does not mean it does not exist, search bug trackers
        and version control system.
+     - **Handling non-GitHub/non-GitLab repositories**: When the `upstream_search` tool returns
+       `related_commits` that are bare commit hashes (not full URLs), it means the upstream
+       repository is hosted on a platform the tool does not know how to build patch URLs for
+       (e.g. gitweb, cgit, kernel.org, etc.). In this case, do NOT attempt to guess the web URL
+       or immediately call `get_patch_from_url` with a fabricated URL. Instead:
+       1. Clone the upstream repository locally using the `repository_url` returned by the tool:
+          `git clone --bare <repository_url> /tmp/<project_name>`
+       2. Inspect the candidate commits locally with `git show <hash>` to read the commit
+          message and diff, and determine whether any of them is the correct fix.
+       3. Only after you have confirmed the right commit locally, attempt to construct
+          a download URL for the patch. Try common hosting URL patterns:
+          - cgit: `<base_url>/patch/?id=<hash>`
+          - gitweb: `<base_url>;a=patch;h=<hash>`
+          - kernel.org: `<base_url>/patch/?id=<hash>`
+          If none of these patterns work with `get_patch_from_url`, use the repository URL
+          with the commit hash appended as a fragment (e.g. `<repository_url>#<hash>`)
+          as the patch URL in your final answer.
    * Using the details from your analysis, search these sources:
      - Bug Trackers (for fixed bugs matching the issue summary and description)
      - Git / Version Control (for commit messages, using keywords, CVE IDs, function names, etc.)
@@ -355,6 +372,23 @@ You must decide between one of the following actions. Follow these guidelines to
      - If you run out of commits to check, use different approach, do not give up. Inability
        of the tool to find proper fix does not mean it does not exist, search bug trackers
        and version control system.
+     - **Handling non-GitHub/non-GitLab repositories**: When the `upstream_search` tool returns
+       `related_commits` that are bare commit hashes (not full URLs), it means the upstream
+       repository is hosted on a platform the tool does not know how to build patch URLs for
+       (e.g. gitweb, cgit, kernel.org, etc.). In this case, do NOT attempt to guess the web URL
+       or immediately call `get_patch_from_url` with a fabricated URL. Instead:
+       1. Clone the upstream repository locally using the `repository_url` returned by the tool:
+          `git clone --bare <repository_url> /tmp/<project_name>`
+       2. Inspect the candidate commits locally with `git show <hash>` to read the commit
+          message and diff, and determine whether any of them is the correct fix.
+       3. Only after you have confirmed the right commit locally, attempt to construct
+          a download URL for the patch. Try common hosting URL patterns:
+          - cgit: `<base_url>/patch/?id=<hash>`
+          - gitweb: `<base_url>;a=patch;h=<hash>`
+          - kernel.org: `<base_url>/patch/?id=<hash>`
+          If none of these patterns work with `get_patch_from_url`, use the repository URL
+          with the commit hash appended as a fragment (e.g. `<repository_url>#<hash>`)
+          as the patch URL in your final answer.
    * Using the details from your analysis, search these sources:
      - Bug Trackers (for fixed bugs matching the issue summary and description)
      - Git / Version Control (for commit messages, using keywords, CVE IDs, function names, etc.)

--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -224,8 +224,8 @@ If `is_older_zstream` is true:
   - If you run out of commits to check, use a different approach; inability to find the fix does not mean it does not exist — search bug trackers and version control systems.
   - **Handling non-GitHub/non-GitLab repositories**: When `upstream_search` returns `related_commits` that are bare commit hashes (not full URLs), the upstream repository is on a platform the tool cannot build patch URLs for (e.g., gitweb, cgit, kernel.org). In this case:
     1. Do NOT guess the web URL or immediately call `get_patch_from_url` with a fabricated URL.
-    2. Clone the upstream repository locally: `git clone --bare <repository_url> /tmp/<project_name>`
-    3. Inspect candidate commits locally with `git show <hash>` to read the message and diff.
+    2. Create a unique temporary directory and clone into it: `CLONE_DIR=$(mktemp -d) && git clone --bare <repository_url> "$CLONE_DIR/repo"`
+    3. Inspect candidate commits locally with `git -C "$CLONE_DIR/repo" show <hash>` to read the message and diff.
     4. Only after confirming the right commit locally, attempt to construct a download URL. You MUST use the exact same URL scheme (`http://` or `https://`) as the `repository_url` — do NOT upgrade or downgrade the scheme. Try common patterns:
        - cgit: `<base_url>/patch/?id=<hash>`
        - gitweb: `<base_url>;a=patch;h=<hash>`

--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -1,606 +1,339 @@
 ---
-description: Analyze JIRA issues for RHEL and identify the most efficient path to resolution (rebase, backport, rebuild, clarification, or open-ended analysis).
+description: Triage Jira issues for RHEL packages — analyze bugs and CVEs to determine whether to rebase, backport a patch, rebuild, or request clarification, and post the result as a Jira comment.
 arguments:
   - name: jira_issue
-    description: "JIRA issue key (e.g., RHEL-12345)"
+    description: "Jira issue key to triage (e.g., RHEL-12345)"
     required: true
+  - name: dry_run
+    description: "If true, skip posting the Jira comment. Default: false"
+    required: false
   - name: force_cve_triage
-    description: "Force triage of CVE issues that would normally be deferred or rejected (eligibility=PENDING_DEPENDENCIES or NEVER). Default: false"
+    description: "If true, force triage even when the CVE eligibility check says the issue is not immediately eligible. Default: false"
     required: false
 ---
 
 # Triage Skill
 
-You are a Red Hat Enterprise Linux developer tasked with analyzing JIRA issues to determine the most efficient path to resolution.
+You are a Red Hat Enterprise Linux developer performing triage on a Jira issue to determine the correct resolution path.
 
 ## Input Arguments
 
-- `jira_issue`: {{jira_issue}} — The JIRA issue key to triage
-- `force_cve_triage`: {{force_cve_triage}} — When true, force triage even if CVE eligibility is PENDING_DEPENDENCIES or NEVER
+- `jira_issue`: {{jira_issue}}
+- `dry_run`: {{dry_run}}
+- `force_cve_triage`: {{force_cve_triage}}
 
 ## Tools
 
 This skill uses the following tools. Do not restrict tool usage — use any tool available as needed.
 
-**MCP Tools (called via MCP gateway):**
-- `check_cve_triage_eligibility` — Check whether a CVE is eligible for triage processing
-- `get_jira_details` — Fetch full details of a JIRA issue
-- `set_jira_fields` — Update JIRA fields (Severity, Fix Version)
-- `get_patch_from_url` — Fetch and validate patch content from a URL
-- `search_jira_issues` — Search JIRA using JQL queries
-- `verify_issue_author` — Check if the JIRA issue author is a Red Hat employee
-- `add_jira_comment` — Post a comment to a JIRA issue
-- `get_internal_rhel_branches` — Check available internal RHEL branches for a package
-- `map_version` — Map RHEL major version to current Y-stream and Z-stream versions
-- `upstream_search` — Search upstream project repositories for commits related to an issue
-- `zstream_search` — Search for fixes in older Z-streams (used only for older Z-stream issues)
+**MCP Tools:**
+- `check_cve_triage_eligibility` — Determine whether a CVE Jira issue is eligible for immediate triage
+- `get_jira_details` — Fetch full details of a Jira issue including comments, fields, and remote links
+- `set_jira_fields` — Set Jira fields such as Severity and Fix Version
+- `get_patch_from_url` — Fetch and validate patch/diff content from a URL
+- `search_jira_issues` — Search Jira using JQL queries
+- `verify_issue_author` — Verify whether the Jira issue author is a Red Hat employee
+- `get_internal_rhel_branches` — List available internal RHEL dist-git branches for a package
+- `add_jira_comment` — Post a comment to a Jira issue
+- `zstream_search` — Search for commits related to an older z-stream backport by looking through newer streams
 
-**Shell Commands:**
-- Run shell commands via the Bash tool (e.g., `git ls-remote`, `git log`, `git blame`) with a 10-minute timeout
+**Local Tools:**
+- `map_version` — Map a RHEL major version to the current Y-stream and Z-stream versions
+- `upstream_search` — Search an upstream project's git repository for commits related to a description
+- `run_shell_command` — Execute shell commands (e.g., `git ls-remote` to verify a package repository exists)
+- `think` — Internal reasoning tool; use it before each decision and after each tool call
 
 ## Workflow
 
-Execute the following steps in order:
+Execute the following steps in order. Track state across steps (CVE eligibility result, triage resolution, target branch).
 
 ### Step 1: Check CVE Eligibility
 
-1. Call `check_cve_triage_eligibility` with `issue_key` set to `{{jira_issue}}`.
-2. The result contains: `is_cve` (bool), `eligibility` (string: "immediately" | "pending-dependencies" | "never"), `reason` (string), `needs_internal_fix` (bool|null), `error` (string|null), `pending_zstream_issues` (list of strings|null).
-3. **If `eligibility` is "immediately"** → proceed to Step 2. Save the CVE eligibility result (especially `is_cve` and `needs_internal_fix`) for later use.
-4. **If `force_cve_triage` is true AND there is no `error`** → proceed to Step 2 regardless of eligibility.
-5. **If `eligibility` is "pending-dependencies":**
-   - Produce a **postponed** resolution with summary set to the `reason` from the eligibility result and `pending_issues` set to the `pending_zstream_issues` list, then skip to Step 6.
-6. **If `eligibility` is "never":**
-   - If there is an `error` → produce an **error** resolution with details about the CVE eligibility check error, then skip to Step 6.
-   - Otherwise → produce an **open-ended-analysis** resolution with summary "CVE eligibility check decided to skip triaging: {reason}" and recommendation "No action needed — this issue is not eligible for triage processing.", then skip to Step 6.
+Call `check_cve_triage_eligibility` with `issue_key` = `{{jira_issue}}`.
 
-### Step 2: Determine Prompt Variant
+Record the full result as `cve_eligibility_result`. Interpret it as follows:
 
-1. Call `get_jira_details` with `issue_key` set to `{{jira_issue}}`.
-2. Extract the Fix Version from `fields.fixVersions[0].name` (if present).
-3. Call `map_version` with the RHEL major version extracted from the issue to get the current Z-stream versions.
-4. Determine if the Fix Version is an **older Z-stream** — a Z-stream version whose minor number is lower than the current Z-stream for the same major version.
-5. **If older Z-stream** → use the **Z-Stream Triage Instructions** (Section A below).
-6. **Otherwise** → use the **Standard Triage Instructions** (Section B below).
+- **`eligibility` = `IMMEDIATELY`**: proceed to Step 2.
+- **`force_cve_triage` is true AND no error in result**: proceed to Step 2 regardless of eligibility value.
+- **`eligibility` = `PENDING_DEPENDENCIES`**: set resolution to **POSTPONED** — summary = the eligibility reason, `pending_issues` = the returned list of pending z-stream issue keys. Skip to Step 5.
+- **`error` field is set in the result**: set resolution to **ERROR** with the error details. Skip to Step 5.
+- **Any other non-eligible result**: set resolution to **OPEN_ENDED_ANALYSIS** — summary = `"CVE eligibility check decided to skip triaging: <reason>"`, recommendation = `"No action needed — this issue is not eligible for triage processing."`. Skip to Step 5.
+
+### Step 2: Pre-fetch Fix Version
+
+Call `get_jira_details` with `issue_key` = `{{jira_issue}}`.
+
+Extract `fields.fixVersions[0].name` as `fix_version_name` (may be absent).
+
+Determine `is_older_zstream`:
+- An older z-stream is a version with format `rhel-X.Y.z` whose minor number `Y` is lower than the current Z-stream minor for the same major version `X`.
+- Use `map_version` with the major version to look up the current Z-stream if needed.
+- Set `is_older_zstream = true` if the fix version is an older z-stream, `false` otherwise.
 
 ### Step 3: Run Triage Analysis
 
-Follow the appropriate instruction set (Section A or B) to analyze the issue and determine the resolution.
+Follow the full analysis instructions in the **Triage Analysis Instructions** section below.
 
-Your analysis must produce a result matching the **Output Schema** defined at the end of this document.
+The analysis produces a `resolution` and accompanying `data`. Record both.
 
-**Important behavioral rules:**
-- Be proactive in your search for fixes and do not give up easily.
-- For any patch URL that you are proposing for backport, you MUST fetch and validate it using the `get_patch_from_url` tool.
-- Do not modify the patch URL in your final answer after it has been validated with `get_patch_from_url`.
-- After completing your triage analysis, if your decision is backport or rebase, always set appropriate JIRA fields per the instructions using `set_jira_fields` tool.
+After analysis, branch as follows:
 
-### Step 4: Verify Rebase Author (only if resolution is "rebase")
+- **REBASE** → Step 4a (Verify Rebase Author)
+- **BACKPORT or REBUILD** → Step 4b (Determine Target Branch), then Step 5
+- **CLARIFICATION_NEEDED, OPEN_ENDED_ANALYSIS, POSTPONED** → Step 5 directly
 
-1. Call `verify_issue_author` with `issue_key` set to `{{jira_issue}}`.
-2. Call `get_jira_details` with `issue_key` set to `{{jira_issue}}` and extract the issue status from `fields.status.name`.
-3. **If the author is NOT a verified Red Hat employee AND the issue status is "New":**
-   - Override the resolution to **clarification-needed** with:
-     - `findings`: "The rebase resolution was determined, but author verification failed."
-     - `additional_info_needed`: "Needs human review, as the issue author is not verified as a Red Hat employee."
-     - `jira_issue`: `{{jira_issue}}`
-   - Skip to Step 6.
-4. Otherwise → proceed to Step 5.
+### Step 4a: Verify Rebase Author
 
-### Step 5: Determine Target Branch (only if resolution is "rebase", "backport", or "rebuild")
+Call `verify_issue_author` with `issue_key` = `{{jira_issue}}`.
+Call `get_jira_details` with `issue_key` = `{{jira_issue}}` and extract `fields.status.name` as `issue_status`.
 
-Determine the target dist-git branch from the `fix_version` in the triage result:
+If the author is **not** a Red Hat employee AND `issue_status` is `"New"`:
+- Override resolution to **CLARIFICATION_NEEDED**:
+  - `findings`: `"The rebase resolution was determined, but author verification failed."`
+  - `additional_info_needed`: `"Needs human review, as the issue author is not verified as a Red Hat employee."`
+- Proceed to Step 5.
 
-1. Parse the fix version string (e.g., "rhel-9.8", "rhel-10.2.z") to extract major version, minor version, and whether it is a Z-stream.
-2. Load the current Y-stream and Z-stream configuration using `map_version`.
-3. Check if this is an older Z-stream (minor number lower than current Z-stream for the same major).
-4. Apply branch mapping rules:
-   - **If CVE needs internal fix AND NOT targeting an older Z-stream:**
-     - If a Y-stream exists for this major version → branch is `rhel-{major}.{minor}.0` (or `rhel-{major}.{minor}` for RHEL 10+)
-     - Otherwise → branch is `c{major}s` (CentOS Stream)
-   - **If Z-stream or older Z-stream:**
-     - Branch is `rhel-{major}.{minor}.0` (or `rhel-{major}.{minor}` for RHEL 10+)
-     - If a package name is available, call `get_internal_rhel_branches` to verify the branch exists for that package
-   - **Default:** branch is `c{major}s` (CentOS Stream)
-5. Record the target branch for inclusion in the output.
-6. Proceed to Step 6.
+Otherwise proceed to Step 4b.
 
-### Step 6: Comment in JIRA
+### Step 4b: Determine Target Branch
 
-Format the triage result as a human-readable comment and post it to the JIRA issue using `add_jira_comment`.
+Determine `target_branch` from the `fix_version` in the triage result data and `cve_eligibility_result`:
 
-Format the comment based on the resolution type:
+1. Parse the fix version string (e.g., `rhel-9.8`, `rhel-10.2.z`) to extract `major_version`, `minor_version`, and `is_zstream`.
+2. Determine `older_zstream` using the same logic as Step 2.
+3. Check if CVE needs internal fix: `cve_needs_internal_fix = (cve_eligibility_result.is_cve AND cve_eligibility_result.needs_internal_fix)`.
+4. Apply these rules in order:
+   - If `cve_needs_internal_fix` is true AND NOT `older_zstream`:
+     - If a Y-stream exists for `major_version` (from `map_version`): `target_branch = rhel-{major}.{minor}.0` (append `.0` only when `major_version < 10`).
+     - Otherwise: `target_branch = c{major}s`.
+   - If `is_zstream` OR `older_zstream`:
+     - `target_branch = rhel-{major}.{minor}.0` (append `.0` only when `major_version < 10`).
+     - Optionally call `get_internal_rhel_branches` for the package to confirm the branch exists (log a warning if it does not, but continue).
+   - Otherwise: `target_branch = c{major}s`.
 
-- **backport**: Include resolution, patch URL(s), justification, and fix version (if set).
-- **rebase**: Include resolution, package name, target version, and fix version (if set).
-- **rebuild**: Include resolution, package name, dependency component and issue (if applicable), and fix version (if set).
-- **clarification-needed**: Include resolution, findings, and additional info needed.
-- **open-ended-analysis**: Include summary and recommendation.
-- **postponed**: Include summary and the list of pending issues being waited on.
-- **error**: Include resolution and error details.
+Record `target_branch`.
+
+### Step 5: Comment in Jira
+
+If `dry_run` is true, end the skill without posting.
+
+Otherwise call `add_jira_comment` with `issue_key` = `{{jira_issue}}` and a comment that summarises the triage result. Format the comment based on the resolution type:
+
+- **backport**: package name, patch URL, justification, fix version, CVE ID (if present).
+- **rebase**: package name, target version, fix version.
+- **rebuild**: package name, dependency issue key, dependency component, fix version.
+- **clarification-needed**: findings and what additional information is needed.
+- **open-ended-analysis**: summary and recommendation.
+- **postponed**: reason and list of pending issue keys.
+- **error**: error details.
 
 ---
 
-## Section A: Z-Stream Triage Instructions
+## Triage Analysis Instructions
 
-Use these instructions when the Fix Version targets an older Z-stream.
+You are an agent tasked to analyze Jira issues for RHEL and identify the most efficient path to resolution, whether through a version rebase, a patch backport, or by requesting clarification when blocked.
 
-You are an agent tasked to analyze Jira issues for RHEL and identify the most efficient path to resolution,
-whether through a version rebase, a patch backport, or by requesting clarification when blocked.
-
-**Important**: Focus on bugs, CVEs, and technical defects that need code fixes.
-QE tasks, feature requests, refactoring, documentation, and other non-bug issues should be marked as "no-action".
+**Important**: Focus on bugs, CVEs, and technical defects that need code fixes. Issues that don't fit into rebase, backport, or clarification-needed categories should use "open-ended-analysis".
 
 Goal: Analyze the given issue to determine the correct course of action.
 
-**Initial Analysis Steps**
+### Initial Analysis Steps
 
 1. Open the `{{jira_issue}}` Jira issue and thoroughly analyze it:
-   * Extract key details from the title, description, fields, and comments
-   * Identify the Fix Version using the `map_version` tool and check if it is an older z-stream.
-     An older z-stream is a z-stream version with a minor number lower than the current
-     z-stream for the same major version.
-   * If the Fix Version is an older z-stream use the `zstream_search` tool to locate the fix.
-     Provide the following from the Jira issue to the tool:
-     - The component name.
-     - The full issue summary text as-is.
-     - The fix_version string.
-     If the tool returns 'found', use the returned commit URLs as your patch candidates.
+   * Extract key details from the title, description, fields, and comments.
+   * If `is_older_zstream` is true:
+     - Identify the Fix Version using the `map_version` tool and confirm it is an older z-stream.
+     - Use the `zstream_search` tool to locate the fix. Provide the following from the Jira issue:
+       - The component name.
+       - The full issue summary text as-is.
+       - The fix_version string.
+     - If the tool returns `found`, use the returned commit URLs as your patch candidates.
    * Pay special attention to comments as they often contain crucial information such as:
      - Additional context about the problem
      - Links to upstream fixes or patches
      - Clarifications from reporters or developers
-   * Look for keywords indicating the root cause of the problem
-   * Identify specific error messages, log snippets, or CVE identifiers
-   * Note any functions, files, or methods mentioned
-   * Pay attention to any direct links to fixes provided in the issue
-   * Do not use upstream patches for older z-streams.
+   * Look for keywords indicating the root cause of the problem.
+   * Identify specific error messages, log snippets, or CVE identifiers.
+   * Note any functions, files, or methods mentioned.
+   * Pay attention to any direct links to fixes provided in the issue.
+   * If `is_older_zstream` is true, do not use upstream patches — only use patches found via `zstream_search`.
 
 2. Identify the package name that must be updated:
-   * Determine the name of the package from the issue details (usually component name)
-   * Confirm the package repository exists by running
+   * Determine the name of the package from the issue details (usually the component name).
+   * Confirm the package repository exists by running:
      `GIT_TERMINAL_PROMPT=0 git ls-remote https://gitlab.com/redhat/centos-stream/rpms/<package_name>`
-   * A successful command (exit code 0) confirms the package exists
-   * If the package does not exist, re-examine the Jira issue for the correct package name and if it is not found,
-     return error and explicitly state the reason
+   * A successful command (exit code 0) confirms the package exists.
+   * If the package does not exist, re-examine the Jira issue for the correct package name. If still not found, return an error and explicitly state the reason.
 
-3. Proceed to decision making process described below.
+3. Proceed to the decision-making process below.
 
-**Decision Guidelines & Investigation Steps**
+### Decision Guidelines & Investigation Steps
 
-You must decide between one of 5 actions. Follow these guidelines to make your decision:
+You must decide between one of the following actions:
 
-1. **Rebase**
-   * A Rebase is only to be chosen when the issue explicitly instructs you to "rebase" or "update"
-     to a newer/specific upstream version. Do not infer this.
-   * Identify the `<package_version>` the package should be updated or rebased to.
-   * Set the Jira fields as per the instructions below.
+#### 1. Rebase
 
-2. **Backport a Patch OR Request Clarification**
-   This path is for issues that represent a clear bug or CVE that needs a targeted fix.
+A Rebase is **only** to be chosen when the issue explicitly instructs you to "rebase" or "update" to a newer/specific upstream version. Do not infer this.
 
-   2.1. Deep Analysis of the Issue
-   * Use the details extracted from your initial analysis
-   * Focus on keywords and root cause identification
-   * If the Jira issue already provides a direct link to the fix, use that as your primary lead
-     (e.g. in the commit hash field or comment) unless backporting to an older z-stream.
+* Identify the `<package_version>` the package should be updated or rebased to.
+* Set the Jira fields as per the instructions in the **Final Step** section.
 
-   2.2. Systematic Source Investigation
-   * Identify the official upstream project from two sources:
-      * Links from the Jira issue (if any direct upstream links are provided)
-      * Package spec file (`<package>.spec`) in the GitLab repository: check the URL field or Source0 field for upstream project location
+#### 2. Backport a Patch OR Request Clarification
 
-   * Even if the Jira issue provides a direct link to a fix, you need to validate it
-   * When no direct link is provided, you must proactively search for fixes - do not give up easily
-   * Try to use `upstream_search` tool to find out commits related to the issue.
-     - The description you will use should be 1-2 sentences long and include implementation
-       details, keywords, function names or any other helpful information.
-     - The description should be like a command for example `Fix`, `Add` etc.
-     - If the tool gives you list of URLs use them without any change.
-     - Use release date of upstream version used in RHEL if you know it.
-     - If the tool says it can not be used for this project, or it encounters internal error,
-       do not try to use it again and proceed with different approach.
-     - If you run out of commits to check, use different approach, do not give up. Inability
-       of the tool to find proper fix does not mean it does not exist, search bug trackers
-       and version control system.
-     - **Handling non-GitHub/non-GitLab repositories**: When the `upstream_search` tool returns
-       `related_commits` that are bare commit hashes (not full URLs), it means the upstream
-       repository is hosted on a platform the tool does not know how to build patch URLs for
-       (e.g. gitweb, cgit, kernel.org, etc.). In this case, do NOT attempt to guess the web URL
-       or immediately call `get_patch_from_url` with a fabricated URL. Instead:
-       1. Clone the upstream repository locally using the `repository_url` returned by the tool:
-          `git clone --bare <repository_url> /tmp/<project_name>`
-       2. Inspect the candidate commits locally with `git show <hash>` to read the commit
-          message and diff, and determine whether any of them is the correct fix.
-       3. Only after you have confirmed the right commit locally, attempt to construct
-          a download URL for the patch. Try common hosting URL patterns:
-          - cgit: `<base_url>/patch/?id=<hash>`
-          - gitweb: `<base_url>;a=patch;h=<hash>`
-          - kernel.org: `<base_url>/patch/?id=<hash>`
-          If none of these patterns work with `get_patch_from_url`, use the repository URL
-          with the commit hash appended as a fragment (e.g. `<repository_url>#<hash>`)
-          as the patch URL in your final answer.
-   * Using the details from your analysis, search these sources:
-     - Bug Trackers (for fixed bugs matching the issue summary and description)
-     - Git / Version Control (for commit messages, using keywords, CVE IDs, function names, etc.)
-   * Be thorough in your search - try multiple search terms and approaches based on the issue details
-   * Advanced investigation techniques:
-     - If you can identify specific files, functions, or code sections mentioned in the issue,
-       locate them in the source code
-     - Use git history (git log, git blame) to examine changes to those specific code areas
-     - Look for commits that modify the problematic code, especially those with relevant keywords in commit messages
-     - Check git tags and releases around the time when the issue was likely fixed
-     - Search for commits by date ranges when you know approximately when the issue was resolved
-     - Utilize dates strategically in your search if needed, using the version/release date of the package
-       currently used in RHEL
-       - Focus on fixes that came after the RHEL package version date, as earlier fixes would already be included
-       - For CVEs, use the CVE publication date to narrow down the timeframe for fixes
-       - Check upstream release notes and changelogs after the RHEL package version date
+This path is for issues that represent a clear bug or CVE that needs a targeted fix.
 
-   2.3. Validate the Fix and URL
-   * Use the `get_patch_from_url` tool to fetch content from any patch/commit URL you intend to use
-   * The tool will verify the URL is accessible and not an issue reference, then return the content
-   * Once you have the content, you must validate two things:
-     1. **Is it a patch/diff?** Look for diff indicators like:
-        - `diff --git` headers
-        - `--- a/file +++ b/file` unified diff headers
-        - `@@...@@` hunk headers
-        - `+` and `-` lines showing changes
-     2. **Does it fix the issue?** Examine the actual code changes to verify:
-        - The fix directly addresses the root cause identified in your analysis
-        - The code changes align with the symptoms described in the Jira issue
-        - The modified functions/files match those mentioned in the issue
-   * Only proceed with URLs that contain valid patch content AND address the specific issue
-   * If the content is not a proper patch or doesn't fix the issue, continue searching for other fixes
+**2.1. Deep Analysis of the Issue**
+* Use the details extracted from your initial analysis.
+* Focus on keywords and root cause identification.
+* If the Jira issue already provides a direct link to the fix, use that as your primary lead (e.g., in the commit hash field or a comment) — unless backporting to an older z-stream.
 
-   2.4. Decide the Outcome
-   * If your investigation successfully identifies a specific fix that passes both validations in step 2.3, your decision is backport
-   * You must be able to justify why the patch is correct and how it addresses the issue
-   * If your investigation confirms a valid bug/CVE but fails to locate a specific fix, your decision
-     is clarification-needed
-   * This is the correct choice when you are sure a problem exists but cannot find the solution yourself
+**2.2. Systematic Source Investigation**
+* Even if the Jira issue provides a direct link to a fix, you need to validate it.
+* When no direct link is provided, proactively search for fixes — do not give up easily.
 
-   2.5 Set the Jira fields as per the instructions below.
+If `is_older_zstream` is false:
+* There are 2 locations where you can search for fixes: Fedora and the upstream project.
+* First, check if the fix is in the Fedora repository at `https://src.fedoraproject.org/rpms/<package_name>`.
+  - In Fedora, search for `.patch` files and check git commit history for fixes using relevant keywords (CVE IDs, function names, error messages).
+* If not found there, identify the official upstream project from:
+  - Links from the Jira issue (if any direct upstream links are provided).
+  - Package spec file (`<package>.spec`) in the GitLab repository: check the `URL` field or `Source0` field for the upstream project location.
 
-3. **No Action**
-   A No Action decision is appropriate for issues that are NOT bugs or CVEs requiring code fixes:
-   * QE tasks, testing, or validation work
-   * Feature requests or enhancements
-   * Refactoring or code restructuring without fixing bugs
-   * Documentation, build system, or process changes
-   * Vague requests or insufficient information to identify a bug
-   * Note: This is not for valid bugs where you simply can't find the patch
+If `is_older_zstream` is true:
+* Identify the official upstream project from:
+  - Links from the Jira issue (if any direct upstream links are provided).
+  - Package spec file (`<package>.spec`) in the GitLab repository: check the `URL` field or `Source0` field.
 
-4. **Error**
-   An Error decision is appropriate when there are processing issues that prevent proper analysis, e.g.:
-   * The package mentioned in the issue cannot be found or identified
-   * The issue cannot be accessed
+* Try using the `upstream_search` tool to find commits related to the issue:
+  - The description should be 1–2 sentences long and include implementation details, keywords, function names, or other helpful information.
+  - The description should be like a command (e.g., `Fix`, `Add`).
+  - If the tool returns a list of URLs, use them without modification.
+  - Use the release date of the upstream version used in RHEL if known.
+  - If the tool says it cannot be used for this project or encounters an internal error, do not try again — proceed with a different approach.
+  - If you run out of commits to check, use a different approach; inability to find the fix does not mean it does not exist — search bug trackers and version control systems.
+  - **Handling non-GitHub/non-GitLab repositories**: When `upstream_search` returns `related_commits` that are bare commit hashes (not full URLs), the upstream repository is on a platform the tool cannot build patch URLs for (e.g., gitweb, cgit, kernel.org). In this case:
+    1. Do NOT guess the web URL or immediately call `get_patch_from_url` with a fabricated URL.
+    2. Clone the upstream repository locally: `git clone --bare <repository_url> /tmp/<project_name>`
+    3. Inspect candidate commits locally with `git show <hash>` to read the message and diff.
+    4. Only after confirming the right commit locally, attempt to construct a download URL. Try common patterns:
+       - cgit: `<base_url>/patch/?id=<hash>`
+       - gitweb: `<base_url>;a=patch;h=<hash>`
+       - kernel.org: `<base_url>/patch/?id=<hash>`
+    5. If none work, use `<repository_url>#<hash>` as the patch URL in your final answer.
 
-**Final Step: Set JIRA Fields (for Rebase and Backport decisions only)**
+* Using the details from your analysis, search these sources:
+  - Bug trackers (for fixed bugs matching the issue summary and description)
+  - Git / Version Control (for commit messages using keywords, CVE IDs, function names, etc.)
 
-   If your decision is rebase or backport, use `set_jira_fields` tool to update JIRA fields (Severity, Fix Version):
-   1. Check all of the mentioned fields in the JIRA issue and don't modify those that are already set
-   2. Extract the affected RHEL major version from the JIRA issue (look in Affects Version/s field or issue description)
-   3. If the Fix Version field is set, do not change it and use its value in the output.
-   4. If the Fix Version field is not set, use the `map_version` tool with the major version to get available streams
-      and determine appropriate Fix Version:
-       * The tool will return both Y-stream and Z-stream versions (if available) and indicate if it's a maintenance version
-       * For maintenance versions (no Y-stream available):
-         - Critical issues should be fixed (privilege escalation, remote code execution, data loss/corruption, system compromise, regressions, moderate and higher severity CVEs)
-         - Non-critical issues should be marked as no-action with appropriate reasoning
-       * For non-maintenance versions (Y-stream available):
-         - Most critical issues (privilege escalation, RCE, data loss, regressions) should use Z-stream
-         - Other issues should use Y-stream (e.g. performance, usability issues)
-   5. Set non-empty JIRA fields:
-       * Severity: default to 'moderate', for important issues use 'important', for most critical use 'critical' (privilege escalation, RCE, data loss)
-       * Fix Version: use the appropriate stream version determined from `map_version` tool result
+* Be thorough — try multiple search terms and approaches based on the issue details.
+
+* Advanced investigation techniques:
+  - If you can identify specific files, functions, or code sections mentioned in the issue, locate them in the source code.
+  - Use git history (`git log`, `git blame`) to examine changes to those specific code areas.
+  - Look for commits that modify the problematic code, especially those with relevant keywords in commit messages.
+  - Check git tags and releases around the time when the issue was likely fixed.
+  - Search for commits by date ranges when you know approximately when the issue was resolved.
+  - Utilize dates strategically using the version/release date of the package currently used in RHEL:
+    - Focus on fixes that came after the RHEL package version date, as earlier fixes would already be included.
+    - For CVEs, use the CVE publication date to narrow down the timeframe for fixes.
+    - Check upstream release notes and changelogs after the RHEL package version date.
+
+**2.3. Validate the Fix and URL**
+* First, make sure the URL is an actual patch/commit link, not an issue or bug tracker reference (reject URLs containing `/issues/`, `/bug/`, `bugzilla`, `jira`, `/tickets/`).
+* Use the `get_patch_from_url` tool to fetch content from any patch/commit URL you intend to use.
+* Once you have the content, validate two things:
+  1. **Is it a patch/diff?** Look for `diff --git` headers, `--- a/file +++ b/file` unified diff headers, `@@...@@` hunk headers, and `+`/`-` change lines.
+  2. **Does it fix the issue?** Verify that the code changes directly address the root cause, align with the symptoms, and modify the functions/files mentioned in the issue.
+* Only proceed with URLs that contain valid patch content AND address the specific issue.
+* If the content is not a proper patch or doesn't fix the issue, continue searching.
+
+**2.4. Decide the Outcome**
+
+If `is_older_zstream` is false:
+* **CRITICAL — Check if the fix belongs to the package or a dependency:**
+  Before deciding on backport, verify that the patch modifies the package's OWN source code, not the source code of a dependency. Watch for these signs that the fix is in a dependency:
+  - The patch comes from a different upstream repository than the package.
+  - The package bundles or vendors dependencies: check the spec file for `Provides: bundled(...)` entries or vendor tarballs like `Source1: *-vendor.tar.gz`.
+  - The CVE describes a vulnerability in a library, runtime, or language that the package merely uses or vendors.
+  - **If the fix is in a dependency**, use the **rebuild** resolution instead.
+* If the patch IS for the package's own code and passes both validations in step 2.3, your decision is **backport**. Justify why the patch is correct and how it addresses the issue.
+
+If `is_older_zstream` is true:
+* If your investigation successfully identifies a specific fix that passes both validations in step 2.3, your decision is **backport**.
+* Justify why the patch is correct and how it addresses the issue.
+
+* If your investigation confirms a valid bug/CVE but fails to locate a specific fix, your decision is **clarification-needed**. This is the correct choice when you are sure a problem exists but cannot find the solution yourself.
+
+**2.5. Set the Jira fields as per the Final Step instructions below.**
+
+#### 3. Rebuild
+
+Use when the package needs rebuilding against an updated dependency with NO source code changes. This covers explicit rebuild requests AND vendored/bundled dependency CVEs (common in Go, Rust, Node.js packages — see step 2.4).
+
+3.1. Confirm no source code changes are needed for the package itself.
+
+3.2. Check dependency readiness — search thoroughly:
+* Look for linked Jira issues in `fields.issuelinks` representing the dependency update.
+* If no linked issue is found, use `search_jira_issues` to find it. Try JQL queries like:
+  - `project = RHEL AND summary ~ "<CVE-ID>" AND component != "<this-package>"`
+  - Include fields `["key", "summary", "fixVersions", "status"]`.
+* Once found, call `get_jira_details` on the dependency issue to check its status.
+* If the dependency issue has a `Fixed in Build` field set → resolution is **rebuild**.
+  Set `dependency_issue` to the issue key AND `dependency_component` to the component name (e.g., `"golang"`, `"openssl"`).
+* Otherwise → resolution is **postponed**.
+  Set summary to explain that rebuild is waiting for the dependency to ship, and set `pending_issues` to the dependency issue key.
+
+3.3. If rebuild: set Jira fields as per the Final Step instructions below.
+
+#### 4. Open-Ended Analysis
+
+This is the catch-all for issues that are NOT bugs or CVEs requiring code fixes. Use this when:
+* The issue requires spec file adjustments, dependency updates, or other packaging-level work.
+* The issue is a QE task, feature request, documentation change, or other non-bug.
+* Refactoring or code restructuring without fixing bugs.
+* The issue is a duplicate, misassigned, or otherwise needs no work.
+* It is a testing issue with nothing to do with the selected component.
+* Vague requests or insufficient information to identify a bug.
+* Note: This is not for valid bugs where you simply can't find the patch.
+* Provide a thorough summary of your findings and a clear recommendation (or explicitly state that no action is needed and why).
+
+#### 5. Error
+
+An Error decision is appropriate when processing issues prevent proper analysis, e.g.:
+* The package mentioned in the issue cannot be found or identified.
+* The issue cannot be accessed.
+
+### Final Step: Set JIRA Fields (for Rebase, Backport, and Rebuild decisions only)
+
+Use `set_jira_fields` to update JIRA fields (Severity, Fix Version):
+
+1. Check all mentioned fields in the JIRA issue and don't modify those that are already set.
+2. Extract the affected RHEL major version from the JIRA issue (look in `Affects Version/s` field or issue description).
+3. If the Fix Version field is set, do not change it and use its value in the output.
+4. If the Fix Version field is not set, use the `map_version` tool with the major version to get available streams and determine the appropriate Fix Version:
+   * The tool will return both Y-stream and Z-stream versions (if available) and indicate if it's a maintenance version.
+   * For maintenance versions (no Y-stream available):
+     - Critical issues should be fixed (privilege escalation, remote code execution, data loss/corruption, system compromise, regressions, moderate and higher severity CVEs).
+     - Non-critical issues should be marked as open-ended-analysis with appropriate reasoning.
+   * For non-maintenance versions (Y-stream available):
+     - Most critical issues (privilege escalation, RCE, data loss, regressions) should use Z-stream.
+     - Other issues should use Y-stream (e.g., performance, usability issues).
+5. Set non-empty JIRA fields:
+   * **Severity**: default to `'moderate'`; for important issues use `'important'`; for most critical use `'critical'` (privilege escalation, RCE, data loss).
+   * **Fix Version**: use the appropriate stream version determined from the `map_version` tool result.
 
 ---
 
-## Section B: Standard Triage Instructions
+## Output
 
-Use these instructions for standard (non-older-Z-stream) issues.
+The final output is the triage result, which is posted as a Jira comment in Step 5. It must include:
 
-You are an agent tasked to analyze Jira issues for RHEL and identify the most efficient path to resolution,
-whether through a version rebase, a patch backport, or by requesting clarification when blocked.
-
-**Important**: Focus on bugs, CVEs, and technical defects that need code fixes.
-Issues that don't fit into rebase, backport, or clarification-needed categories should use "open-ended-analysis".
-
-Goal: Analyze the given issue to determine the correct course of action.
-
-**Initial Analysis Steps**
-
-1. Open the `{{jira_issue}}` Jira issue and thoroughly analyze it:
-   * Extract key details from the title, description, fields, and comments
-   * Pay special attention to comments as they often contain crucial information such as:
-     - Additional context about the problem
-     - Links to upstream fixes or patches
-     - Clarifications from reporters or developers
-   * Look for keywords indicating the root cause of the problem
-   * Identify specific error messages, log snippets, or CVE identifiers
-   * Note any functions, files, or methods mentioned
-   * Pay attention to any direct links to fixes provided in the issue
-
-2. Identify the package name that must be updated:
-   * Determine the name of the package from the issue details (usually component name)
-   * Confirm the package repository exists by running
-     `GIT_TERMINAL_PROMPT=0 git ls-remote https://gitlab.com/redhat/centos-stream/rpms/<package_name>`
-   * A successful command (exit code 0) confirms the package exists
-   * If the package does not exist, re-examine the Jira issue for the correct package name and if it is not found,
-     return error and explicitly state the reason
-
-3. Proceed to decision making process described below.
-
-**Decision Guidelines & Investigation Steps**
-
-You must decide between one of the following actions. Follow these guidelines to make your decision:
-
-1. **Rebase**
-   * A Rebase is only to be chosen when the issue explicitly instructs you to "rebase" or "update"
-     to a newer/specific upstream version. Do not infer this.
-   * Identify the `<package_version>` the package should be updated or rebased to.
-   * Set the Jira fields as per the instructions below.
-
-2. **Backport a Patch OR Request Clarification**
-   This path is for issues that represent a clear bug or CVE that needs a targeted fix.
-
-   2.1. Deep Analysis of the Issue
-   * Use the details extracted from your initial analysis
-   * Focus on keywords and root cause identification
-   * If the Jira issue already provides a direct link to the fix, use that as your primary lead
-     (e.g. in the commit hash field or comment)
-
-   2.2. Systematic Source Investigation
-   * Even if the Jira issue provides a direct link to a fix, you need to validate it
-   * When no direct link is provided, you must proactively search for fixes - do not give up easily
-   * There are 2 locations where you can search for the fixes: Fedora and upstream project.
-   * First, check if the fix is in Fedora repository in `https://src.fedoraproject.org/rpms/<package_name>`.
-     * In Fedora, search for .patch files and check git commit history for fixes using relevant keywords (CVE IDs, function names, error messages)
-   * If it's not, identify the official upstream project from the following 2 sources and search there:
-      * Links from the Jira issue (if any direct upstream links are provided)
-      * Package spec file (`<package>.spec`) in the GitLab repository: check the URL field or Source0 field for upstream project location
-
-   * Try to use `upstream_search` tool to find out commits related to the issue.
-     - The description you will use should be 1-2 sentences long and include implementation
-       details, keywords, function names or any other helpful information.
-     - The description should be like a command for example `Fix`, `Add` etc.
-     - If the tool gives you list of URLs use them without any change.
-     - Use release date of upstream version used in RHEL if you know it.
-     - If the tool says it can not be used for this project, or it encounters internal error,
-       do not try to use it again and proceed with different approach.
-     - If you run out of commits to check, use different approach, do not give up. Inability
-       of the tool to find proper fix does not mean it does not exist, search bug trackers
-       and version control system.
-     - **Handling non-GitHub/non-GitLab repositories**: When the `upstream_search` tool returns
-       `related_commits` that are bare commit hashes (not full URLs), it means the upstream
-       repository is hosted on a platform the tool does not know how to build patch URLs for
-       (e.g. gitweb, cgit, kernel.org, etc.). In this case, do NOT attempt to guess the web URL
-       or immediately call `get_patch_from_url` with a fabricated URL. Instead:
-       1. Clone the upstream repository locally using the `repository_url` returned by the tool:
-          `git clone --bare <repository_url> /tmp/<project_name>`
-       2. Inspect the candidate commits locally with `git show <hash>` to read the commit
-          message and diff, and determine whether any of them is the correct fix.
-       3. Only after you have confirmed the right commit locally, attempt to construct
-          a download URL for the patch. Try common hosting URL patterns:
-          - cgit: `<base_url>/patch/?id=<hash>`
-          - gitweb: `<base_url>;a=patch;h=<hash>`
-          - kernel.org: `<base_url>/patch/?id=<hash>`
-          If none of these patterns work with `get_patch_from_url`, use the repository URL
-          with the commit hash appended as a fragment (e.g. `<repository_url>#<hash>`)
-          as the patch URL in your final answer.
-   * Using the details from your analysis, search these sources:
-     - Bug Trackers (for fixed bugs matching the issue summary and description)
-     - Git / Version Control (for commit messages, using keywords, CVE IDs, function names, etc.)
-   * Be thorough in your search - try multiple search terms and approaches based on the issue details
-   * Advanced investigation techniques:
-     - If you can identify specific files, functions, or code sections mentioned in the issue,
-       locate them in the source code
-     - Use git history (git log, git blame) to examine changes to those specific code areas
-     - Look for commits that modify the problematic code, especially those with relevant keywords in commit messages
-     - Check git tags and releases around the time when the issue was likely fixed
-     - Search for commits by date ranges when you know approximately when the issue was resolved
-     - Utilize dates strategically in your search if needed, using the version/release date of the package
-       currently used in RHEL
-       - Focus on fixes that came after the RHEL package version date, as earlier fixes would already be included
-       - For CVEs, use the CVE publication date to narrow down the timeframe for fixes
-       - Check upstream release notes and changelogs after the RHEL package version date
-
-   2.3. Validate the Fix and URL
-   * First, make sure the URL is an actual patch/commit link, not an issue or bug tracker reference
-     (e.g. reject URLs containing /issues/, /bug/, bugzilla, jira, /tickets/)
-   * Use the `get_patch_from_url` tool to fetch content from any patch/commit URL you intend to use
-   * Once you have the content, you must validate two things:
-     1. **Is it a patch/diff?** Look for diff indicators like:
-        - `diff --git` headers
-        - `--- a/file +++ b/file` unified diff headers
-        - `@@...@@` hunk headers
-        - `+` and `-` lines showing changes
-     2. **Does it fix the issue?** Examine the actual code changes to verify:
-        - The fix directly addresses the root cause identified in your analysis
-        - The code changes align with the symptoms described in the Jira issue
-        - The modified functions/files match those mentioned in the issue
-   * Only proceed with URLs that contain valid patch content AND address the specific issue
-   * If the content is not a proper patch or doesn't fix the issue, continue searching for other fixes
-
-   2.4. Decide the Outcome
-   * **CRITICAL — Check if the fix belongs to the package or a dependency:**
-     Before deciding on backport, verify that the patch you found modifies the package's OWN source
-     code, not the source code of a dependency. Watch for these signs that the fix is in a DEPENDENCY:
-     - The patch comes from a different upstream repository than the package (e.g., a Go standard
-       library or Go module patch for a Go application, a C library patch for an application that
-       links to it, etc.)
-     - The package bundles or vendors dependencies. Check the spec file for indicators like:
-       * `Provides: bundled(golang(...))` or `Provides: bundled(...)` entries
-       * Vendor tarballs like `Source1: *-vendor.tar.gz` or `Source1: *-vendor-*.tar.*`
-     - The CVE describes a vulnerability in a library, runtime, or language (e.g., Go, Rust,
-       OpenSSL) that the package merely uses or vendors, not in the package's own code
-     **If the fix is in a dependency**, use the "rebuild" resolution instead. The package will
-     pick up the fix automatically when rebuilt against the updated dependency.
-   * If the patch IS for the package's own code and passes both validations in step 2.3, your
-     decision is backport. You must justify why the patch is correct and how it addresses the issue.
-   * If your investigation confirms a valid bug/CVE but fails to locate a specific fix, your decision
-     is clarification-needed
-   * This is the correct choice when you are sure a problem exists but cannot find the solution yourself
-
-   2.5 Set the Jira fields as per the instructions below.
-
-3. **Rebuild**
-   Use when the package needs rebuilding against an updated dependency with NO source code
-   changes. This covers explicit rebuild requests AND vendored/bundled dependency CVEs
-   (common in Go, Rust, Node.js packages — see step 2.4 which redirects here).
-
-   3.1. Confirm no source code changes are needed for the package itself.
-   3.2. Check dependency readiness — search thoroughly:
-   * Look for linked Jira issues in fields.issuelinks representing the dependency update
-   * If no linked issue found, use `search_jira_issues` to find it. Try JQL queries like:
-     - `project = RHEL AND summary ~ "<CVE-ID>" AND component != "<this-package>"`
-     Include fields `["key", "summary", "fixVersions", "status"]` in the search
-   * Once found, call `get_jira_details` on the dependency issue to check its status
-   * If the dependency issue has a `Fixed in Build` field set → resolution is "rebuild"
-     Set `dependency_issue` to the issue key AND `dependency_component` to the component name
-     (e.g., "golang", "openssl") from the dependency issue's component field
-   * Otherwise → resolution is "postponed"
-     Set summary to explain that rebuild is waiting for the dependency to ship,
-     and set pending_issues to the dependency issue key
-   3.3. If rebuild: set Jira fields as per the instructions below.
-
-4. **Open-Ended Analysis**
-   This is the catch-all for issues that don't fit rebase, backport, rebuild, or clarification-needed. Use this when:
-   * The issue requires specfile adjustments, dependency updates, or other packaging-level work
-   * The issue is a QE task, feature request, documentation change, or other non-bug
-   * The issue is a duplicate, misassigned, or otherwise needs no work
-   * The issue is a legitimate problem but doesn't cleanly fit other categories
-   * It is a testing issue and has nothing to do with the selected component
-   * Provide a thorough summary of your findings and a clear recommendation for what action
-     should be taken (or explicitly state that no action is needed and why)
-
-5. **Error**
-   An Error decision is appropriate when there are processing issues that prevent proper analysis, e.g.:
-   * The package mentioned in the issue cannot be found or identified
-   * The issue cannot be accessed
-
-**Final Step: Set JIRA Fields (for Rebase, Backport, and Rebuild decisions only)**
-
-   If your decision is rebase, backport, or rebuild, use `set_jira_fields` tool to update JIRA fields (Severity, Fix Version):
-   1. Check all of the mentioned fields in the JIRA issue and don't modify those that are already set
-   2. Extract the affected RHEL major version from the JIRA issue (look in Affects Version/s field or issue description)
-   3. If the Fix Version field is set, do not change it and use its value in the output.
-   4. If the Fix Version field is not set, use the `map_version` tool with the major version to get available streams
-      and determine appropriate Fix Version:
-       * The tool will return both Y-stream and Z-stream versions (if available) and indicate if it's a maintenance version
-       * For maintenance versions (no Y-stream available):
-         - Critical issues should be fixed (privilege escalation, remote code execution, data loss/corruption, system compromise, regressions, moderate and higher severity CVEs)
-         - Non-critical issues should be marked as open-ended-analysis with appropriate reasoning
-       * For non-maintenance versions (Y-stream available):
-         - Most critical issues (privilege escalation, RCE, data loss, regressions) should use Z-stream
-         - Other issues should use Y-stream (e.g. performance, usability issues)
-   5. Set non-empty JIRA fields:
-       * Severity: default to 'moderate', for important issues use 'important', for most critical use 'critical' (privilege escalation, RCE, data loss)
-       * Fix Version: use the appropriate stream version determined from `map_version` tool result
-
----
-
-## Output Schema
-
-The final output must be a JSON object with the following structure:
-
-```json
-{
-    "resolution": "<one of: rebase, backport, rebuild, clarification-needed, open-ended-analysis, postponed, error>",
-    "data": { ... }
-}
-```
-
-The `data` field MUST be a nested JSON object (not a stringified JSON). Its structure depends on the `resolution`:
-
-### Resolution: "rebase"
-```json
-{
-    "resolution": "rebase",
-    "data": {
-        "package": "package-name",
-        "version": "target upstream version (e.g., '2.4.1')",
-        "jira_issue": "RHEL-12345",
-        "fix_version": "rhel-9.8 (or null)"
-    }
-}
-```
-
-### Resolution: "backport"
-```json
-{
-    "resolution": "backport",
-    "data": {
-        "package": "package-name",
-        "patch_urls": ["https://example.com/commit.patch"],
-        "justification": "Explanation of why this patch fixes the issue",
-        "jira_issue": "RHEL-12345",
-        "cve_id": "CVE-2025-12345 (or null)",
-        "fix_version": "rhel-9.8 (or null)"
-    }
-}
-```
-
-### Resolution: "rebuild"
-```json
-{
-    "resolution": "rebuild",
-    "data": {
-        "package": "package-name",
-        "jira_issue": "RHEL-12345",
-        "dependency_issue": "RHEL-67890 (or null)",
-        "dependency_component": "golang (or null)",
-        "fix_version": "rhel-9.8 (or null)"
-    }
-}
-```
-
-### Resolution: "clarification-needed"
-```json
-{
-    "resolution": "clarification-needed",
-    "data": {
-        "findings": "Summary of understanding and investigation",
-        "additional_info_needed": "What information is missing",
-        "jira_issue": "RHEL-12345"
-    }
-}
-```
-
-### Resolution: "open-ended-analysis"
-```json
-{
-    "resolution": "open-ended-analysis",
-    "data": {
-        "summary": "2-3 sentence summary of the issue analysis",
-        "recommendation": "1-2 sentence recommended course of action",
-        "jira_issue": "RHEL-12345"
-    }
-}
-```
-
-### Resolution: "postponed"
-```json
-{
-    "resolution": "postponed",
-    "data": {
-        "summary": "Reason for postponement",
-        "pending_issues": ["RHEL-67890"],
-        "jira_issue": "RHEL-12345"
-    }
-}
-```
-
-### Resolution: "error"
-```json
-{
-    "resolution": "error",
-    "data": {
-        "details": "Specific details about the error",
-        "jira_issue": "RHEL-12345"
-    }
-}
-```
-
-**Note:** The `jira_issue` field in the output data must always be UPPERCASE (e.g., "RHEL-12345", not "rhel-12345").
+- **resolution**: one of `backport`, `rebase`, `rebuild`, `clarification-needed`, `open-ended-analysis`, `postponed`, `error`
+- **data**: resolution-specific fields:
+  - `backport`: `package`, `patch_url`, `justification`, `jira_issue`, `cve_id` (optional), `fix_version`
+  - `rebase`: `package`, `version`, `jira_issue`, `fix_version`
+  - `rebuild`: `package`, `dependency_issue`, `dependency_component`, `jira_issue`, `fix_version`
+  - `clarification-needed`: `findings`, `additional_info_needed`, `jira_issue`
+  - `open-ended-analysis`: `summary`, `recommendation`, `jira_issue`
+  - `postponed`: `summary`, `pending_issues`, `jira_issue`
+  - `error`: `details`, `jira_issue`

--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -223,7 +223,7 @@ If `is_older_zstream` is true:
   - If the tool says it cannot be used for this project or encounters an internal error, do not try again — proceed with a different approach.
   - If you run out of commits to check, use a different approach; inability to find the fix does not mean it does not exist — search bug trackers and version control systems.
   - **Handling non-GitHub/non-GitLab repositories**: When `upstream_search` returns `related_commits` that are bare commit hashes (not full URLs), the upstream repository is on a platform the tool cannot build patch URLs for (e.g., gitweb, cgit, kernel.org). In this case:
-    1. Do NOT guess the web URL or immediately call `get_patch_from_url` with a fabricated URL.
+    1. Do NOT guess the web URL nor immediately call `get_patch_from_url` with a fabricated URL.
     2. Create a unique temporary directory and clone into it: `CLONE_DIR=$(mktemp -d) && git clone --bare <repository_url> "$CLONE_DIR/repo"`
     3. Inspect candidate commits locally with `git -C "$CLONE_DIR/repo" show <hash>` to read the message and diff.
     4. Only after confirming the right commit locally, attempt to construct a download URL. You MUST use the exact same URL scheme (`http://` or `https://`) as the `repository_url` — do NOT upgrade or downgrade the scheme. Try common patterns:

--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -41,7 +41,18 @@ This skill uses the following tools. Do not restrict tool usage — use any tool
 - `map_version` — Map a RHEL major version to the current Y-stream and Z-stream versions
 - `upstream_search` — Search an upstream project's git repository for commits related to a description
 - `run_shell_command` — Execute shell commands (e.g., `git ls-remote` to verify a package repository exists)
-- `think` — Internal reasoning tool; use it before each decision and after each tool call
+- `think` — Internal reasoning tool; use it at the very first step, before each decision, and after each tool call
+
+## Key Instructions
+
+These constraints apply throughout the entire skill execution:
+
+1. **Be proactive** — search thoroughly for fixes and do not give up easily.
+2. **Always validate patch URLs** — for any patch URL you intend to use for a backport, fetch and validate it using `get_patch_from_url` before including it in your result.
+3. **Do not modify validated URLs** — once a patch URL has been validated with `get_patch_from_url`, do not modify it in your final answer.
+4. **Preserve URL scheme** — when constructing patch URLs from `upstream_search` results, you MUST use the exact URL scheme (`http://` or `https://`) from the `repository_url` returned by `upstream_search`. Do NOT upgrade `http://` to `https://` or vice versa — some upstream repositories only support one protocol.
+5. **Set JIRA fields** — after completing triage analysis, if your decision is backport or rebase, always set appropriate JIRA fields using `set_jira_fields`.
+6. **Use `get_jira_details` first** — call `get_jira_details` before using `upstream_search`, `run_shell_command`, `get_patch_from_url`, `set_jira_fields`, or `search_jira_issues`.
 
 ## Workflow
 
@@ -215,7 +226,7 @@ If `is_older_zstream` is true:
     1. Do NOT guess the web URL or immediately call `get_patch_from_url` with a fabricated URL.
     2. Clone the upstream repository locally: `git clone --bare <repository_url> /tmp/<project_name>`
     3. Inspect candidate commits locally with `git show <hash>` to read the message and diff.
-    4. Only after confirming the right commit locally, attempt to construct a download URL. Try common patterns:
+    4. Only after confirming the right commit locally, attempt to construct a download URL. You MUST use the exact same URL scheme (`http://` or `https://`) as the `repository_url` — do NOT upgrade or downgrade the scheme. Try common patterns:
        - cgit: `<base_url>/patch/?id=<hash>`
        - gitweb: `<base_url>;a=patch;h=<hash>`
        - kernel.org: `<base_url>/patch/?id=<hash>`

--- a/scripts/sync-agent-skills.py
+++ b/scripts/sync-agent-skills.py
@@ -20,7 +20,6 @@ SKILLS_DIR = Path("agents_as_skills")
 
 CLAUDE_CMD_TEMPLATE = (
     "claude --model claude-sonnet-4-6 --effort high"
-    " --allowedTools Read Glob Grep"
     ' "Please take a look at the BeeAI workflows implemented in agents'
     " directory. Please convert Workflow in {workflow_file} to Claude skill and"
     f" save that skill to {SKILLS_DIR} directory.\n"

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import pytest
@@ -14,8 +15,10 @@ class TriageAgentTestCase:
         self.input: str = input
         self.expected_output: TriageOutputSchema = expected_output
         self.metrics: dict = None
+        self.finished_state: TriageState | None = None
+        self.error: BaseException | None = None
 
-    async def run(self) -> TriageState:
+    async def run(self) -> None:
         metrics_middleware = MetricsMiddleware()
 
         def testing_factory(gateway_tools):
@@ -23,9 +26,12 @@ class TriageAgentTestCase:
             triage_agent.middlewares.append(metrics_middleware)
             return triage_agent
 
-        finished_state = await run_workflow(self.input, False, testing_factory)
-        self.metrics = metrics_middleware.get_metrics()
-        return finished_state
+        try:
+            self.finished_state = await run_workflow(self.input, False, testing_factory)
+        except BaseException as e:
+            self.error = e
+        finally:
+            self.metrics = metrics_middleware.get_metrics()
 
 
 test_cases = [
@@ -102,8 +108,16 @@ def observability_fixture():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def mydata(request):
+def run_test_cases_concurrently(request):
+    """Execute all triage test cases concurrently via asyncio.gather, then collect metrics."""
+
+    async def _run_all():
+        await asyncio.gather(*(tc.run() for tc in test_cases))
+
+    asyncio.run(_run_all())
+
     yield
+
     collected_metrics = []
     for test_case in test_cases:
         if test_case.metrics is None:
@@ -112,19 +126,21 @@ def mydata(request):
     request.config.stash["metrics"] = tabulate(collected_metrics, ["Issue", "Time"])
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "test_case",
     test_cases,
 )
-async def test_triage_agent(test_case: TriageAgentTestCase):
-    def verify_result(real_output: TriageOutputSchema, expected_output: TriageOutputSchema):
-        assert real_output.resolution == expected_output.resolution
-        assert real_output.data.package == expected_output.data.package
-        assert real_output.data.patch_urls == expected_output.data.patch_urls
-        assert real_output.data.jira_issue == expected_output.data.jira_issue
-        assert real_output.data.cve_id == expected_output.data.cve_id
-        assert real_output.data.fix_version == expected_output.data.fix_version
+def test_triage_agent(test_case: TriageAgentTestCase):
+    if test_case.error is not None:
+        raise test_case.error
 
-    finished_state = await test_case.run()
-    verify_result(finished_state.triage_result, test_case.expected_output)
+    assert test_case.finished_state is not None, f"Test case {test_case.input} did not produce a result"
+
+    real_output = test_case.finished_state.triage_result
+    expected_output = test_case.expected_output
+    assert real_output.resolution == expected_output.resolution
+    assert real_output.data.package == expected_output.data.package
+    assert real_output.data.patch_urls == expected_output.data.patch_urls
+    assert real_output.data.jira_issue == expected_output.data.jira_issue
+    assert real_output.data.cve_id == expected_output.data.cve_id
+    assert real_output.data.fix_version == expected_output.data.fix_version

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -1,5 +1,7 @@
 import asyncio
+import logging
 import os
+import subprocess
 
 import pytest
 from tabulate import tabulate
@@ -9,6 +11,47 @@ from ymir.agents.observability import setup_observability
 from ymir.agents.triage_agent import TriageState, create_triage_agent, run_workflow
 from ymir.common.models import BackportData, Resolution, TriageOutputSchema
 
+logger = logging.getLogger(__name__)
+
+# Per-test-case CentOS Stream RPM repo fixtures.
+# Each entry maps a Jira issue key to a list of repos that should be cloned
+# and reset to a pre-fix commit so the agent cannot "cheat" by finding the
+# already-applied backport.
+REPO_FIXTURES = {
+    "RHEL-15216": [
+        {
+            "package": "dnsmasq",
+            "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/dnsmasq",
+            "pre_fix_ref": "8a2a7d987c18aecc60c0757b6e47200ba89f3940",  # pragma: allowlist secret
+            "branch": "c8s",
+        },
+    ],
+    "RHEL-112546": [
+        {
+            "package": "libtiff",
+            "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/libtiff",
+            "pre_fix_ref": "1d8f0e982d3beff79b63559640b7bd578109ceaf",  # pragma: allowlist secret
+            "branch": "c9s",
+        },
+    ],
+    "RHEL-61943": [
+        {
+            "package": "dnsmasq",
+            "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/dnsmasq",
+            "pre_fix_ref": "29f30a06a4be3f9af277e049b9f754ae58451306",  # pragma: allowlist secret
+            "branch": "c8s",
+        },
+    ],
+    "RHEL-29712": [
+        {
+            "package": "bind",
+            "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/bind",
+            "pre_fix_ref": "f523ee34fdb30075a28daf6b8a72f2aed52eb80e",  # pragma: allowlist secret
+            "branch": "c8s",
+        },
+    ],
+}
+
 
 class TriageAgentTestCase:
     def __init__(self, input: str, expected_output: TriageOutputSchema):
@@ -17,12 +60,14 @@ class TriageAgentTestCase:
         self.metrics: dict = None
         self.finished_state: TriageState | None = None
         self.error: BaseException | None = None
+        self.git_env: dict | None = None
 
     async def run(self) -> None:
         metrics_middleware = MetricsMiddleware()
 
         def testing_factory(gateway_tools):
-            triage_agent = create_triage_agent(gateway_tools)
+            local_tool_options = {"env": self.git_env} if self.git_env else None
+            triage_agent = create_triage_agent(gateway_tools, local_tool_options)
             triage_agent.middlewares.append(metrics_middleware)
             return triage_agent
 
@@ -108,7 +153,56 @@ def observability_fixture():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def run_test_cases_concurrently(request):
+def mock_centos_stream_repos(tmp_path_factory):
+    """Clone CentOS Stream RPM repos at pre-fix state, one per (test_case, package).
+
+    Each bare clone has its branch ref rewound to the pre-fix commit.  A per-test-case
+    env dict is built with GIT_CONFIG_COUNT / GIT_CONFIG_KEY_* / GIT_CONFIG_VALUE_*
+    so that git's ``insteadOf`` URL rewriting transparently redirects the agent's
+    git commands to the local clone.
+    """
+    repo_dir = tmp_path_factory.mktemp("centos_stream_repos")
+
+    for issue_key, repos in REPO_FIXTURES.items():
+        git_env: dict[str, str] = {}
+        for i, repo_info in enumerate(repos):
+            local_path = repo_dir / f"{issue_key}-{repo_info['package']}.git"
+            logger.info(
+                "Cloning %s (bare) into %s for %s",
+                repo_info["remote_url"],
+                local_path,
+                issue_key,
+            )
+            subprocess.run(
+                ["git", "clone", "--bare", repo_info["remote_url"], str(local_path)],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "update-ref",
+                    f"refs/heads/{repo_info['branch']}",
+                    repo_info["pre_fix_ref"],
+                ],
+                cwd=str(local_path),
+                check=True,
+            )
+            git_env[f"GIT_CONFIG_KEY_{i}"] = f"url.file://{local_path}.insteadOf"
+            git_env[f"GIT_CONFIG_VALUE_{i}"] = repo_info["remote_url"]
+
+        git_env["GIT_CONFIG_COUNT"] = str(len(repos))
+
+        for tc in test_cases:
+            if tc.input == issue_key:
+                tc.git_env = git_env
+                break
+
+    yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def run_test_cases_concurrently(request, mock_centos_stream_repos):
     """Execute all triage test cases concurrently via asyncio.gather, then collect metrics."""
 
     async def _run_all():

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -478,6 +478,10 @@ def create_triage_agent(gateway_tools, local_tool_options=None):
             "to fetch and validate it using get_patch_from_url tool.",
             "Do not modify the patch URL in your final answer after it has been "
             "validated with get_patch_from_url.",
+            "When constructing patch URLs for upstream commits, you MUST preserve "
+            "the exact URL scheme (http:// or https://) from the repository_url "
+            "returned by upstream_search. Do NOT upgrade http:// to https:// or "
+            "vice versa — some upstream repositories only support one protocol.",
             "After completing your triage analysis, if your decision is backport "
             "or rebase, always set appropriate JIRA fields per the instructions "
             "using set_jira_fields tool.",

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -269,7 +269,9 @@ TRIAGE_PROMPT = """
              2. Inspect the candidate commits locally with `git show <hash>` to read the commit
                 message and diff, and determine whether any of them is the correct fix.
              3. Only after you have confirmed the right commit locally, attempt to construct
-                a download URL for the patch. Try common hosting URL patterns:
+                a download URL for the patch. You MUST use the exact same URL scheme
+                (http or https) as the `repository_url` returned by upstream_search.
+                Try common hosting URL patterns:
                 - cgit: `<base_url>/patch/?id=<hash>`
                 - gitweb: `<base_url>;a=patch;h=<hash>`
                 - kernel.org: `<base_url>/patch/?id=<hash>`

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -543,14 +543,14 @@ class TriageState(BaseModel):
     target_branch: str | None = Field(default=None)
 
 
-def create_triage_agent(gateway_tools):
+def create_triage_agent(gateway_tools, local_tool_options=None):
     return RequirementAgent(
         name="TriageAgent",
         llm=get_chat_model(),
         tool_call_checker=get_tool_call_checker_config(),
         tools=[
             ThinkTool(),
-            RunShellCommandTool(),
+            RunShellCommandTool(options=local_tool_options) if local_tool_options else RunShellCommandTool(),
             VersionMapperTool(),
             UpstreamSearchTool(),
         ]

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -173,6 +173,17 @@ TRIAGE_PROMPT = """
 
       1. Open the {{issue}} Jira issue and thoroughly analyze it:
          * Extract key details from the title, description, fields, and comments
+         {{#is_older_zstream}}
+         * Identify the Fix Version using the map_version tool and check if it is an older z-stream.
+           An older z-stream is a z-stream version with a minor number lower than the current
+           z-stream for the same major version.
+         * If the Fix Version is an older z-stream use the zstream_search tool to locate the fix.
+           Provide the following from the Jira issue to the tool:
+           - The component name.
+           - The full issue summary text as-is.
+           - The fix_version string.
+           If the tool returns 'found', use the returned commit URLs as your patch candidates.
+         {{/is_older_zstream}}
          * Pay special attention to comments as they often contain crucial information such as:
            - Additional context about the problem
            - Links to upstream fixes or patches
@@ -181,6 +192,9 @@ TRIAGE_PROMPT = """
          * Identify specific error messages, log snippets, or CVE identifiers
          * Note any functions, files, or methods mentioned
          * Pay attention to any direct links to fixes provided in the issue
+         {{#is_older_zstream}}
+         * Do not use upstream patches for older z-streams.
+         {{/is_older_zstream}}
 
       2. Identify the package name that must be updated:
          * Determine the name of the package from the issue details (usually component name)
@@ -211,10 +225,12 @@ TRIAGE_PROMPT = """
          * Focus on keywords and root cause identification
          * If the Jira issue already provides a direct link to the fix, use that as your primary lead
            (e.g. in the commit hash field or comment)
+          {{#is_older_zstream}}unless backporting to an older z-stream{{/is_older_zstream}}
 
          2.2. Systematic Source Investigation
          * Even if the Jira issue provides a direct link to a fix, you need to validate it
          * When no direct link is provided, you must proactively search for fixes - do not give up easily
+         {{^is_older_zstream}}
          * There are 2 locations where you can search for the fixes: Fedora and upstream project.
          * First, check if the fix is in Fedora repository in https://src.fedoraproject.org/rpms/<package_name>.
            * In Fedora, search for .patch files and check git commit history
@@ -224,6 +240,13 @@ TRIAGE_PROMPT = """
             * Links from the Jira issue (if any direct upstream links are provided)
             * Package spec file (<package>.spec) in the GitLab repository:
               check the URL field or Source0 field for upstream project location
+         {{/is_older_zstream}}
+         {{#is_older_zstream}}
+         * Identify the official upstream project from two sources:
+            * Links from the Jira issue (if any direct upstream links are provided)
+            * Package spec file (<package>.spec) in the GitLab repository:
+              check the URL field or Source0 field for upstream project location
+         {{/is_older_zstream}}
 
          * Try to use upstream_search tool to find out commits related to the issue.
            - The description you will use should be 1-2 sentences long and include implementation
@@ -291,6 +314,7 @@ TRIAGE_PROMPT = """
          * If the content is not a proper patch or doesn't fix the issue, continue searching for other fixes
 
          2.4. Decide the Outcome
+         {{^is_older_zstream}}
          * **CRITICAL — Check if the fix belongs to the package or a dependency:**
            Before deciding on backport, verify that the patch you found modifies the package's OWN source
            code, not the source code of a dependency. Watch for these signs that the fix is in a DEPENDENCY:
@@ -306,6 +330,12 @@ TRIAGE_PROMPT = """
            pick up the fix automatically when rebuilt against the updated dependency.
          * If the patch IS for the package's own code and passes both validations in step 2.3, your
            decision is backport. You must justify why the patch is correct and how it addresses the issue.
+         {{/is_older_zstream}}
+         {{#is_older_zstream}}
+         * If your investigation successfully identifies a specific fix that
+           passes both validations in step 2.3, your decision is backport
+         * You must be able to justify why the patch is correct and how it addresses the issue
+         {{/is_older_zstream}}
          * If your investigation confirms a valid bug/CVE but fails to locate a specific fix, your decision
            is clarification-needed
          * This is the correct choice when you are sure a problem exists but cannot find the solution yourself
@@ -333,24 +363,34 @@ TRIAGE_PROMPT = """
          3.3. If rebuild: set Jira fields as per the instructions below.
 
       4. **Open-Ended Analysis**
-         This is the catch-all for issues that don't fit rebase, backport,
-         rebuild, or clarification-needed. Use this when:
-         * The issue requires specfile adjustments, dependency updates, or other packaging-level work
-         * The issue is a QE task, feature request, documentation change, or other non-bug
+         This is the catch-all for issues that are NOT bugs or CVEs
+         requiring code fixes. Use this when:
+         * The issue requires specfile adjustments, dependency updates,
+           or other packaging-level work
+         * The issue is a QE task, feature request, documentation change,
+           or other non-bug
+         * Refactoring or code restructuring without fixing bugs
          * The issue is a duplicate, misassigned, or otherwise needs no work
-         * The issue is a legitimate problem but doesn't cleanly fit other categories
-         * It is a testing issue and has nothing to do with the selected component
-         * Provide a thorough summary of your findings and a clear recommendation for what action
-           should be taken (or explicitly state that no action is needed and why)
+         * The issue is a legitimate problem but doesn't cleanly fit
+           other categories
+         * It is a testing issue and has nothing to do with the
+           selected component
+         * Vague requests or insufficient information to identify a bug
+         * Note: This is not for valid bugs where you simply can't
+           find the patch
+         * Provide a thorough summary of your findings and a clear
+           recommendation for what action should be taken (or explicitly
+           state that no action is needed and why)
 
       5. **Error**
          An Error decision is appropriate when there are processing issues that prevent proper analysis, e.g.:
          * The package mentioned in the issue cannot be found or identified
          * The issue cannot be accessed
 
-      **Final Step: Set JIRA Fields (for Rebase, Backport, and Rebuild decisions only)**
+      **Final Step: Set JIRA Fields
+      (for Rebase, Backport, and Rebuild decisions only)**
 
-         If your decision is rebase, backport, or rebuild, use set_jira_fields
+         If your decision is rebase or backport or rebuild, use set_jira_fields
          tool to update JIRA fields (Severity, Fix Version):
          1. Check all of the mentioned fields in the JIRA issue and don't modify those that are already set
          2. Extract the affected RHEL major version from the JIRA issue
@@ -376,198 +416,11 @@ TRIAGE_PROMPT = """
              * Fix Version: use the appropriate stream version determined from map_version tool result
     """
 
-TRIAGE_PROMPT_ZSTREAM = """
-      You are an agent tasked to analyze Jira issues for RHEL and identify
-      the most efficient path to resolution, whether through a version rebase,
-      a patch backport, or by requesting clarification when blocked.
-
-      **Important**: Focus on bugs, CVEs, and technical defects that need code fixes.
-      QE tasks, feature requests, refactoring, documentation,
-      and other non-bug issues should be marked as "no-action".
-
-      Goal: Analyze the given issue to determine the correct course of action.
-
-      **Initial Analysis Steps**
-
-      1. Open the {{issue}} Jira issue and thoroughly analyze it:
-         * Extract key details from the title, description, fields, and comments
-         * Identify the Fix Version using the map_version tool and check if it is an older z-stream.
-           An older z-stream is a z-stream version with a minor number lower than the current
-           z-stream for the same major version.
-         * If the Fix Version is an older z-stream use the zstream_search tool to locate the fix.
-           Provide the following from the Jira issue to the tool:
-           - The component name.
-           - The full issue summary text as-is.
-           - The fix_version string.
-           If the tool returns 'found', use the returned commit URLs as your patch candidates.
-         * Pay special attention to comments as they often contain crucial information such as:
-           - Additional context about the problem
-           - Links to upstream fixes or patches
-           - Clarifications from reporters or developers
-         * Look for keywords indicating the root cause of the problem
-         * Identify specific error messages, log snippets, or CVE identifiers
-         * Note any functions, files, or methods mentioned
-         * Pay attention to any direct links to fixes provided in the issue
-         * Do not use upstream patches for older z-streams.
-
-      2. Identify the package name that must be updated:
-         * Determine the name of the package from the issue details (usually component name)
-         * Confirm the package repository exists by running
-           `GIT_TERMINAL_PROMPT=0 git ls-remote https://gitlab.com/redhat/centos-stream/rpms/<package_name>`
-         * A successful command (exit code 0) confirms the package exists
-         * If the package does not exist, re-examine the Jira issue
-           for the correct package name and if it is not found,
-           return error and explicitly state the reason
-
-      3. Proceed to decision making process described below.
-
-      **Decision Guidelines & Investigation Steps**
-
-      You must decide between one of 5 actions. Follow these guidelines to make your decision:
-
-      1. **Rebase**
-         * A Rebase is only to be chosen when the issue explicitly instructs you to "rebase" or "update"
-           to a newer/specific upstream version. Do not infer this.
-         * Identify the <package_version> the package should be updated or rebased to.
-         * Set the Jira fields as per the instructions below.
-
-      2. **Backport a Patch OR Request Clarification**
-         This path is for issues that represent a clear bug or CVE that needs a targeted fix.
-
-         2.1. Deep Analysis of the Issue
-         * Use the details extracted from your initial analysis
-         * Focus on keywords and root cause identification
-         * If the Jira issue already provides a direct link to the fix, use that as your primary lead
-           (e.g. in the commit hash field or comment) unless backporting to an older z-stream.
-
-         2.2. Systematic Source Investigation
-         * Identify the official upstream project from two sources:
-            * Links from the Jira issue (if any direct upstream links are provided)
-            * Package spec file (<package>.spec) in the GitLab repository:
-              check the URL field or Source0 field for upstream project location
-
-         * Even if the Jira issue provides a direct link to a fix, you need to validate it
-         * When no direct link is provided, you must proactively search for fixes - do not give up easily
-         * Try to use upstream_search tool to find out commits related to the issue.
-           - The description you will use should be 1-2 sentences long and include implementation
-             details, keywords, function names or any other helpful information.
-           - The description should be like a command for example `Fix`, `Add` etc.
-           - If the tool gives you list of URLs use them without any change.
-           - Use release date of upstream version used in RHEL if you know it.
-           - If the tool says it can not be used for this project, or it encounters internal error,
-             do not try to use it again and proceed with different approach.
-           - If you run out of commits to check, use different approach, do not give up. Inability
-             of the tool to find proper fix does not mean it does not exist, search bug trackers
-             and version control system.
-           - **Handling non-GitHub/non-GitLab repositories**: When the upstream_search tool returns
-             `related_commits` that are bare commit hashes (not full URLs), it means the upstream
-             repository is hosted on a platform the tool does not know how to build patch URLs for
-             (e.g. gitweb, cgit, kernel.org, etc.). In this case, do NOT attempt to guess the web URL
-             or immediately call get_patch_from_url with a fabricated URL. Instead:
-             1. Clone the upstream repository locally using the `repository_url` returned by the tool:
-                `git clone --bare <repository_url> /tmp/<project_name>`
-             2. Inspect the candidate commits locally with `git show <hash>` to read the commit
-                message and diff, and determine whether any of them is the correct fix.
-             3. Only after you have confirmed the right commit locally, attempt to construct
-                a download URL for the patch. Try common hosting URL patterns:
-                - cgit: `<base_url>/patch/?id=<hash>`
-                - gitweb: `<base_url>;a=patch;h=<hash>`
-                - kernel.org: `<base_url>/patch/?id=<hash>`
-                If none of these patterns work with get_patch_from_url, use the repository URL
-                with the commit hash appended as a fragment (e.g. `<repository_url>#<hash>`)
-                as the patch URL in your final answer.
-         * Using the details from your analysis, search these sources:
-           - Bug Trackers (for fixed bugs matching the issue summary and description)
-           - Git / Version Control (for commit messages, using keywords, CVE IDs, function names, etc.)
-         * Be thorough in your search - try multiple search terms and approaches based on the issue details
-         * Advanced investigation techniques:
-           - If you can identify specific files, functions, or code sections mentioned in the issue,
-             locate them in the source code
-           - Use git history (git log, git blame) to examine changes to those specific code areas
-           - Look for commits that modify the problematic code, especially those
-             with relevant keywords in commit messages
-           - Check git tags and releases around the time when the issue was likely fixed
-           - Search for commits by date ranges when you know approximately when the issue was resolved
-           - Utilize dates strategically in your search if needed, using
-             the version/release date of the package
-             currently used in RHEL
-             - Focus on fixes that came after the RHEL package version date,
-               as earlier fixes would already be included
-             - For CVEs, use the CVE publication date to narrow down the timeframe for fixes
-             - Check upstream release notes and changelogs after the RHEL package version date
-
-         2.3. Validate the Fix and URL
-         * Use the PatchValidator tool to fetch content from any patch/commit URL you intend to use
-         * The tool will verify the URL is accessible and not an issue reference, then return the content
-         * Once you have the content, you must validate two things:
-           1. **Is it a patch/diff?** Look for diff indicators like:
-              - `diff --git` headers
-              - `--- a/file +++ b/file` unified diff headers
-              - `@@...@@` hunk headers
-              - `+` and `-` lines showing changes
-           2. **Does it fix the issue?** Examine the actual code changes to verify:
-              - The fix directly addresses the root cause identified in your analysis
-              - The code changes align with the symptoms described in the Jira issue
-              - The modified functions/files match those mentioned in the issue
-         * Only proceed with URLs that contain valid patch content AND address the specific issue
-         * If the content is not a proper patch or doesn't fix the issue, continue searching for other fixes
-
-         2.4. Decide the Outcome
-         * If your investigation successfully identifies a specific fix that
-           passes both validations in step 2.3, your decision is backport
-         * You must be able to justify why the patch is correct and how it addresses the issue
-         * If your investigation confirms a valid bug/CVE but fails to locate a specific fix, your decision
-           is clarification-needed
-         * This is the correct choice when you are sure a problem exists but cannot find the solution yourself
-
-         2.5 Set the Jira fields as per the instructions below.
-
-      3. **No Action**
-         A No Action decision is appropriate for issues that are NOT bugs or CVEs requiring code fixes:
-         * QE tasks, testing, or validation work
-         * Feature requests or enhancements
-         * Refactoring or code restructuring without fixing bugs
-         * Documentation, build system, or process changes
-         * Vague requests or insufficient information to identify a bug
-         * Note: This is not for valid bugs where you simply can't find the patch
-
-      4. **Error**
-         An Error decision is appropriate when there are processing issues that prevent proper analysis, e.g.:
-         * The package mentioned in the issue cannot be found or identified
-         * The issue cannot be accessed
-
-      **Final Step: Set JIRA Fields (for Rebase and Backport decisions only)**
-
-         If your decision is rebase or backport, use set_jira_fields tool
-         to update JIRA fields (Severity, Fix Version):
-         1. Check all of the mentioned fields in the JIRA issue and don't modify those that are already set
-         2. Extract the affected RHEL major version from the JIRA issue
-            (look in Affects Version/s field or issue description)
-         3. If the Fix Version field is set, do not change it and use its value in the output.
-         4. If the Fix Version field is not set, use the map_version tool
-            with the major version to get available streams
-            and determine appropriate Fix Version:
-             * The tool will return both Y-stream and Z-stream versions
-               (if available) and indicate if it's a maintenance version
-             * For maintenance versions (no Y-stream available):
-               - Critical issues should be fixed (privilege escalation,
-                 remote code execution, data loss/corruption, system compromise,
-                 regressions, moderate and higher severity CVEs)
-               - Non-critical issues should be marked as no-action with appropriate reasoning
-             * For non-maintenance versions (Y-stream available):
-               - Most critical issues (privilege escalation, RCE, data loss, regressions) should use Z-stream
-               - Other issues should use Y-stream (e.g. performance, usability issues)
-         5. Set non-empty JIRA fields:
-             * Severity: default to 'moderate', for important issues use
-               'important', for most critical use 'critical'
-               (privilege escalation, RCE, data loss)
-             * Fix Version: use the appropriate stream version determined from map_version tool result
-    """
-
 
 async def render_prompt(input: InputSchema, fix_version: str | None = None) -> str:
-    template = TRIAGE_PROMPT_ZSTREAM if fix_version and await is_older_zstream(fix_version) else TRIAGE_PROMPT
-    return PromptTemplate(schema=InputSchema, template=template).render(input)
+    older_zstream = bool(fix_version and await is_older_zstream(fix_version))
+    input_with_flag = input.model_copy(update={"is_older_zstream": older_zstream})
+    return PromptTemplate(schema=InputSchema, template=TRIAGE_PROMPT).render(input_with_flag)
 
 
 class TriageState(BaseModel):

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -263,7 +263,7 @@ TRIAGE_PROMPT = """
              `related_commits` that are bare commit hashes (not full URLs), it means the upstream
              repository is hosted on a platform the tool does not know how to build patch URLs for
              (e.g. gitweb, cgit, kernel.org, etc.). In this case, do NOT attempt to guess the web URL
-             or immediately call get_patch_from_url with a fabricated URL. Instead:
+             nor immediately call get_patch_from_url with a fabricated URL. Instead:
              1. Create a unique temporary directory and clone into it:
                 `CLONE_DIR=$(mktemp -d) && git clone --bare <repository_url> "$CLONE_DIR/repo"`
              2. Inspect the candidate commits locally with `git -C "$CLONE_DIR/repo" show <hash>`

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -236,6 +236,23 @@ TRIAGE_PROMPT = """
            - If you run out of commits to check, use different approach, do not give up. Inability
              of the tool to find proper fix does not mean it does not exist, search bug trackers
              and version control system.
+           - **Handling non-GitHub/non-GitLab repositories**: When the upstream_search tool returns
+             `related_commits` that are bare commit hashes (not full URLs), it means the upstream
+             repository is hosted on a platform the tool does not know how to build patch URLs for
+             (e.g. gitweb, cgit, kernel.org, etc.). In this case, do NOT attempt to guess the web URL
+             or immediately call get_patch_from_url with a fabricated URL. Instead:
+             1. Clone the upstream repository locally using the `repository_url` returned by the tool:
+                `git clone --bare <repository_url> /tmp/<project_name>`
+             2. Inspect the candidate commits locally with `git show <hash>` to read the commit
+                message and diff, and determine whether any of them is the correct fix.
+             3. Only after you have confirmed the right commit locally, attempt to construct
+                a download URL for the patch. Try common hosting URL patterns:
+                - cgit: `<base_url>/patch/?id=<hash>`
+                - gitweb: `<base_url>;a=patch;h=<hash>`
+                - kernel.org: `<base_url>/patch/?id=<hash>`
+                If none of these patterns work with get_patch_from_url, use the repository URL
+                with the commit hash appended as a fragment (e.g. `<repository_url>#<hash>`)
+                as the patch URL in your final answer.
          * Using the details from your analysis, search these sources:
            - Bug Trackers (for fixed bugs matching the issue summary and description)
            - Git / Version Control (for commit messages, using keywords, CVE IDs, function names, etc.)
@@ -442,6 +459,23 @@ TRIAGE_PROMPT_ZSTREAM = """
            - If you run out of commits to check, use different approach, do not give up. Inability
              of the tool to find proper fix does not mean it does not exist, search bug trackers
              and version control system.
+           - **Handling non-GitHub/non-GitLab repositories**: When the upstream_search tool returns
+             `related_commits` that are bare commit hashes (not full URLs), it means the upstream
+             repository is hosted on a platform the tool does not know how to build patch URLs for
+             (e.g. gitweb, cgit, kernel.org, etc.). In this case, do NOT attempt to guess the web URL
+             or immediately call get_patch_from_url with a fabricated URL. Instead:
+             1. Clone the upstream repository locally using the `repository_url` returned by the tool:
+                `git clone --bare <repository_url> /tmp/<project_name>`
+             2. Inspect the candidate commits locally with `git show <hash>` to read the commit
+                message and diff, and determine whether any of them is the correct fix.
+             3. Only after you have confirmed the right commit locally, attempt to construct
+                a download URL for the patch. Try common hosting URL patterns:
+                - cgit: `<base_url>/patch/?id=<hash>`
+                - gitweb: `<base_url>;a=patch;h=<hash>`
+                - kernel.org: `<base_url>/patch/?id=<hash>`
+                If none of these patterns work with get_patch_from_url, use the repository URL
+                with the commit hash appended as a fragment (e.g. `<repository_url>#<hash>`)
+                as the patch URL in your final answer.
          * Using the details from your analysis, search these sources:
            - Bug Trackers (for fixed bugs matching the issue summary and description)
            - Git / Version Control (for commit messages, using keywords, CVE IDs, function names, etc.)

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -264,10 +264,11 @@ TRIAGE_PROMPT = """
              repository is hosted on a platform the tool does not know how to build patch URLs for
              (e.g. gitweb, cgit, kernel.org, etc.). In this case, do NOT attempt to guess the web URL
              or immediately call get_patch_from_url with a fabricated URL. Instead:
-             1. Clone the upstream repository locally using the `repository_url` returned by the tool:
-                `git clone --bare <repository_url> /tmp/<project_name>`
-             2. Inspect the candidate commits locally with `git show <hash>` to read the commit
-                message and diff, and determine whether any of them is the correct fix.
+             1. Create a unique temporary directory and clone into it:
+                `CLONE_DIR=$(mktemp -d) && git clone --bare <repository_url> "$CLONE_DIR/repo"`
+             2. Inspect the candidate commits locally with `git -C "$CLONE_DIR/repo" show <hash>`
+                to read the commit message and diff, and determine whether any of them is the
+                correct fix.
              3. Only after you have confirmed the right commit locally, attempt to construct
                 a download URL for the patch. You MUST use the exact same URL scheme
                 (http or https) as the `repository_url` returned by upstream_search.

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -58,6 +58,10 @@ class TriageInputSchema(BaseModel):
             " (eligibility=PENDING_DEPENDENCIES or NEVER)"
         ),
     )
+    is_older_zstream: bool = Field(
+        default=False,
+        description="Whether the issue targets an older Z-stream",
+    )
 
 
 class Task(BaseModel):

--- a/ymir/tools/unprivileged/commands.py
+++ b/ymir/tools/unprivileged/commands.py
@@ -60,6 +60,7 @@ class RunShellCommandTool(Tool[RunShellCommandToolInput, ToolRunOptions, RunShel
                     tool_input.command,
                     shell=True,
                     cwd=(self.options or {}).get("working_directory"),
+                    env=(self.options or {}).get("env"),
                 ),
                 timeout=TIMEOUT,
             )


### PR DESCRIPTION
- Run triage e2e tests in parallel
- Mock CentOS Stream RPM repositories during testing
- Merge the two triage prompts into one
- Add instructions for handling non-GitHub/non-GitLab upstreams with upstream-search
- Enforce URL scheme preservation