### PR TITLE
Add SILENT_RUN to triage agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ MOCK_JIRA ?= false
 JIRA_DRY_RUN ?= false
 AUTO_CHAIN ?= true
 FORCE_CVE_TRIAGE ?= false
+SILENT_RUN ?= false
 
 COMPOSE ?= $(shell if podman compose ls >/dev/null 2>&1; then echo "podman compose"; elif command -v podman-compose >/dev/null 2>&1; then echo "podman-compose"; else echo "docker-compose"; fi)
 COMPOSE_AGENTS=$(COMPOSE) -f $(COMPOSE_FILE) --profile=agents
@@ -26,6 +27,7 @@ run-triage-agent-standalone:
 		-e MOCK_JIRA=$(MOCK_JIRA) \
 		-e JIRA_DRY_RUN=$(JIRA_DRY_RUN) \
 		-e FORCE_CVE_TRIAGE=$(FORCE_CVE_TRIAGE) \
+		-e SILENT_RUN=$(SILENT_RUN) \
 		triage-agent
 
 .PHONY: run-triage-agent-e2e-tests
@@ -169,11 +171,11 @@ build-jira-issue-fetcher:
 
 .PHONY: start
 start:
-	DRY_RUN=$(DRY_RUN) MOCK_JIRA=$(MOCK_JIRA) JIRA_DRY_RUN=$(JIRA_DRY_RUN) AUTO_CHAIN=$(AUTO_CHAIN) $(COMPOSE_AGENTS) up
+	DRY_RUN=$(DRY_RUN) MOCK_JIRA=$(MOCK_JIRA) JIRA_DRY_RUN=$(JIRA_DRY_RUN) AUTO_CHAIN=$(AUTO_CHAIN) SILENT_RUN=$(SILENT_RUN) $(COMPOSE_AGENTS) up
 
 .PHONY: start-detached
 start-detached:
-	DRY_RUN=$(DRY_RUN) MOCK_JIRA=$(MOCK_JIRA) JIRA_DRY_RUN=$(JIRA_DRY_RUN) AUTO_CHAIN=$(AUTO_CHAIN) $(COMPOSE_AGENTS) up -d
+	DRY_RUN=$(DRY_RUN) MOCK_JIRA=$(MOCK_JIRA) JIRA_DRY_RUN=$(JIRA_DRY_RUN) AUTO_CHAIN=$(AUTO_CHAIN) SILENT_RUN=$(SILENT_RUN) $(COMPOSE_AGENTS) up -d
 
 .PHONY: stop
 stop:

--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -13,6 +13,9 @@ arguments:
   - name: auto_chain
     description: "If true, suppress the follow-up note in the Jira comment (downstream automation will handle it). Default: false"
     required: false
+  - name: silent_run
+    description: "If true, only post Jira comments and set labels when the resolution is not-affected or postponed. Default: false"
+    required: false
 ---
 
 # Triage Skill
@@ -25,6 +28,7 @@ You are a Red Hat Enterprise Linux developer performing triage on a Jira issue t
 - `dry_run`: {{dry_run}}
 - `force_cve_triage`: {{force_cve_triage}}
 - `auto_chain`: {{auto_chain}}
+- `silent_run`: {{silent_run}}
 
 ## Tools
 
@@ -255,6 +259,8 @@ Clean up any temporary applicability directories created in Step 5.
 If `applicability_check_skipped` is true, append to the comment: `"Note: CVE applicability check could not be performed (source preparation failed)."`
 
 If `dry_run` is true, end the skill without posting.
+
+If `silent_run` is true and the resolution is **not** one of `not-affected` or `postponed`, skip posting the comment and end the skill. In silent mode, only `not-affected` and `postponed` resolutions produce Jira comments and label updates.
 
 Otherwise call `add_jira_comment` with `issue_key` = `{{jira_issue}}` and a comment that summarises the triage result. Format the comment based on the resolution type:
 

--- a/ymir/agents/rebuild_consolidation.py
+++ b/ymir/agents/rebuild_consolidation.py
@@ -22,9 +22,27 @@ from ymir.common.models import (
     Resolution,
     TriageEligibility,
 )
-from ymir.tools.privileged.jira import build_rebuild_siblings_jql
 
 logger = logging.getLogger(__name__)
