### PR TITLE
Deploy updates: OpenShift egress rules and image stream rollback

### DIFF
--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -14,6 +14,9 @@ import_image() {
     oc import-image "$1" --all -n jotnar-ymir--jotnar-ymir
 }
 
+# Egress rules
+apply tenant-egress.yml
+
 # Shared ConfigMaps
 apply configmap-agents-env.yml
 apply configmap-chat-env.yml

--- a/openshift/imagestream-beeai-agent.yml
+++ b/openshift/imagestream-beeai-agent.yml
@@ -15,7 +15,7 @@ spec:
     - name: c10s
       from:
         kind: DockerImage
-        name: quay.io/tomastomecek/beeai-agent:c10s
+        name: quay.io/jotnar/beeai:c10s
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
         scheduled: true

--- a/openshift/imagestream-mcp-gateway.yml
+++ b/openshift/imagestream-mcp-gateway.yml
@@ -8,7 +8,7 @@ spec:
     - name: prod
       from:
         kind: DockerImage
-        name: quay.io/tomastomecek/mcp-gateway:latest
+        name: quay.io/jotnar/mcp-server:latest
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
         scheduled: true

--- a/openshift/tenant-egress.yml
+++ b/openshift/tenant-egress.yml
@@ -1,0 +1,92 @@
+apiVersion: tenant.paas.redhat.com/v1alpha1
+kind: TenantEgress
+metadata:
+  name: default
+  namespace: jotnar-ymir--jotnar-ymir
+spec:
+  egress:
+    # Internal CIDRs
+    - type: Allow
+      to:
+        cidrSelector: 172.0.0.0/8
+    - type: Allow
+      to:
+        cidrSelector: 10.0.0.0/8
+    # AWS S3 CIDRs (pre-existing)
+    - type: Allow
+      to:
+        cidrSelector: 52.218.128.0/17
+    - type: Allow
+      to:
+        cidrSelector: 52.92.128.0/17
+    - type: Allow
+      to:
+        cidrSelector: 52.216.0.0/15
+    # Red Hat services (pre-existing)
+    - type: Allow
+      to:
+        dnsName: api.access.redhat.com
+    - type: Allow
+      to:
+        dnsName: cert-api.access.redhat.com
+    - type: Allow
+      to:
+        dnsName: cdn.redhat.com
+    # Jira REST API
+    - type: Allow
+      to:
+        dnsName: redhat.atlassian.net
+    # CentOS Stream / RHEL package repos and MR management
+    - type: Allow
+      to:
+        dnsName: gitlab.com
+    # Upstream patch and commit lookup
+    - type: Allow
+      to:
+        dnsName: github.com
+    - type: Allow
+      to:
+        dnsName: api.github.com
+    # Fedora package repository
+    - type: Allow
+      to:
+        dnsName: src.fedoraproject.org
+    # Internal Red Hat COPR build system
+    - type: Allow
+      to:
+        dnsName: copr.devel.redhat.com
+    # Red Hat Security Advisories
+    - type: Allow
+      to:
+        dnsName: access.redhat.com
+    # CVE/vulnerability databases
+    - type: Allow
+      to:
+        dnsName: nvd.nist.gov
+    - type: Allow
+      to:
+        dnsName: cve.mitre.org
+    - type: Allow
+      to:
+        dnsName: osv.dev
+    # Go ecosystem
+    - type: Allow
+      to:
+        dnsName: go.dev
+    - type: Allow
+      to:
+        dnsName: pkg.go.dev
+    # Google Groups (mailing list archives)
+    - type: Allow
+      to:
+        dnsName: groups.google.com
+    # GNU project hosting (gnu.org, ftp.gnu.org, savannah.gnu.org, savannah.nongnu.org)
+    # All resolve to 209.51.188.0/24; dnsName selector picks AAAA records which
+    # don't match this cluster's IPv4-only egress policy, so use CIDR instead.
+    - type: Allow
+      to:
+        cidrSelector: 209.51.188.0/24
+    # Catch-all deny
+    - type: Deny
+      to:
+        cidrSelector: 0.0.0.0/0


### PR DESCRIPTION
## Summary
- Define custom OpenShift egress rules for network policy
- Roll back OpenShift image streams to previous configuration

## Test Plan
- [ ] Verify deployment in OpenShift environment
- [ ] Confirm network policies are correctly applied
- [ ] Check image streams are properly resolved