### PR TITLE
Add image build dependency to each container test target

### DIFF
--- a/.github/workflows/check-in-container.yml
+++ b/.github/workflows/check-in-container.yml
@@ -32,12 +32,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y podman
         podman --version
-    - name: Build Fedora test image from Containerfile.tests
-      run: |
-        podman build --rm --tag beeai-tests -f Containerfile.tests .
-    - name: Build CentOS Stream 9 test image from Containerfile.c9s-tests
-      run: |
-        podman build --rm --tag beeai-tests-c9s -f Containerfile.c9s-tests .
     - name: Run ${{ matrix.target }} target
       env:
         CONTAINER_ENGINE: podman

--- a/Makefile
+++ b/Makefile
@@ -286,19 +286,19 @@ build-test-image:
 	$(MAKE) -f Makefile.tests build-test-image
 
 .PHONY: check-in-container check-agents-in-container check-unprivileged-tools-in-container check-privileged-tools-in-container check-jira-issue-fetcher-in-container check-ymir-common-in-container check-supervisor-in-container check-mcp-install-in-container
-check-in-container:
+check-in-container: build-test-image
 	$(MAKE) -f Makefile.tests check-in-container
-check-agents-in-container:
+check-agents-in-container: build-test-image
 	$(MAKE) -f Makefile.tests check-agents-in-container
-check-unprivileged-tools-in-container:
+check-unprivileged-tools-in-container: build-test-image
 	$(MAKE) -f Makefile.tests check-unprivileged-tools-in-container
-check-privileged-tools-in-container:
+check-privileged-tools-in-container: build-test-image
 	$(MAKE) -f Makefile.tests check-privileged-tools-in-container
-check-jira-issue-fetcher-in-container:
+check-jira-issue-fetcher-in-container: build-test-image
 	$(MAKE) -f Makefile.tests check-jira-issue-fetcher-in-container
-check-ymir-common-in-container:
+check-ymir-common-in-container: build-test-image
 	$(MAKE) -f Makefile.tests check-ymir-common-in-container
-check-supervisor-in-container:
+check-supervisor-in-container: build-test-image
 	$(MAKE) -f Makefile.tests check-supervisor-in-container
-check-mcp-install-in-container:
+check-mcp-install-in-container: build-test-image
 	$(MAKE) -f Makefile.tests check-mcp-install-in-container

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -5,7 +5,9 @@ TEST_TARGET ?= ./tests/unit
 CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || echo "docker")
 
 .PHONY: build-test-image build-test-image-fedora build-test-image-c9s
+ifndef SKIP_IMG_BUILD
 build-test-image: build-test-image-fedora build-test-image-c9s
+endif
 
 build-test-image-fedora:
 	$(CONTAINER_ENGINE) build --rm --tag $(TEST_IMAGE) -f Containerfile.tests


### PR DESCRIPTION
With this you can launch tests with `make check-in-container` and be sure that you are not running with a stale image, and you avoid the "choose image" dialog from podman.

This way we can be sure that we always test on the newest code. There is some redundancy involved, as the build is called even if the image is present. But with layer caching the time wasted become negligible. This also removes separate build image step in the workflow, as that would be really redundant.