+
+
+def build_rebuild_siblings_jql(
+    issue_key: str,
+    component: str,
+    fix_version: str,
+) -> str:
+    escaped_component = component.replace('"', '\\"')
+    escaped_fix_version = fix_version.replace('"', '\\"')
+    return (
+        f'project = RHEL AND component = "{escaped_component}" '
+        f'AND fixVersion = "{escaped_fix_version}" '
+        f'AND key != "{issue_key}" '
+        f'AND labels = "SecurityTracking" '
+        f"AND labels not in "
+        f'("ymir_triaged_rebuild", "ymir_rebuilt", '
+        f'"ymir_triaged_not_affected", "ymir_triaged_backport", "ymir_triaged_rebase") '
+        f'AND status in ("New", "Planning")'
+    )
 
 
 class SiblingRebuildAnalysis(BaseModel):

--- a/ymir/agents/tests/unit/test_rebuild_consolidation.py
+++ b/ymir/agents/tests/unit/test_rebuild_consolidation.py
@@ -1,0 +1,22 @@
+from ymir.agents.rebuild_consolidation import build_rebuild_siblings_jql
+
+
+def test_build_rebuild_siblings_jql():
+    jql = build_rebuild_siblings_jql("RHEL-100", "git-lfs", "rhel-9.8")
+    assert 'component = "git-lfs"' in jql
+    assert 'fixVersion = "rhel-9.8"' in jql
+    assert 'key != "RHEL-100"' in jql
+    assert 'labels = "SecurityTracking"' in jql
+    assert "labels not in" in jql
+    assert '"ymir_triaged_rebuild"' in jql
+    assert '"ymir_rebuilt"' in jql
+    assert '"ymir_triaged_not_affected"' in jql
+    assert '"ymir_triaged_backport"' in jql
+    assert '"ymir_triaged_rebase"' in jql
+    assert 'status in ("New", "Planning")' in jql
+
+
+def test_build_rebuild_siblings_jql_escapes_quotes():
+    jql = build_rebuild_siblings_jql("RHEL-100", 'comp"name', 'rhel-9.8"z')
+    assert r'component = "comp\"name"' in jql
+    assert r'fixVersion = "rhel-9.8\"z"' in jql

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -61,11 +61,23 @@ from ymir.tools.unprivileged.version_mapper import VersionMapperTool
 logger = logging.getLogger(__name__)
 
 
-def _should_update_jira(silent_run: bool, resolution: Resolution) -> bool:
+def _should_update_jira(silent_run: bool, resolution: Resolution = None) -> bool:
     """In silent mode, only update Jira for not-affected and postponed resolutions."""
     if not silent_run:
         return True
     return resolution in (Resolution.NOT_AFFECTED, Resolution.POSTPONED)
