### PR TITLE
Adding note about development dependency on libpq-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ python3-devel podman-compose gcc krb5-devel libpq-devel
 Then, use the provided stub pyproject.toml file to set up the development environment:
 
 ```
-uv sync
+uv sync --extra test
 uv run make -f Makefile.tests check
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `goose/` directory contains some automation components that were used in the
 You need to have the following packages installed on your system:
 
 ```
-python3-devel podman-compose gcc krb5-devel
+python3-devel podman-compose gcc krb5-devel libpq-devel
 ```
 
 Then, use the provided stub pyproject.toml file to set up the development environment:


### PR DESCRIPTION
Couple of things in README.md need updating.

When installing dependencies with ai-workflows with `uv sync` one can get an error when building psycopg2:

```
 × Failed to build `psycopg2==2.9.12`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)

      [stdout]
      running egg_info
      writing psycopg2.egg-info/PKG-INFO
      writing dependency_links to psycopg2.egg-info/dependency_links.txt
      writing top-level names to psycopg2.egg-info/top_level.txt

      [stderr]
      /home/jpodivin/.cache/uv/builds-v0/.tmpuEJopq/lib64/python3.13/site-packages/setuptools/dist.py:765: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        self._finalize_license_expression()

      Error: pg_config executable not found.

      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:

          python setup.py build_ext --pg-config /path/to/pg_config build ...

      or with the pg_config option in 'setup.cfg'.

      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.

      For further information please check the 'doc/src/install.rst' file (also at
      <https://www.psycopg.org/docs/install.html>).


      hint: This usually indicates a problem with the package or the build environment.
  help: `psycopg2` (v2.9.12) was included because `ymir` (v0.1.0) depends on `nitrate` (v1.9.0) which depends on `psycopg2`
```

The binary pg_config obviously isn't packaged with Fedora by default, you have to install it. One of the options, is libpq-devel. Which should be available in standard repos.

Also, installing standard dependencies is not enough for development. One also needs dependencies in the `test` group. 