### PR TITLE
Fix dependency check missing clones with stale Y-stream fixVersion

### DIFF
--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, Field
 from ymir.common import CVEEligibilityResult, TriageEligibility, load_rhel_config
 from ymir.common.base_utils import get_jira_auth_headers
 from ymir.common.constants import JIRA_SEARCH_PATH
-from ymir.common.version_utils import normalize_fix_version, parse_rhel_version
+from ymir.common.version_utils import get_fix_version_variants, normalize_fix_version, parse_rhel_version
 from ymir.tools.constants import AIOHTTP_TIMEOUT
 
 if os.getenv("MOCK_JIRA", "False").lower() == "true":
@@ -326,10 +326,11 @@ async def _check_zstream_clones_shipped(
         logger.info(f"Maintenance-phase major versions (excluded): {sorted(maintenance_majors)}")
 
     relevant_z_streams = {
-        v.lower()
+        variant.lower()
         for streams in (current_z_streams, upcoming_z_streams)
         for major, v in streams.items()
         if major not in maintenance_majors
+        for variant in get_fix_version_variants(v)
     }
     logger.info(f"Relevant Z-streams from config: {sorted(relevant_z_streams)}")
 

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -570,6 +570,31 @@ async def test_check_zstream_clones_wontdo_with_pending():
     assert pending == ["RHEL-222"]
 
 
+@pytest.mark.asyncio
+async def test_check_zstream_clones_stale_ystream_fixversion():
+    """Clone with stale Y-stream fixVersion (rhel-9.6 instead of rhel-9.6.z) is still recognized."""
+    search_result = [
+        {
+            "key": "RHEL-333",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.6"}],
+                "status": {"name": "In Progress"},
+                "resolution": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+
+    any_shipped, pending = await _check_zstream_clones_shipped("CVE-2025-12345", "curl", "RHEL-999")
+    assert any_shipped is False
+    assert pending == ["RHEL-333"]
+
+
 # --- CVE triage eligibility tests ---
 
 


### PR DESCRIPTION
The Z-stream clone dependency check (used for Y-stream and maintenance eligibility) built its relevant_z_streams set using only the .z form from config (e.g. rhel-9.6.z). Clones with a stale Y-stream fixVersion (rhel-9.6, not yet updated after GA) were silently skipped, potentially unblocking Y-stream/maintenance issues prematurely.

Use get_fix_version_variants() to include both forms in the set.

Assisted-by: Claude Opus 4.6