+
+
+_RESOLUTION_TO_LABEL: dict[Resolution, JiraLabels] = {
+    Resolution.REBASE: JiraLabels.TRIAGED_REBASE,
+    Resolution.BACKPORT: JiraLabels.TRIAGED_BACKPORT,
+    Resolution.REBUILD: JiraLabels.TRIAGED_REBUILD,
+    Resolution.CLARIFICATION_NEEDED: JiraLabels.NEEDS_ATTENTION,
+    Resolution.OPEN_ENDED_ANALYSIS: JiraLabels.TRIAGED,
+    Resolution.POSTPONED: JiraLabels.TRIAGED_POSTPONED,
+    Resolution.NOT_AFFECTED: JiraLabels.TRIAGED_NOT_AFFECTED,
+    Resolution.ERROR: JiraLabels.TRIAGE_ERRORED,
+}
 
 
 async def determine_target_branch(
@@ -1060,7 +1072,7 @@ async def main() -> None:
                     await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
 
             try:
-                if not silent_run:
+                if _should_update_jira(silent_run):
                     await tasks.set_jira_labels(
                         jira_issue=input.issue,
                         labels_to_add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
@@ -1100,48 +1112,17 @@ async def main() -> None:
                 )
             else:
                 update_jira = _should_update_jira(silent_run, output.resolution)
+                logger.info(f"Triage resolved as {output.resolution.value} for {input.issue}")
 
-                if output.resolution == Resolution.REBASE:
-                    logger.info(f"Triage resolved as REBASE for {input.issue}")
-                    if update_jira:
-                        await tasks.set_jira_labels(
-                            jira_issue=input.issue,
-                            labels_to_add=[JiraLabels.TRIAGED_REBASE.value],
-                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                            dry_run=dry_run,
-                        )
-                    if auto_chain:
-                        task = Task(metadata=state.model_dump())
-                        rebase_queue = RedisQueues.get_rebase_queue_for_branch(state.target_branch)
-                        await fix_await(redis.lpush(rebase_queue, task.model_dump_json()))
-                        logger.info(f"Pushed {input.issue} to {rebase_queue}")
-                    else:
-                        logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
-                elif output.resolution == Resolution.BACKPORT:
-                    logger.info(f"Triage resolved as BACKPORT for {input.issue}")
-                    if update_jira:
-                        await tasks.set_jira_labels(
-                            jira_issue=input.issue,
-                            labels_to_add=[JiraLabels.TRIAGED_BACKPORT.value],
-                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                            dry_run=dry_run,
-                        )
-                    if auto_chain:
-                        task = Task(metadata=state.model_dump())
-                        backport_queue = RedisQueues.get_backport_queue_for_branch(state.target_branch)
-                        await fix_await(redis.lpush(backport_queue, task.model_dump_json()))
-                        logger.info(f"Pushed {input.issue} to {backport_queue}")
-                    else:
-                        logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
-                elif output.resolution == Resolution.REBUILD:
-                    logger.info(f"Triage resolved as REBUILD for {input.issue}")
-                    if update_jira:
-                        await tasks.set_jira_labels(
-                            jira_issue=input.issue,
-                            labels_to_add=[JiraLabels.TRIAGED_REBUILD.value],
-                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                            dry_run=dry_run,
-                        )
+                resolution_label = _RESOLUTION_TO_LABEL.get(output.resolution)
+                if update_jira and resolution_label:
+                    await tasks.set_jira_labels(
+                        jira_issue=input.issue,
+                        labels_to_add=[resolution_label.value],
+                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                        dry_run=dry_run,
+                    )
+                    if output.resolution == Resolution.REBUILD:
                         for consolidated in output.data.consolidated_issues:
                             try:
                                 await tasks.set_jira_labels(
@@ -1152,63 +1133,14 @@ async def main() -> None:
                                 )
                             except Exception as e:
                                 logger.warning(
-                                    f"Failed to set labels on consolidated issue {consolidated.issue_key}: {e}"
+                                    f"Failed to set labels on consolidated issue "
+                                    f"{consolidated.issue_key}: {e}"
                                 )
-                    if auto_chain:
-                        task = Task(metadata=state.model_dump())
-                        rebuild_queue = RedisQueues.get_rebuild_queue_for_branch(state.target_branch)
-                        await fix_await(redis.lpush(rebuild_queue, task.model_dump_json()))
-                        logger.info(f"Pushed {input.issue} to {rebuild_queue}")
-                    else:
-                        logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
-                elif output.resolution == Resolution.CLARIFICATION_NEEDED:
-                    logger.info(f"Triage resolved as CLARIFICATION_NEEDED for {input.issue}")
-                    if update_jira:
-                        await tasks.set_jira_labels(
-                            jira_issue=input.issue,
-                            labels_to_add=[JiraLabels.NEEDS_ATTENTION.value],
-                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                            dry_run=dry_run,
-                        )
-                    if auto_chain:
-                        task = Task(metadata=state.model_dump())
-                        await fix_await(
-                            redis.lpush(
-                                RedisQueues.CLARIFICATION_NEEDED_QUEUE.value,
-                                task.model_dump_json(),
-                            )
-                        )
-                        logger.info(f"Pushed {input.issue} to {RedisQueues.CLARIFICATION_NEEDED_QUEUE.value}")
-                    else:
-                        logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
-                elif output.resolution == Resolution.OPEN_ENDED_ANALYSIS:
-                    logger.info(f"Triage resolved as OPEN_ENDED_ANALYSIS for {input.issue}")
-                    if update_jira:
-                        await tasks.set_jira_labels(
-                            jira_issue=input.issue,
-                            labels_to_add=[JiraLabels.TRIAGED.value],
-                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                            dry_run=dry_run,
-                        )
-                    if auto_chain:
-                        await fix_await(
-                            redis.lpush(
-                                RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value,
-                                output.data.model_dump_json(),
-                            )
-                        )
-                        logger.info(f"Pushed {input.issue} to {RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value}")
-                    else:
-                        logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
+
+                # Dispatch to downstream queues
+                if output.resolution == Resolution.ERROR:
+                    await retry(task, output.data.model_dump_json())
                 elif output.resolution == Resolution.POSTPONED:
-                    logger.info(f"Triage resolved as POSTPONED for {input.issue}")
-                    if update_jira:
-                        await tasks.set_jira_labels(
-                            jira_issue=input.issue,
-                            labels_to_add=[JiraLabels.TRIAGED_POSTPONED.value],
-                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                            dry_run=dry_run,
-                        )
                     await fix_await(
                         redis.lpush(
                             RedisQueues.POSTPONED_LIST.value,
@@ -1216,25 +1148,32 @@ async def main() -> None:
                         )
                     )
                     logger.info(f"Pushed {input.issue} to {RedisQueues.POSTPONED_LIST.value}")
-                elif output.resolution == Resolution.NOT_AFFECTED:
-                    logger.info(f"Triage resolved as NOT_AFFECTED for {input.issue}")
-                    if update_jira:
-                        await tasks.set_jira_labels(
-                            jira_issue=input.issue,
-                            labels_to_add=[JiraLabels.TRIAGED_NOT_AFFECTED.value],
-                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                            dry_run=dry_run,
-                        )
-                elif output.resolution == Resolution.ERROR:
-                    logger.warning(f"Triage resolved as ERROR for {input.issue}, retrying")
-                    if update_jira:
-                        await tasks.set_jira_labels(
-                            jira_issue=input.issue,
-                            labels_to_add=[JiraLabels.TRIAGE_ERRORED.value],
-                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                            dry_run=dry_run,
-                        )
-                    await retry(task, output.data.model_dump_json())
+                elif output.resolution in (
+                    Resolution.REBASE,
+                    Resolution.BACKPORT,
+                    Resolution.REBUILD,
+                    Resolution.CLARIFICATION_NEEDED,
+                    Resolution.OPEN_ENDED_ANALYSIS,
+                ):
+                    if auto_chain:
+                        if output.resolution == Resolution.OPEN_ENDED_ANALYSIS:
+                            queue = RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value
+                            payload = output.data.model_dump_json()
+                        else:
+                            task = Task(metadata=state.model_dump())
+                            payload = task.model_dump_json()
+                            if output.resolution == Resolution.REBASE:
+                                queue = RedisQueues.get_rebase_queue_for_branch(state.target_branch)
+                            elif output.resolution == Resolution.BACKPORT:
+                                queue = RedisQueues.get_backport_queue_for_branch(state.target_branch)
+                            elif output.resolution == Resolution.REBUILD:
+                                queue = RedisQueues.get_rebuild_queue_for_branch(state.target_branch)
+                            else:
+                                queue = RedisQueues.CLARIFICATION_NEEDED_QUEUE.value
+                        await fix_await(redis.lpush(queue, payload))
+                        logger.info(f"Pushed {input.issue} to {queue}")
+                    else:
+                        logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
 
 
 if __name__ == "__main__":

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -61,6 +61,13 @@ from ymir.tools.unprivileged.version_mapper import VersionMapperTool
 logger = logging.getLogger(__name__)
 
 
+def _should_update_jira(silent_run: bool, resolution: Resolution) -> bool:
+    """In silent mode, only update Jira for not-affected and postponed resolutions."""
+    if not silent_run:
+        return True
+    return resolution in (Resolution.NOT_AFFECTED, Resolution.POSTPONED)
+
+
 async def determine_target_branch(
     cve_eligibility_result: CVEEligibilityResult | None, triage_data: BaseModel
 ) -> str | None:
@@ -518,7 +525,9 @@ def create_triage_agent(gateway_tools, local_tool_options=None):
     )
 
 
