### PR TITLE
Download package sources via MCP gateway

### DIFF
--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -1004,6 +1004,13 @@ async def main() -> None:
                     available_tools=gateway_tools,
                 )
                 local_tool_options["working_directory"] = state.local_clone
+                await run_tool(
+                    "download_sources",
+                    dist_git_path=str(state.local_clone),
+                    package=state.package,
+                    dist_git_branch=state.dist_git_branch,
+                    available_tools=gateway_tools,
+                )
                 if is_cs_branch(state.dist_git_branch):
                     pkg_cmd = [
                         "centpkg",
@@ -1020,7 +1027,6 @@ async def main() -> None:
                         "--offline",
                         "--released",
                     ]
-                await check_subprocess([*pkg_cmd, "sources"], cwd=state.local_clone)
                 await check_subprocess([*pkg_cmd, "prep"], cwd=state.local_clone)
                 state.unpacked_sources = tasks.get_unpacked_sources(state.local_clone, state.package)
                 for idx, upstream_patch in enumerate(state.upstream_patches):

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -454,6 +454,14 @@ async def clone_and_prep_sources(
         available_tools=available_tools,
     )
 
+    await run_tool(
+        "download_sources",
+        dist_git_path=str(local_clone),
+        package=package,
+        dist_git_branch=dist_git_branch,
+        available_tools=available_tools,
+    )
+
     if is_cs_branch(dist_git_branch):
         pkg_cmd = [
             "centpkg",
@@ -470,8 +478,6 @@ async def clone_and_prep_sources(
             "--offline",
             "--released",
         ]
-    await check_subprocess([*pkg_cmd, "sources"], cwd=local_clone)
-
     exit_code, _, stderr = await run_subprocess([*pkg_cmd, "prep"], cwd=local_clone)
     if exit_code == 0:
         unpacked = get_unpacked_sources(local_clone, package)


### PR DESCRIPTION
rhpkg needs to be authenticated to download sources so it has to be done via the MCP gateway instead of doing it directly from the agent instances. since we already have the existing tool to do just that there is no reason to do it directly. this actually used to work via tool but somehow got broken (regressed) recently and broke our backporting workflow.
