### PR TITLE
Mocking mkdir call on path object

### DIFF
--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -143,7 +143,7 @@ async def test_open_merge_request_with_existing_mr():
 async def test_clone_repository(mock_git_repo_basepath):
     repository = "https://gitlab.com/centos-stream/rpms/bash"
     branch = "rhel-8.10.0"
-    clone_path = Path("/git-repos/bash")
+    clone_path = mock_git_repo_basepath / "bash"
 
     async def create_subprocess_exec(cmd, *args, **kwargs):
         assert cmd == "git"


### PR DESCRIPTION
Minor test adjustment. It doesn't matter in a container, but when you execute tests directly on host, attempt to make `/git-repos/bash` dir fails for obvious reasons. We should talk about changing instructions in the README at some point.

But for now this will do. Plus, it will actually check that the call is made while preventing contamination of the test environment. 