-async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=False, force_cve_triage=False):
+async def run_workflow(
+    jira_issue, dry_run, triage_agent_factory, auto_chain=False, force_cve_triage=False, silent_run=False
+):
     async with mcp_tools(os.getenv("MCP_GATEWAY_URL")) as gateway_tools:
         triage_agent = triage_agent_factory(gateway_tools)
 
@@ -958,6 +967,12 @@ async def run_workflow(jira_issue, dry_run, triage_agent_factory, auto_chain=Fal
             logger.info(f"Result to be put in Jira comment: {comment_text}")
             if dry_run:
                 return Workflow.END
+            if not _should_update_jira(silent_run, state.triage_result.resolution):
+                logger.info(
+                    f"Silent run: skipping Jira comment for {state.jira_issue} "
+                    f"(resolution={state.triage_result.resolution.value})"
+                )
+                return Workflow.END
             await tasks.comment_in_jira(
                 jira_issue=state.jira_issue,
                 agent_type="Triage",
@@ -986,6 +1001,7 @@ async def main() -> None:
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     auto_chain = os.getenv("AUTO_CHAIN", "true").lower() == "true"
     force_cve_triage = os.getenv("FORCE_CVE_TRIAGE", "false").lower() == "true"
+    silent_run = os.getenv("SILENT_RUN", "false").lower() == "true"
 
     if jira_issue := os.getenv("JIRA_ISSUE", None):
         logger.info("Running in direct mode with environment variable")
@@ -995,6 +1011,7 @@ async def main() -> None:
             create_triage_agent,
             auto_chain=auto_chain,
             force_cve_triage=force_cve_triage,
+            silent_run=silent_run,
         )
         logger.info(f"Direct run completed: {state.triage_result.model_dump_json(indent=4)}")
         if state.cve_eligibility_result:
@@ -1043,17 +1060,18 @@ async def main() -> None:
                     await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
 
             try:
-                await tasks.set_jira_labels(
-                    jira_issue=input.issue,
-                    labels_to_add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                    labels_to_remove=[
-                        label
-                        for label in JiraLabels.all_labels()
-                        if label != JiraLabels.TRIAGE_IN_PROGRESS.value
-                    ],
-                    dry_run=dry_run,
-                )
-                logger.info(f"Cleaned up existing labels for {input.issue}")
+                if not silent_run:
+                    await tasks.set_jira_labels(
+                        jira_issue=input.issue,
+                        labels_to_add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                        labels_to_remove=[
+                            label
+                            for label in JiraLabels.all_labels()
+                            if label != JiraLabels.TRIAGE_IN_PROGRESS.value
+                        ],
+                        dry_run=dry_run,
+                    )
+                    logger.info(f"Cleaned up existing labels for {input.issue}")
 
                 logger.info(f"Starting triage processing for {input.issue}")
                 state = await run_workflow(
@@ -1062,6 +1080,7 @@ async def main() -> None:
                     create_triage_agent,
                     auto_chain=auto_chain,
                     force_cve_triage=input.force_cve_triage,
+                    silent_run=silent_run,
                 )
                 output = state.triage_result
                 logger.info(
@@ -1080,14 +1099,17 @@ async def main() -> None:
                     ErrorData(details=error, jira_issue=input.issue).model_dump_json(),
                 )
             else:
+                update_jira = _should_update_jira(silent_run, output.resolution)
+
                 if output.resolution == Resolution.REBASE:
                     logger.info(f"Triage resolved as REBASE for {input.issue}")
-                    await tasks.set_jira_labels(
-                        jira_issue=input.issue,
-                        labels_to_add=[JiraLabels.TRIAGED_REBASE.value],
-                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                        dry_run=dry_run,
-                    )
+                    if update_jira:
+                        await tasks.set_jira_labels(
+                            jira_issue=input.issue,
+                            labels_to_add=[JiraLabels.TRIAGED_REBASE.value],
+                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                            dry_run=dry_run,
+                        )
                     if auto_chain:
                         task = Task(metadata=state.model_dump())
                         rebase_queue = RedisQueues.get_rebase_queue_for_branch(state.target_branch)
@@ -1097,12 +1119,13 @@ async def main() -> None:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
                 elif output.resolution == Resolution.BACKPORT:
                     logger.info(f"Triage resolved as BACKPORT for {input.issue}")
-                    await tasks.set_jira_labels(
-                        jira_issue=input.issue,
-                        labels_to_add=[JiraLabels.TRIAGED_BACKPORT.value],
-                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                        dry_run=dry_run,
-                    )
+                    if update_jira:
+                        await tasks.set_jira_labels(
+                            jira_issue=input.issue,
+                            labels_to_add=[JiraLabels.TRIAGED_BACKPORT.value],
+                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                            dry_run=dry_run,
+                        )
                     if auto_chain:
                         task = Task(metadata=state.model_dump())
                         backport_queue = RedisQueues.get_backport_queue_for_branch(state.target_branch)
@@ -1112,24 +1135,25 @@ async def main() -> None:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
                 elif output.resolution == Resolution.REBUILD:
                     logger.info(f"Triage resolved as REBUILD for {input.issue}")
-                    await tasks.set_jira_labels(
-                        jira_issue=input.issue,
-                        labels_to_add=[JiraLabels.TRIAGED_REBUILD.value],
-                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                        dry_run=dry_run,
-                    )
-                    for consolidated in output.data.consolidated_issues:
-                        try:
-                            await tasks.set_jira_labels(
-                                jira_issue=consolidated.issue_key,
-                                labels_to_add=[JiraLabels.TRIAGED_REBUILD.value],
-                                labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                                dry_run=dry_run,
-                            )
-                        except Exception as e:
-                            logger.warning(
-                                f"Failed to set labels on consolidated issue {consolidated.issue_key}: {e}"
-                            )
+                    if update_jira:
+                        await tasks.set_jira_labels(
+                            jira_issue=input.issue,
+                            labels_to_add=[JiraLabels.TRIAGED_REBUILD.value],
+                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                            dry_run=dry_run,
+                        )
+                        for consolidated in output.data.consolidated_issues:
+                            try:
+                                await tasks.set_jira_labels(
+                                    jira_issue=consolidated.issue_key,
+                                    labels_to_add=[JiraLabels.TRIAGED_REBUILD.value],
+                                    labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                                    dry_run=dry_run,
+                                )
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to set labels on consolidated issue {consolidated.issue_key}: {e}"
+                                )
                     if auto_chain:
                         task = Task(metadata=state.model_dump())
                         rebuild_queue = RedisQueues.get_rebuild_queue_for_branch(state.target_branch)
@@ -1139,12 +1163,13 @@ async def main() -> None:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
                 elif output.resolution == Resolution.CLARIFICATION_NEEDED:
                     logger.info(f"Triage resolved as CLARIFICATION_NEEDED for {input.issue}")
-                    await tasks.set_jira_labels(
-                        jira_issue=input.issue,
-                        labels_to_add=[JiraLabels.NEEDS_ATTENTION.value],
-                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                        dry_run=dry_run,
-                    )
+                    if update_jira:
+                        await tasks.set_jira_labels(
+                            jira_issue=input.issue,
+                            labels_to_add=[JiraLabels.NEEDS_ATTENTION.value],
+                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                            dry_run=dry_run,
+                        )
                     if auto_chain:
                         task = Task(metadata=state.model_dump())
                         await fix_await(
@@ -1158,12 +1183,13 @@ async def main() -> None:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
                 elif output.resolution == Resolution.OPEN_ENDED_ANALYSIS:
                     logger.info(f"Triage resolved as OPEN_ENDED_ANALYSIS for {input.issue}")
-                    await tasks.set_jira_labels(
-                        jira_issue=input.issue,
-                        labels_to_add=[JiraLabels.TRIAGED.value],
-                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                        dry_run=dry_run,
-                    )
+                    if update_jira:
+                        await tasks.set_jira_labels(
+                            jira_issue=input.issue,
+                            labels_to_add=[JiraLabels.TRIAGED.value],
+                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                            dry_run=dry_run,
+                        )
                     if auto_chain:
                         await fix_await(
                             redis.lpush(
@@ -1176,12 +1202,13 @@ async def main() -> None:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
                 elif output.resolution == Resolution.POSTPONED:
                     logger.info(f"Triage resolved as POSTPONED for {input.issue}")
-                    await tasks.set_jira_labels(
-                        jira_issue=input.issue,
-                        labels_to_add=[JiraLabels.TRIAGED_POSTPONED.value],
-                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                        dry_run=dry_run,
-                    )
+                    if update_jira:
+                        await tasks.set_jira_labels(
+                            jira_issue=input.issue,
+                            labels_to_add=[JiraLabels.TRIAGED_POSTPONED.value],
+                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                            dry_run=dry_run,
+                        )
                     await fix_await(
                         redis.lpush(
                             RedisQueues.POSTPONED_LIST.value,
@@ -1191,20 +1218,22 @@ async def main() -> None:
                     logger.info(f"Pushed {input.issue} to {RedisQueues.POSTPONED_LIST.value}")
                 elif output.resolution == Resolution.NOT_AFFECTED:
                     logger.info(f"Triage resolved as NOT_AFFECTED for {input.issue}")
-                    await tasks.set_jira_labels(
-                        jira_issue=input.issue,
-                        labels_to_add=[JiraLabels.TRIAGED_NOT_AFFECTED.value],
-                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                        dry_run=dry_run,
-                    )
+                    if update_jira:
+                        await tasks.set_jira_labels(
+                            jira_issue=input.issue,
+                            labels_to_add=[JiraLabels.TRIAGED_NOT_AFFECTED.value],
+                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                            dry_run=dry_run,
+                        )
                 elif output.resolution == Resolution.ERROR:
                     logger.warning(f"Triage resolved as ERROR for {input.issue}, retrying")
-                    await tasks.set_jira_labels(
-                        jira_issue=input.issue,
-                        labels_to_add=[JiraLabels.TRIAGE_ERRORED.value],
-                        labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                        dry_run=dry_run,
-                    )
+                    if update_jira:
+                        await tasks.set_jira_labels(
+                            jira_issue=input.issue,
+                            labels_to_add=[JiraLabels.TRIAGE_ERRORED.value],
+                            labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                            dry_run=dry_run,
+                        )
                     await retry(task, output.data.model_dump_json())
 
 

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -377,25 +377,6 @@ async def _check_zstream_clones_shipped(
     return (True, [])
 
 
-def build_rebuild_siblings_jql(
-    issue_key: str,
-    component: str,
-    fix_version: str,
-) -> str:
-    escaped_component = component.replace('"', '\\"')
-    escaped_fix_version = fix_version.replace('"', '\\"')
-    return (
-        f'project = RHEL AND component = "{escaped_component}" '
-        f'AND fixVersion = "{escaped_fix_version}" '
-        f'AND key != "{issue_key}" '
-        f'AND labels = "SecurityTracking" '
-        f"AND labels not in "
-        f'("ymir_triaged_rebuild", "ymir_rebuilt", '
-        f'"ymir_triaged_not_affected", "ymir_triaged_backport", "ymir_triaged_rebase") '
-        f'AND status in ("New", "Planning")'
-    )
-
-
 class CheckCveTriageEligibilityToolInput(BaseModel):
     issue_key: str = Field(description="Jira issue key (e.g. RHEL-12345)")
 

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -20,7 +20,6 @@ from ymir.tools.privileged.jira import (
     Severity,
     VerifyIssueAuthorTool,
     _check_zstream_clones_shipped,
-    build_rebuild_siblings_jql,
     extract_cve_id,
 )
 
@@ -787,27 +786,3 @@ async def test_eligibility_maintenance_zstream_clones_pending():
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
     assert result["eligibility"] == TriageEligibility.PENDING_DEPENDENCIES
     assert result["pending_zstream_issues"] == ["RHEL-555"]
-
-
-# --- build_rebuild_siblings_jql tests ---
-
-
-def test_build_rebuild_siblings_jql():
-    jql = build_rebuild_siblings_jql("RHEL-100", "git-lfs", "rhel-9.8")
-    assert 'component = "git-lfs"' in jql
-    assert 'fixVersion = "rhel-9.8"' in jql
-    assert 'key != "RHEL-100"' in jql
-    assert 'labels = "SecurityTracking"' in jql
-    assert "labels not in" in jql
-    assert '"ymir_triaged_rebuild"' in jql
-    assert '"ymir_rebuilt"' in jql
-    assert '"ymir_triaged_not_affected"' in jql
-    assert '"ymir_triaged_backport"' in jql
-    assert '"ymir_triaged_rebase"' in jql
-    assert 'status in ("New", "Planning")' in jql
-
-
-def test_build_rebuild_siblings_jql_escapes_quotes():
-    jql = build_rebuild_siblings_jql("RHEL-100", 'comp"name', 'rhel-9.8"z')
-    assert r'component = "comp\"name"' in jql
-    assert r'fixVersion = "rhel-9.8\"z"' in jql


### PR DESCRIPTION
Works in a simmilar way as the DRY_RUN does, except it does changes to Jira only when the resolution is either not-affected or postponed.