### PR TITLE
Mocking upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,9 @@ noarch/
 
 # Testing Jira files
 ymir/tools/privileged/tests/data/*
-!ymir/tools/privileged/tests/data/README.md
 
 # Testing mock repo fixtures
 ymir/agents/tests/e2e/mock_repos/*
-!ymir/agents/tests/e2e/mock_repos/README.md
+
+# MCP gateway debug logs
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ noarch/
 
 # Testing Jira files
 ymir/tools/privileged/tests/data/*
+!ymir/tools/privileged/tests/data/README.md
+
+# Testing mock repo fixtures
+ymir/agents/tests/e2e/mock_repos/*
+!ymir/agents/tests/e2e/mock_repos/README.md

--- a/claude-triage-mock.md
+++ b/claude-triage-mock.md
@@ -1,0 +1,226 @@
+# Running the Triage Skill with Mocked Data
+
+This guide explains how to set up a local environment for executing the triage
+skill against mocked JIRA data and pre-fix CentOS Stream repos — without
+touching any production services.
+
+---
+
+## Prerequisites
+
+- MCP tools installed (`ymir-common` + `ymir-tools`) as described in
+  `skills_installation.md`
+- The triage skill installed (see `skills_installation.md` for Claude Code /
+  Cursor instructions)
+- Access to the private test data repository:
+  `git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git`
+- A valid `rhel-config.json` (template in `templates/rhel-config.json`)
+
+## 1. Clone the test data repository
+
+```bash
+git clone git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git /tmp/testing-jiras
+```
+
+The repository layout:
+
+```
+testing-jiras/
+├── jiras/                  ← JIRA mock files (one JSON file per issue key)
+│   ├── RHEL-112546
+│   ├── RHEL-15216
+│   ├── RHEL-29712
+│   └── RHEL-61943
+├── mock_data/              ← repo fixture configs (repos to clone at pre-fix state)
+│   ├── RHEL-112546.json
+│   ├── RHEL-15216.json
+│   ├── RHEL-29712.json
+│   └── RHEL-61943.json
+└── README.md
+```
+
+### JIRA mock files (`jiras/`)
+
+Each file is a JSON snapshot of a JIRA issue as returned by the REST API.
+When `MOCK_JIRA=true`, the mock HTTP session reads these instead of calling
+the real JIRA API.
+
+### Repo fixture configs (`mock_data/`)
+
+Each JSON file describes CentOS Stream repos to clone at a pre-fix state so
+the agent cannot "cheat" by finding the already-applied backport:
+
+```json
+{
+    "zstream_override": {"9": "rhel-9.2.z"},
+    "repos": [
+        {
+            "package": "libtiff",
+            "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/libtiff",
+            "pre_fix_ref": "<pre-fix-commit>",
+            "branch": "c9s"
+        }
+    ]
+}
+```
+
+- **`repos`** (required): list of repos to bare-clone and rewind. The
+  `pre_fix_ref` is the commit hash to reset the branch to (before the fix
+  was applied).
+- **`zstream_override`** (optional): overrides what the agent considers the
+  "current" z-stream for a given major version, so it follows the normal
+  backport path instead of the restricted older-zstream path.
+
+See `ymir/common/mock_repos.py` for full schema documentation.
+
+## 2. Prepare `rhel-config.json`
+
+Several tools (`map_version`, `check_cve_triage_eligibility`,
+`normalize_fix_version`) load `rhel-config.json` from the current working
+directory at runtime. Copy the template:
+
+```bash
+cp templates/rhel-config.json ./rhel-config.json
+```
+
+Make sure the unprivileged MCP gateway is started from the directory that
+contains this file (or symlink it there).
+
+## 3. Ensure writable JIRA mock files
+
+The mock JIRA session writes back to the files (e.g. when adding comments or
+updating fields), so they need to be writable:
+
+```bash
+chmod -R u+w /tmp/testing-jiras/jiras/
+```
+
+## 4. Environment variables reference
+
+### Privileged gateway (`ymir-privileged`)
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `MOCK_JIRA` | `true` | Swaps the real HTTP client for a mock that reads/writes JSON files |
+| `JIRA_MOCK_FILES` | `/tmp/testing-jiras/jiras` | Directory containing JIRA mock files |
+| `JIRA_DRY_RUN` | `true` | Prevents any JIRA write operations (comments, fields, status) |
+
+### Unprivileged gateway (`ymir-unprivileged`)
+
+| Variable | Value | Purpose |
+|---|---|---|
+| `MOCK_REPOS_DIR` | `/tmp/testing-jiras/mock_data` | Directory with per-issue repo fixture JSON files. At runtime the repos are bare-cloned, rewound to the pre-fix commit, and git `insteadOf` rewriting redirects git operations to the local clone. |
+| `MOCK_BLOCKED_URLS` | Comma-separated URL prefixes | Blocks `curl`/`wget` access to these URLs in `RunShellCommandTool`. Automatically populated when `MOCK_REPOS_DIR` is used, but can also be set explicitly. |
+| `MOCK_ZSTREAMS` | JSON string, e.g. `{"9":"rhel-9.2.z"}` | Standalone z-stream override (applied globally). Per-issue overrides in fixture files take precedence. |
+
+> **Note:** `MOCK_REPOS_DIR` automatically populates `MOCK_BLOCKED_URLS` at
+> runtime via `_register_blocked_urls()`. However, if you want the URL
+> blocking to be active from gateway startup (before any tool invocation),
+> set `MOCK_BLOCKED_URLS` explicitly as well.
+
+## 5. MCP configuration
+
+### Claude Code (`~/.claude.json`)
+
+```json
+{
+  "mcpServers": {
+    "ymir-privileged": {
+      "command": "ymir-privileged-gateway",
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "GITLAB_TOKEN": "<your-gitlab-token>",
+        "JIRA_URL": "https://redhat.atlassian.net",
+        "JIRA_EMAIL": "you@redhat.com",
+        "JIRA_TOKEN": "your-jira-api-token",
+        "KRB5CCNAME": "FILE:/tmp/krb5cc_1000",
+        "MOCK_JIRA": "true",
+        "JIRA_MOCK_FILES": "/tmp/testing-jiras/jiras",
+        "JIRA_DRY_RUN": "true"
+      }
+    },
+    "ymir-unprivileged": {
+      "command": "ymir-unprivileged-gateway",
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "UPSTREAM_SEARCH_API_URL": "http://upstream-search.hosted.upshift.rdu2.redhat.com:80/v1",
+        "MOCK_REPOS_DIR": "/tmp/testing-jiras/mock_data",
+        "MOCK_BLOCKED_URLS": "<comma-separated remote_url values from the fixture>"
+      }
+    }
+  }
+}
+```
+
+Replace `MOCK_BLOCKED_URLS` with the `remote_url` values from the fixture
+file for the issue you're testing. For example, for `RHEL-15216`:
+
+```
+"MOCK_BLOCKED_URLS": "https://gitlab.com/redhat/centos-stream/rpms/dnsmasq"
+```
+
+For project-scoped configuration, place the same `mcpServers` block in
+`.claude/settings.json` inside your project directory instead.
+
+### Cursor
+
+Use the same env vars in your Cursor MCP configuration.
+
+## 6. Run the skill
+
+Start a session and invoke the triage skill with the desired issue key:
+
+```
+Use the triage skill with jira_issue=RHEL-15216 and dry_run=true
+```
+
+### What happens under the hood
+
+1. The **privileged gateway** reads the JIRA mock file (e.g.
+   `/tmp/testing-jiras/jiras/RHEL-15216`) instead of calling the real JIRA
+   API.
+2. The **unprivileged gateway** reads the repo fixture config (e.g.
+   `/tmp/testing-jiras/mock_data/RHEL-15216.json`), bare-clones the
+   CentOS Stream repo, rewinds its branch to the pre-fix commit, and sets
+   up `GIT_CONFIG` `insteadOf` rewriting so all git operations against the
+   remote URL are transparently redirected to the local clone.
+3. If the fixture file contains a `zstream_override`, the z-stream mapping
+   is overridden via the `current_z_streams_override` ContextVar.
+4. If the agent tries to `curl` or `wget` a mocked repo URL,
+   `RunShellCommandTool` blocks it with a `ToolError`.
+5. `JIRA_DRY_RUN=true` prevents any writes to the mock JIRA files;
+   `dry_run=true` (skill argument) skips posting the final comment.
+
+## Available test scenarios
+
+| Issue key | Package | Expected resolution | Notes |
+|---|---|---|---|
+| `RHEL-15216` | dnsmasq | backport | Standard backport from upstream gitweb |
+| `RHEL-112546` | libtiff | backport | Z-stream override (`9` → `rhel-9.2.z`), multiple patches |
+| `RHEL-61943` | dnsmasq | backport | Z-stream backport |
+| `RHEL-29712` | bind | backport | Standard backport |
+
+## Troubleshooting
+
+### `rhel-config.json not found`
+
+The unprivileged gateway loads `rhel-config.json` from its current working
+directory. Make sure the file exists there:
+
+```bash
+cp templates/rhel-config.json ./rhel-config.json
+```
+
+### JIRA mock files are not writable
+
+If you see write errors from the mock session, ensure permissions:
+
+```bash
+chmod -R u+w /tmp/testing-jiras/jiras/
+```
+
+### Agent uses `curl`/`wget` instead of `git` to access the repo
+
+Set `MOCK_BLOCKED_URLS` to include the mocked `remote_url` values. The
+`RunShellCommandTool` will raise a `ToolError` before the command executes,
+guiding the agent to use git instead.

--- a/scripts/run-mock-triage.py
+++ b/scripts/run-mock-triage.py
@@ -14,11 +14,11 @@ Prerequisites:
 """
 
 import argparse
-import atexit
 import json
 import os
 import shutil
 import stat
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -173,7 +173,6 @@ def main() -> None:
     mcp_config = build_mcp_config(jira_mock_dir, mock_data_dir, upstream_search_url, blocked_urls, log_dir)
 
     tmp_fd, tmp_path = tempfile.mkstemp(prefix="mock-triage-mcp-", suffix=".json")
-    atexit.register(lambda: os.unlink(tmp_path))
 
     with os.fdopen(tmp_fd, "w") as fh:
         json.dump(mcp_config, fh, indent=2)
@@ -192,17 +191,19 @@ def main() -> None:
     print("============================")
     print()
 
-    os.chdir(REPO_ROOT)
-
-    os.execvp(
-        "claude",
-        [
-            "claude",
-            f"Use the triage skill with jira_issue={issue} and dry_run=true",
-            "--mcp-config",
-            tmp_path,
-        ],
-    )
+    try:
+        result = subprocess.run(
+            [
+                "claude",
+                f"Use the triage skill with jira_issue={issue} and dry_run=true",
+                "--mcp-config",
+                tmp_path,
+            ],
+            cwd=REPO_ROOT,
+        )
+        sys.exit(result.returncode)
+    finally:
+        os.unlink(tmp_path)
 
 
 if __name__ == "__main__":

--- a/scripts/run-mock-triage.py
+++ b/scripts/run-mock-triage.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Launch Claude Code with the triage skill against mocked JIRA data.
+
+Usage:
+    export TESTING_JIRAS_DIR=/path/to/testing-jiras
+    ./scripts/run-mock-triage.py RHEL-15216
+
+Prerequisites:
+    - claude CLI on PATH
+    - ymir-privileged-gateway and ymir-unprivileged-gateway on PATH
+    - TESTING_JIRAS_DIR pointing to a clone of
+      git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git
+    - rhel-config.json in the repo root (copied from templates/ if missing)
+"""
+
+import argparse
+import atexit
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_UPSTREAM_SEARCH_URL = "http://upstream-search.hosted.upshift.rdu2.redhat.com:80/v1"
+
+
+def fail(msg: str) -> None:
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def require_command(name: str, hint: str) -> None:
+    if shutil.which(name) is None:
+        fail(f"{name} not found on PATH. {hint}")
+
+
+def list_scenarios(mock_data_dir: Path) -> list[str]:
+    if not mock_data_dir.is_dir():
+        return []
+    return sorted(p.stem for p in mock_data_dir.glob("*.json"))
+
+
+def extract_blocked_urls(fixture_path: Path) -> str:
+    with open(fixture_path) as fh:
+        data = json.load(fh)
+    urls = [r["remote_url"] for r in data.get("repos", [])]
+    return ",".join(urls)
+
+
+def ensure_writable(directory: Path) -> None:
+    for root, _dirs, files in os.walk(directory):
+        for name in files:
+            path = Path(root) / name
+            path.chmod(path.stat().st_mode | stat.S_IWUSR)
+
+
+def build_mcp_config(
+    jira_mock_dir: Path,
+    mock_data_dir: Path,
+    upstream_search_url: str,
+    blocked_urls: str,
+    log_dir: Path,
+) -> dict:
+    return {
+        "mcpServers": {
+            "ymir-privileged": {
+                "command": "ymir-privileged-gateway",
+                "env": {
+                    "MCP_TRANSPORT": "stdio",
+                    "MOCK_JIRA": "true",
+                    "JIRA_MOCK_FILES": str(jira_mock_dir),
+                    "JIRA_DRY_RUN": "true",
+                    "JIRA_URL": os.environ.get("JIRA_URL", "https://redhat.atlassian.net"),
+                    "JIRA_EMAIL": os.environ.get("JIRA_EMAIL", ""),
+                    "JIRA_TOKEN": os.environ.get("JIRA_TOKEN", ""),
+                    "GITLAB_TOKEN": os.environ.get("GITLAB_TOKEN", ""),
+                    "KRB5CCNAME": os.environ.get("KRB5CCNAME", f"FILE:/tmp/krb5cc_{os.getuid()}"),
+                    "GIT_REPO_BASEPATH": os.environ.get("GIT_REPO_BASEPATH", "/tmp/ymir-git-repos"),
+                    "DEBUG_FILE": str(log_dir / "ymir-privileged.log"),
+                },
+            },
+            "ymir-unprivileged": {
+                "command": "ymir-unprivileged-gateway",
+                "env": {
+                    "MCP_TRANSPORT": "stdio",
+                    "UPSTREAM_SEARCH_API_URL": upstream_search_url,
+                    "MOCK_REPOS_DIR": str(mock_data_dir),
+                    "MOCK_BLOCKED_URLS": blocked_urls,
+                    "DEBUG_FILE": str(log_dir / "ymir-unprivileged.log"),
+                },
+            },
+        }
+    }
+
+
+def main() -> None:
+    testing_jiras_dir = os.environ.get("TESTING_JIRAS_DIR", "")
+    mock_data_dir = Path(testing_jiras_dir) / "mock_data" if testing_jiras_dir else None
+
+    epilog_lines = ["available test scenarios (from testing-jiras/mock_data/):"]
+    if mock_data_dir and mock_data_dir.is_dir():
+        epilog_lines.extend(f"  {scenario}" for scenario in list_scenarios(mock_data_dir))
+    else:
+        epilog_lines.append("  (set TESTING_JIRAS_DIR to list available scenarios)")
+
+    parser = argparse.ArgumentParser(
+        description="Launch Claude Code with the triage skill against mocked data.",
+        epilog="\n".join(epilog_lines),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("issue_key", metavar="ISSUE_KEY", help="JIRA issue key (e.g. RHEL-15216)")
+    args = parser.parse_args()
+
+    issue = args.issue_key
+
+    # -- Validation -----------------------------------------------------------
+
+    require_command("claude", "Install Claude Code first.")
+    require_command(
+        "ymir-privileged-gateway",
+        "Install ymir-tools first (see skills_installation.md).",
+    )
+    require_command(
+        "ymir-unprivileged-gateway",
+        "Install ymir-tools first (see skills_installation.md).",
+    )
+
+    if not testing_jiras_dir:
+        fail("TESTING_JIRAS_DIR is not set. Point it to a clone of testing-jiras.git.")
+
+    testing_jiras_path = Path(testing_jiras_dir)
+    if not testing_jiras_path.is_dir():
+        fail(f"TESTING_JIRAS_DIR={testing_jiras_dir} does not exist.")
+
+    jira_mock_dir = testing_jiras_path / "jiras"
+    mock_data_dir = testing_jiras_path / "mock_data"
+
+    jira_mock_file = jira_mock_dir / issue
+    if not jira_mock_file.is_file():
+        fail(f"JIRA mock file not found: {jira_mock_file}")
+
+    fixture_file = mock_data_dir / f"{issue}.json"
+    if not fixture_file.is_file():
+        fail(f"Repo fixture not found: {fixture_file}")
+
+    rhel_config = REPO_ROOT / "rhel-config.json"
+    if not rhel_config.is_file():
+        template = REPO_ROOT / "templates" / "rhel-config.json"
+        if template.is_file():
+            print("Copying templates/rhel-config.json to repo root...")
+            shutil.copy2(template, rhel_config)
+        else:
+            fail(f"rhel-config.json not found in {REPO_ROOT} and no template available.")
+
+    # -- Extract blocked URLs -------------------------------------------------
+
+    blocked_urls = extract_blocked_urls(fixture_file)
+
+    # -- Ensure JIRA mock files are writable ----------------------------------
+
+    ensure_writable(jira_mock_dir)
+
+    # -- Generate temporary MCP config ----------------------------------------
+
+    upstream_search_url = os.environ.get("UPSTREAM_SEARCH_API_URL", DEFAULT_UPSTREAM_SEARCH_URL)
+
+    log_dir = REPO_ROOT / "logs" / "mock-triage"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    mcp_config = build_mcp_config(jira_mock_dir, mock_data_dir, upstream_search_url, blocked_urls, log_dir)
+
+    tmp_fd, tmp_path = tempfile.mkstemp(prefix="mock-triage-mcp-", suffix=".json")
+    atexit.register(lambda: os.unlink(tmp_path))
+
+    with os.fdopen(tmp_fd, "w") as fh:
+        json.dump(mcp_config, fh, indent=2)
+
+    # -- Launch Claude Code ---------------------------------------------------
+
+    print("=== Mock Triage Launcher ===")
+    print(f"Issue:            {issue}")
+    print(f"JIRA mock dir:    {jira_mock_dir}")
+    print(f"Repo fixtures:    {mock_data_dir}")
+    print(f"Blocked URLs:     {blocked_urls}")
+    print(f"MCP config:       {tmp_path}")
+    print(f"Logs:             {log_dir}/")
+    print(f"  privileged:     {log_dir / 'ymir-privileged.log'}")
+    print(f"  unprivileged:   {log_dir / 'ymir-unprivileged.log'}")
+    print("============================")
+    print()
+
+    os.chdir(REPO_ROOT)
+
+    os.execvp(
+        "claude",
+        [
+            "claude",
+            f"Use the triage skill with jira_issue={issue} and dry_run=true",
+            "--mcp-config",
+            tmp_path,
+        ],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-agent-skills.py
+++ b/scripts/sync-agent-skills.py
@@ -19,7 +19,7 @@ AGENTS_DIR = Path("ymir/agents")
 SKILLS_DIR = Path("agents_as_skills")
 
 CLAUDE_CMD_TEMPLATE = (
-    "claude --model claude-sonnet-4-6 --effort high"
+    "claude --model claude-opus-4-6 --effort high"
     ' "Please take a look at the BeeAI workflows implemented in agents'
     " directory. Please convert Workflow in {workflow_file} to Claude skill and"
     f" save that skill to {SKILLS_DIR} directory.\n"

--- a/ymir/agents/tests/e2e/mock_repos/README.md
+++ b/ymir/agents/tests/e2e/mock_repos/README.md
@@ -1,9 +1,8 @@
-# Where are the Jira files?
-This directory is meant to contain Jira mock files from
+# Where are the mock data files?
+This directory is meant to contain mock repo fixture files from
 `git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git` if you have the access.
 
-Clone the repository and copy (or symlink) the contents of its `jiras/` directory here.
-If you want agents to be able to write to them, add the writing permission bit for all users.
+Clone the repository and copy (or symlink) the contents of its `mock_data/` directory here.
 
 The expected layout of the private repository is:
 
@@ -21,3 +20,7 @@ The expected layout of the private repository is:
 │   └── RHEL-61943.json
 └── README.md
 ```
+
+Each JSON file in `mock_data/` describes the repos to clone at a pre-fix state
+and an optional z-stream override for a given Jira issue. See
+`ymir/common/mock_repos.py` for the schema documentation.

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -127,14 +127,17 @@ def observability_fixture():
 
 @pytest.fixture(scope="session", autouse=True)
 def mock_centos_stream_repos(tmp_path_factory):
-    """Clone CentOS Stream RPM repos at pre-fix state, one per (test_case, package).
+    """Clone CentOS Stream RPM repos at pre-fix state for each test case.
 
     Fixture configs are loaded from ``MOCK_REPOS_DIR`` (env var) or the
-    ``mock_repos/`` directory next to this test file.  Each bare clone has its
-    branch ref rewound to the pre-fix commit.  A per-test-case env dict is
-    built with GIT_CONFIG_COUNT / GIT_CONFIG_KEY_* / GIT_CONFIG_VALUE_* so that
-    git's ``insteadOf`` URL rewriting transparently redirects the agent's git
-    commands to the local clone.
+    ``mock_repos/`` directory next to this test file. Each bare clone has its
+    branch ref rewound to the pre-fix commit. A per-test-case env dict is
+    built with ``GIT_CONFIG_COUNT`` / ``GIT_CONFIG_KEY_*`` /
+    ``GIT_CONFIG_VALUE_*`` so that git's ``insteadOf`` URL rewriting
+    transparently redirects the agent's git commands to the local clone.
+
+    Yields:
+        Control to the test session after repos are prepared.
     """
     mock_dir = os.getenv("MOCK_REPOS_DIR", str(DEFAULT_MOCK_REPOS_DIR))
     configs = load_all_mock_configs(mock_dir)

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -1,8 +1,7 @@
 import asyncio
 import logging
 import os
-import shutil
-import subprocess
+from pathlib import Path
 
 import pytest
 from tabulate import tabulate
@@ -10,56 +9,16 @@ from tabulate import tabulate
 from ymir.agents.metrics_middleware import MetricsMiddleware
 from ymir.agents.observability import setup_observability
 from ymir.agents.triage_agent import TriageState, create_triage_agent, run_workflow
+from ymir.common.mock_repos import (
+    apply_zstream_override,
+    load_all_mock_configs,
+    setup_mock_repos,
+)
 from ymir.common.models import BackportData, Resolution, TriageOutputSchema
-from ymir.common.version_utils import current_z_streams_override
 
 logger = logging.getLogger(__name__)
 
-# Per-test-case CentOS Stream RPM repo fixtures.
-# Each entry maps a Jira issue key to a list of repos that should be cloned
-# and reset to a pre-fix commit so the agent cannot "cheat" by finding the
-# already-applied backport.
-# Per-test-case overrides for what counts as the "current" z-stream.
-# This lets a test treat an older z-stream as current so the agent follows
-# the normal backport path instead of the restricted older-zstream path.
-ZSTREAM_OVERRIDES: dict[str, dict[str, str]] = {
-    "RHEL-112546": {"9": "rhel-9.2.z"},
-}
-
-REPO_FIXTURES = {
-    "RHEL-15216": [
-        {
-            "package": "dnsmasq",
-            "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/dnsmasq",
-            "pre_fix_ref": "8a2a7d987c18aecc60c0757b6e47200ba89f3940",  # pragma: allowlist secret
-            "branch": "c8s",
-        },
-    ],
-    "RHEL-112546": [
-        {
-            "package": "libtiff",
-            "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/libtiff",
-            "pre_fix_ref": "1d8f0e982d3beff79b63559640b7bd578109ceaf",  # pragma: allowlist secret
-            "branch": "c9s",
-        },
-    ],
-    "RHEL-61943": [
-        {
-            "package": "dnsmasq",
-            "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/dnsmasq",
-            "pre_fix_ref": "29f30a06a4be3f9af277e049b9f754ae58451306",  # pragma: allowlist secret
-            "branch": "c8s",
-        },
-    ],
-    "RHEL-29712": [
-        {
-            "package": "bind",
-            "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/bind",
-            "pre_fix_ref": "f523ee34fdb30075a28daf6b8a72f2aed52eb80e",  # pragma: allowlist secret
-            "branch": "c8s",
-        },
-    ],
-}
+DEFAULT_MOCK_REPOS_DIR = Path(__file__).parent / "mock_repos"
 
 
 class TriageAgentTestCase:
@@ -70,11 +29,11 @@ class TriageAgentTestCase:
         self.finished_state: TriageState | None = None
         self.error: BaseException | None = None
         self.git_env: dict | None = None
-        self.zstream_override: dict[str, str] | None = ZSTREAM_OVERRIDES.get(input)
+        self.zstream_override: dict[str, str] | None = None
 
     async def run(self) -> None:
         if self.zstream_override:
-            current_z_streams_override.set(self.zstream_override)
+            apply_zstream_override(self.zstream_override)
 
         metrics_middleware = MetricsMiddleware()
 
@@ -105,7 +64,7 @@ test_cases = [
                 justification="not-implemented",
                 jira_issue="RHEL-15216",
                 cve_id=None,
-                fix_version="rhel-8.10",
+                fix_version="rhel-8.10.z",
             ),
         ),
     ),
@@ -170,98 +129,28 @@ def observability_fixture():
 def mock_centos_stream_repos(tmp_path_factory):
     """Clone CentOS Stream RPM repos at pre-fix state, one per (test_case, package).
 
-    Each bare clone has its branch ref rewound to the pre-fix commit.  A per-test-case
-    env dict is built with GIT_CONFIG_COUNT / GIT_CONFIG_KEY_* / GIT_CONFIG_VALUE_*
-    so that git's ``insteadOf`` URL rewriting transparently redirects the agent's
-    git commands to the local clone.
+    Fixture configs are loaded from ``MOCK_REPOS_DIR`` (env var) or the
+    ``mock_repos/`` directory next to this test file.  Each bare clone has its
+    branch ref rewound to the pre-fix commit.  A per-test-case env dict is
+    built with GIT_CONFIG_COUNT / GIT_CONFIG_KEY_* / GIT_CONFIG_VALUE_* so that
+    git's ``insteadOf`` URL rewriting transparently redirects the agent's git
+    commands to the local clone.
     """
+    mock_dir = os.getenv("MOCK_REPOS_DIR", str(DEFAULT_MOCK_REPOS_DIR))
+    configs = load_all_mock_configs(mock_dir)
     repo_dir = tmp_path_factory.mktemp("centos_stream_repos")
 
-    for issue_key, repos in REPO_FIXTURES.items():
-        git_env: dict[str, str] = {}
-        for i, repo_info in enumerate(repos):
-            local_path = repo_dir / f"{issue_key}-{repo_info['package']}.git"
-            logger.info(
-                "Cloning %s (bare) into %s for %s",
-                repo_info["remote_url"],
-                local_path,
-                issue_key,
-            )
-            subprocess.run(
-                ["git", "clone", "--bare", repo_info["remote_url"], str(local_path)],
-                check=True,
-                capture_output=True,
-            )
-            subprocess.run(
-                [
-                    "git",
-                    "update-ref",
-                    f"refs/heads/{repo_info['branch']}",
-                    repo_info["pre_fix_ref"],
-                ],
-                cwd=str(local_path),
-                check=True,
-            )
-            all_refs = (
-                subprocess.run(
-                    ["git", "for-each-ref", "--format=%(refname)"],
-                    cwd=str(local_path),
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                .stdout.strip()
-                .splitlines()
-            )
-            keep_ref = f"refs/heads/{repo_info['branch']}"
-            refs_to_delete = [ref for ref in all_refs if ref != keep_ref]
-            if refs_to_delete:
-                subprocess.run(
-                    ["git", "update-ref", "--stdin"],
-                    input="".join(f"delete {ref}\n" for ref in refs_to_delete),
-                    cwd=str(local_path),
-                    text=True,
-                    check=True,
-                )
-            subprocess.run(
-                ["git", "gc", "--prune=now", "-q"],
-                cwd=str(local_path),
-                check=True,
-                capture_output=True,
-            )
-            git_env[f"GIT_CONFIG_KEY_{i}"] = f"url.file://{local_path}.insteadOf"
-            git_env[f"GIT_CONFIG_VALUE_{i}"] = repo_info["remote_url"]
+    for issue_key, config in configs.items():
+        repos = config.get("repos", [])
+        if not repos:
+            continue
 
-        git_env["GIT_CONFIG_COUNT"] = str(len(repos))
-
-        blocked_urls = [r["remote_url"] for r in repos]
-        wrapper_dir = repo_dir / f"{issue_key}-wrappers"
-        wrapper_dir.mkdir()
-        for cmd in ["curl", "wget"]:
-            real_path = shutil.which(cmd)
-            if not real_path:
-                continue
-            blocked_patterns = " ".join(f'"{url}"' for url in blocked_urls)
-            wrapper = wrapper_dir / cmd
-            wrapper.write_text(
-                f"#!/bin/bash\n"
-                f"BLOCKED=({blocked_patterns})\n"
-                f'for arg in "$@"; do\n'
-                f'  for b in "${{BLOCKED[@]}}"; do\n'
-                f'    if [[ "$arg" == "$b"* ]]; then\n'
-                f'      echo "BLOCKED: $b is mocked locally; use git commands instead of curl/wget" >&2\n'
-                f"      exit 1\n"
-                f"    fi\n"
-                f"  done\n"
-                f"done\n"
-                f'exec {real_path} "$@"\n'
-            )
-            wrapper.chmod(0o755)
-        git_env["PATH"] = f"{wrapper_dir}:{os.environ.get('PATH', '/usr/bin:/bin')}"
+        git_env = setup_mock_repos(repos, issue_key, repo_dir)
 
         for tc in test_cases:
             if tc.input == issue_key:
                 tc.git_env = git_env
+                tc.zstream_override = config.get("zstream_override")
                 break
 
     yield

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1028,6 +1028,34 @@ async def run_workflow(
         return response.state
 
 
+def _build_mock_agent_factory(jira_issue: str):
+    """If ``MOCK_REPOS_DIR`` is set, prepare mock repos and return a
+    triage-agent factory that injects the resulting ``git_env``.
+
+    Also applies ``MOCK_ZSTREAMS`` (standalone env-var) and any per-issue
+    ``zstream_override`` found in the config file.
+
+    Returns ``create_triage_agent`` unchanged when mocking is not configured.
+    """
+    from ymir.common.mock_repos import (
+        apply_zstream_override_from_env,
+        setup_mock_repos_from_env,
+    )
+
+    apply_zstream_override_from_env()
+
+    git_env = setup_mock_repos_from_env(jira_issue)
+    if git_env is None:
+        return create_triage_agent
+
+    logger.info("Mock repos configured for %s via MOCK_REPOS_DIR", jira_issue)
+
+    def _factory(gateway_tools, local_tool_options=None):
+        return create_triage_agent(gateway_tools, {"env": git_env})
+
+    return _factory
+
+
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     resolve_chat_model_override("triage")
@@ -1041,10 +1069,11 @@ async def main() -> None:
 
     if jira_issue := os.getenv("JIRA_ISSUE", None):
         logger.info("Running in direct mode with environment variable")
+        agent_factory = _build_mock_agent_factory(jira_issue)
         state = await run_workflow(
             jira_issue,
             dry_run,
-            create_triage_agent,
+            agent_factory,
             auto_chain=auto_chain,
             force_cve_triage=force_cve_triage,
             silent_run=silent_run,

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -36,6 +36,10 @@ from ymir.agents.utils import (
 from ymir.common.base_utils import fix_await, redis_client
 from ymir.common.config import load_rhel_config
 from ymir.common.constants import JiraLabels, RedisQueues
+from ymir.common.mock_repos import (
+    apply_zstream_override_from_env,
+    setup_mock_repos_from_env,
+)
 from ymir.common.models import (
     ApplicabilityResult,
     ClarificationNeededData,
@@ -1043,11 +1047,6 @@ def _build_mock_agent_factory(jira_issue: str):
         A triage-agent factory callable. Returns ``create_triage_agent``
         unchanged when mocking is not configured.
     """
-    from ymir.common.mock_repos import (
-        apply_zstream_override_from_env,
-        setup_mock_repos_from_env,
-    )
-
     apply_zstream_override_from_env()
 
     git_env = setup_mock_repos_from_env(jira_issue)

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -26,6 +26,7 @@ from ymir.agents.cve_applicability_agent import build_applicability_prompt, crea
 from ymir.agents.observability import setup_observability
 from ymir.agents.rebuild_consolidation import find_rebuild_siblings
 from ymir.agents.utils import (
+    build_agent_factory_with_mock_repos,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -36,10 +37,6 @@ from ymir.agents.utils import (
 from ymir.common.base_utils import fix_await, redis_client
 from ymir.common.config import load_rhel_config
 from ymir.common.constants import JiraLabels, RedisQueues
-from ymir.common.mock_repos import (
-    apply_zstream_override_from_env,
-    setup_mock_repos_from_env,
-)
 from ymir.common.models import (
     ApplicabilityResult,
     ClarificationNeededData,
@@ -1032,35 +1029,6 @@ async def run_workflow(
         return response.state
 
 
-def _build_mock_agent_factory(jira_issue: str):
-    """Build a triage-agent factory with mock repo support when configured.
-
-    If ``MOCK_REPOS_DIR`` is set, prepares mock repos and returns a factory
-    that injects the resulting ``git_env``. Also applies ``MOCK_ZSTREAMS``
-    (standalone env-var) and any per-issue ``zstream_override`` found in the
-    config file.
-
-    Args:
-        jira_issue: The Jira issue key (e.g. ``RHEL-15216``).
-
-    Returns:
-        A triage-agent factory callable. Returns ``create_triage_agent``
-        unchanged when mocking is not configured.
-    """
-    apply_zstream_override_from_env()
-
-    git_env = setup_mock_repos_from_env(jira_issue)
-    if git_env is None:
-        return create_triage_agent
-
-    logger.info("Mock repos configured for %s via MOCK_REPOS_DIR", jira_issue)
-
-    def _factory(gateway_tools, local_tool_options=None):
-        return create_triage_agent(gateway_tools, {"env": git_env})
-
-    return _factory
-
-
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     resolve_chat_model_override("triage")
@@ -1074,7 +1042,7 @@ async def main() -> None:
 
     if jira_issue := os.getenv("JIRA_ISSUE", None):
         logger.info("Running in direct mode with environment variable")
-        agent_factory = _build_mock_agent_factory(jira_issue)
+        agent_factory = build_agent_factory_with_mock_repos(create_triage_agent, jira_issue)
         state = await run_workflow(
             jira_issue,
             dry_run,

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1029,13 +1029,19 @@ async def run_workflow(
 
 
 def _build_mock_agent_factory(jira_issue: str):
-    """If ``MOCK_REPOS_DIR`` is set, prepare mock repos and return a
-    triage-agent factory that injects the resulting ``git_env``.
+    """Build a triage-agent factory with mock repo support when configured.
 
-    Also applies ``MOCK_ZSTREAMS`` (standalone env-var) and any per-issue
-    ``zstream_override`` found in the config file.
+    If ``MOCK_REPOS_DIR`` is set, prepares mock repos and returns a factory
+    that injects the resulting ``git_env``. Also applies ``MOCK_ZSTREAMS``
+    (standalone env-var) and any per-issue ``zstream_override`` found in the
+    config file.
 
-    Returns ``create_triage_agent`` unchanged when mocking is not configured.
+    Args:
+        jira_issue: The Jira issue key (e.g. ``RHEL-15216``).
+
+    Returns:
+        A triage-agent factory callable. Returns ``create_triage_agent``
+        unchanged when mocking is not configured.
     """
     from ymir.common.mock_repos import (
         apply_zstream_override_from_env,

--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -1,5 +1,7 @@
 import logging
 import os
+from collections.abc import Callable
+from typing import Any
 
 from beeai_framework.agents.tool_calling.utils import ToolCallCheckerConfig
 from beeai_framework.backend import ChatModel, ChatModelParameters
@@ -7,6 +9,7 @@ from beeai_framework.template import PromptTemplate
 from pydantic import BaseModel
 
 from ymir.common.base_utils import check_subprocess, run_subprocess  # noqa: F401 — re-exported
+from ymir.common.mock_repos import apply_zstream_override_from_env, setup_mock_repos_from_env
 from ymir.common.utils import get_absolute_path, mcp_tools, run_tool  # noqa: F401 — re-exported
 
 logger = logging.getLogger(__name__)
@@ -88,3 +91,36 @@ def set_litellm_debug() -> None:
     from beeai_framework.adapters.litellm.utils import litellm_debug
 
     litellm_debug(True)
+
+
+def build_agent_factory_with_mock_repos(
+    agent_factory: Callable[[list, dict[str, Any] | None], Any], jira_issue: str
+) -> Callable[[list, dict[str, Any] | None], Any]:
+    """Wrap an agent factory with mock repo support when configured.
+
+    If ``MOCK_REPOS_DIR`` is set, prepares mock repos and returns a factory
+    that injects the resulting ``git_env`` into ``local_tool_options``.
+    Also applies ``MOCK_ZSTREAMS`` (standalone env-var) and any per-issue
+    ``zstream_override`` found in the config file.
+
+    Args:
+        agent_factory: The original agent factory callable
+            (e.g. ``create_triage_agent``).
+        jira_issue: The Jira issue key (e.g. ``RHEL-15216``).
+
+    Returns:
+        The original factory unchanged when mocking is not configured,
+        or a wrapper that injects mock ``git_env``.
+    """
+    apply_zstream_override_from_env()
+
+    git_env = setup_mock_repos_from_env(jira_issue)
+    if git_env is None:
+        return agent_factory
+
+    logger.info("Mock repos configured for %s via MOCK_REPOS_DIR", jira_issue)
+
+    def _factory(gateway_tools, local_tool_options=None):
+        return agent_factory(gateway_tools, {"env": git_env})
+
+    return _factory

--- a/ymir/common/mock_repos.py
+++ b/ymir/common/mock_repos.py
@@ -1,0 +1,200 @@
+"""
+Shared utilities for setting up mock CentOS Stream repo fixtures.
+
+When ``MOCK_REPOS_DIR`` is set, per-issue JSON configs are loaded from that
+directory.  Each bare clone has its branch ref rewound to a pre-fix commit so
+that agents cannot "cheat" by finding an already-applied backport.
+
+When ``MOCK_ZSTREAMS`` is set (JSON string), the z-stream override is applied
+via the ``current_z_streams_override`` ContextVar.
+
+When ``MOCK_BLOCKED_URLS`` is set (comma-separated or JSON array),
+``RunShellCommandTool`` blocks curl/wget invocations targeting those URL
+prefixes.
+
+Directory layout expected under ``MOCK_REPOS_DIR``::
+
+    MOCK_REPOS_DIR/
+        RHEL-15216.json
+        RHEL-112546.json
+        ...
+
+Each JSON file contains::
+
+    {
+        "zstream_override": {"9": "rhel-9.2.z"},   // optional
+        "repos": [
+            {
+                "package": "libtiff",
+                "remote_url": "https://gitlab.com/redhat/centos-stream/rpms/libtiff",
+                "pre_fix_ref": "1d8f0e982d...",
+                "branch": "c9s"
+            }
+        ]
+    }
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import git
+
+from ymir.common.version_utils import current_z_streams_override
+
+logger = logging.getLogger(__name__)
+
+
+def load_mock_config(issue_key: str, mock_dir: str | Path) -> dict | None:
+    """Load the mock config for a given issue key.
+
+    Args:
+        issue_key: The Jira issue key (e.g. ``RHEL-15216``).
+        mock_dir: Directory containing per-issue JSON config files.
+
+    Returns:
+        The parsed config dict, or ``None`` when no config file exists
+        for the given issue.
+    """
+    config_path = Path(mock_dir) / f"{issue_key}.json"
+    if not config_path.exists():
+        return None
+    with open(config_path) as fh:
+        return json.load(fh)
+
+
+def load_all_mock_configs(mock_dir: str | Path) -> dict[str, dict]:
+    """Load every ``<ISSUE_KEY>.json`` in a mock directory.
+
+    Args:
+        mock_dir: Directory containing per-issue JSON config files.
+
+    Returns:
+        A dict mapping issue keys to their parsed config dicts.
+    """
+    configs: dict[str, dict] = {}
+    mock_path = Path(mock_dir)
+    for config_file in sorted(mock_path.glob("*.json")):
+        issue_key = config_file.stem
+        with open(config_file) as fh:
+            configs[issue_key] = json.load(fh)
+    return configs
+
+
+def setup_mock_repos(repos: list[dict], issue_key: str, base_dir: Path) -> dict[str, str]:
+    """Clone repos at pre-fix state and return a ``git_env`` dict.
+
+    Each bare clone has its branch ref rewound to the pre-fix commit.
+    The mocked remote URLs are appended to the ``MOCK_BLOCKED_URLS``
+    environment variable so that ``RunShellCommandTool`` blocks direct
+    curl/wget access to them.
+
+    Args:
+        repos: List of repo dicts, each containing ``package``,
+            ``remote_url``, ``pre_fix_ref``, and ``branch`` keys.
+        issue_key: The Jira issue key used for naming the local clones.
+        base_dir: Directory in which bare clones are created.
+
+    Returns:
+        A dict with ``GIT_CONFIG_COUNT``/``KEY``/``VALUE`` entries for
+        ``insteadOf`` URL rewriting.
+    """
+    git_env: dict[str, str] = {}
+
+    for i, repo_info in enumerate(repos):
+        local_path = base_dir / f"{issue_key}-{repo_info['package']}.git"
+        logger.info(
+            "Cloning %s (bare) into %s for %s",
+            repo_info["remote_url"],
+            local_path,
+            issue_key,
+        )
+        repo = git.Repo.clone_from(repo_info["remote_url"], str(local_path), bare=True)
+
+        keep_branch = repo_info["branch"]
+        repo.git.update_ref(f"refs/heads/{keep_branch}", repo_info["pre_fix_ref"])
+
+        keep_ref = f"refs/heads/{keep_branch}"
+        refs_to_delete = [ref.path for ref in repo.references if ref.path != keep_ref]
+        for ref_path in refs_to_delete:
+            repo.git.update_ref("-d", ref_path)
+
+        repo.git.gc("--prune=now", "-q")
+
+        git_env[f"GIT_CONFIG_KEY_{i}"] = f"url.file://{local_path}.insteadOf"
+        git_env[f"GIT_CONFIG_VALUE_{i}"] = repo_info["remote_url"]
+
+    git_env["GIT_CONFIG_COUNT"] = str(len(repos))
+
+    _register_blocked_urls([r["remote_url"] for r in repos])
+
+    return git_env
+
+
+def _register_blocked_urls(urls: list[str]) -> None:
+    """Append URLs to the ``MOCK_BLOCKED_URLS`` environment variable.
+
+    Existing entries are preserved (comma-separated). Duplicates are
+    deduplicated.
+
+    Args:
+        urls: Remote URL strings to block.
+    """
+    existing = os.getenv("MOCK_BLOCKED_URLS", "")
+    current = {u.strip() for u in existing.split(",") if u.strip()} if existing else set()
+    current.update(urls)
+    os.environ["MOCK_BLOCKED_URLS"] = ",".join(sorted(current))
+
+
+def apply_zstream_override(override: dict[str, str] | None) -> None:
+    """Set the ``current_z_streams_override`` ContextVar if non-empty.
+
+    Args:
+        override: Mapping of RHEL major version to z-stream target,
+            or ``None`` to skip.
+    """
+    if override:
+        current_z_streams_override.set(override)
+
+
+def apply_zstream_override_from_env() -> None:
+    """Read the ``MOCK_ZSTREAMS`` env var (JSON) and apply it."""
+    raw = os.getenv("MOCK_ZSTREAMS")
+    if raw:
+        apply_zstream_override(json.loads(raw))
+
+
+def setup_mock_repos_from_env(issue_key: str, base_dir: Path | None = None) -> dict[str, str] | None:
+    """Load config from ``MOCK_REPOS_DIR`` for an issue and set up repos.
+
+    Also applies the per-issue z-stream override if present in the config.
+
+    Args:
+        issue_key: The Jira issue key (e.g. ``RHEL-15216``).
+        base_dir: Directory for bare clones. A temporary directory is
+            created when ``None``.
+
+    Returns:
+        The ``git_env`` dict on success, or ``None`` when mocking is not
+        configured or no config exists for the issue.
+    """
+    mock_dir = os.getenv("MOCK_REPOS_DIR")
+    if not mock_dir:
+        return None
+
+    config = load_mock_config(issue_key, mock_dir)
+    if config is None:
+        return None
+
+    apply_zstream_override(config.get("zstream_override"))
+
+    repos = config.get("repos")
+    if not repos:
+        return None
+
+    if base_dir is None:
+        base_dir = Path(tempfile.mkdtemp(prefix=f"mock_repos_{issue_key}_"))
+
+    return setup_mock_repos(repos, issue_key, base_dir)

--- a/ymir/common/pyproject.toml
+++ b/ymir/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-common"
-version = "0.2.0"
+version = "0.3.0"
 description = "Common utilities shared across Ymir AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]
@@ -34,3 +34,4 @@ packages = []
 "validators.py" = "ymir/common/validators.py"
 "version_utils.py" = "ymir/common/version_utils.py"
 "base_utils.py" = "ymir/common/base_utils.py"
+"mock_repos.py" = "ymir/common/mock_repos.py"

--- a/ymir/common/requirements.txt
+++ b/ymir/common/requirements.txt
@@ -1,2 +1,3 @@
 # Dependencies specific to ymir-common
+GitPython>=3.1.0
 redis>=6.4.0

--- a/ymir/tools/pyproject.toml
+++ b/ymir/tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-tools"
-version = "0.2.0"
+version = "0.3.0"
 description = "Ymir MCP tools for AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]

--- a/ymir/tools/unprivileged/commands.py
+++ b/ymir/tools/unprivileged/commands.py
@@ -13,6 +13,7 @@ from ymir.common.base_utils import run_subprocess
 
 TIMEOUT = 10 * 60  # seconds
 ELLIPSIZED_LINES = 200
+URL_FETCH_COMMANDS = ["curl", "wget"]
 
 
 def _get_blocked_urls() -> list[str]:
@@ -47,8 +48,9 @@ def _check_blocked_urls(command: str, blocked_urls: list[str]) -> str | None:
     except ValueError:
         tokens = command.split()
 
-    has_curl_or_wget = any(tok in ("curl", "wget") or tok.endswith(("/curl", "/wget")) for tok in tokens)
-    if not has_curl_or_wget:
+    suffixes = tuple(f"/{cmd}" for cmd in URL_FETCH_COMMANDS)
+    has_url_fetch_cmd = any(tok in URL_FETCH_COMMANDS or tok.endswith(suffixes) for tok in tokens)
+    if not has_url_fetch_cmd:
         return None
 
     for token in tokens:
@@ -105,7 +107,8 @@ class RunShellCommandTool(Tool[RunShellCommandToolInput, ToolRunOptions, RunShel
             blocked = _check_blocked_urls(tool_input.command, blocked_urls)
             if blocked:
                 raise ToolError(
-                    f"BLOCKED: {blocked} is mocked locally; use git commands instead of curl/wget"
+                    f"BLOCKED: {blocked} is mocked locally; "
+                    f"use git commands instead of {'/'.join(URL_FETCH_COMMANDS)}"
                 )
 
         try:

--- a/ymir/tools/unprivileged/commands.py
+++ b/ymir/tools/unprivileged/commands.py
@@ -1,5 +1,7 @@
 import asyncio
 import math
+import os
+import shlex
 
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
@@ -10,6 +12,40 @@ from ymir.common.base_utils import run_subprocess
 
 TIMEOUT = 10 * 60  # seconds
 ELLIPSIZED_LINES = 200
+
+
+def _get_blocked_urls() -> list[str]:
+    """Return the list of blocked URL prefixes from ``MOCK_BLOCKED_URLS``.
+
+    The env var accepts either a JSON array or a comma-separated string.
+    """
+    raw = os.getenv("MOCK_BLOCKED_URLS", "")
+    if not raw:
+        return []
+    raw = raw.strip()
+    if raw.startswith("["):
+        import json
+
+        return json.loads(raw)
+    return [url.strip() for url in raw.split(",") if url.strip()]
+
+
+def _check_blocked_urls(command: str, blocked_urls: list[str]) -> str | None:
+    """If *command* invokes curl/wget targeting a blocked URL, return the URL."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    has_curl_or_wget = any(tok in ("curl", "wget") or tok.endswith(("/curl", "/wget")) for tok in tokens)
+    if not has_curl_or_wget:
+        return None
+
+    for token in tokens:
+        for blocked in blocked_urls:
+            if token.startswith(blocked):
+                return blocked
+    return None
 
 
 class RunShellCommandToolInput(BaseModel):
@@ -54,6 +90,14 @@ class RunShellCommandTool(Tool[RunShellCommandToolInput, ToolRunOptions, RunShel
         options: ToolRunOptions | None,
         context: RunContext,
     ) -> RunShellCommandToolOutput:
+        blocked_urls = _get_blocked_urls()
+        if blocked_urls:
+            blocked = _check_blocked_urls(tool_input.command, blocked_urls)
+            if blocked:
+                raise ToolError(
+                    f"BLOCKED: {blocked} is mocked locally; use git commands instead of curl/wget"
+                )
+
         try:
             exit_code, stdout, stderr = await asyncio.wait_for(
                 run_subprocess(

--- a/ymir/tools/unprivileged/commands.py
+++ b/ymir/tools/unprivileged/commands.py
@@ -24,13 +24,13 @@ def _get_blocked_urls() -> list[str]:
     Returns:
         A list of URL prefix strings to block.
     """
-    raw = os.getenv("MOCK_BLOCKED_URLS", "")
-    if not raw:
+    if not (raw := os.getenv("MOCK_BLOCKED_URLS", "")):
         return []
     raw = raw.strip()
-    if raw.startswith("["):
+    try:
         return json.loads(raw)
-    return [url.strip() for url in raw.split(",") if url.strip()]
+    except json.decoder.JSONDecodeError:
+        return [stripped for url in raw.split(",") if (stripped := url.strip())]
 
 
 def _check_blocked_urls(command: str, blocked_urls: list[str]) -> str | None:

--- a/ymir/tools/unprivileged/commands.py
+++ b/ymir/tools/unprivileged/commands.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import math
 import os
 import shlex
@@ -27,8 +28,6 @@ def _get_blocked_urls() -> list[str]:
         return []
     raw = raw.strip()
     if raw.startswith("["):
-        import json
-
         return json.loads(raw)
     return [url.strip() for url in raw.split(",") if url.strip()]
 

--- a/ymir/tools/unprivileged/commands.py
+++ b/ymir/tools/unprivileged/commands.py
@@ -18,6 +18,9 @@ def _get_blocked_urls() -> list[str]:
     """Return the list of blocked URL prefixes from ``MOCK_BLOCKED_URLS``.
 
     The env var accepts either a JSON array or a comma-separated string.
+
+    Returns:
+        A list of URL prefix strings to block.
     """
     raw = os.getenv("MOCK_BLOCKED_URLS", "")
     if not raw:
@@ -31,7 +34,15 @@ def _get_blocked_urls() -> list[str]:
 
 
 def _check_blocked_urls(command: str, blocked_urls: list[str]) -> str | None:
-    """If *command* invokes curl/wget targeting a blocked URL, return the URL."""
+    """Check whether a shell command targets a blocked URL via curl/wget.
+
+    Args:
+        command: The shell command string to inspect.
+        blocked_urls: URL prefixes that should be blocked.
+
+    Returns:
+        The matched blocked URL prefix, or ``None`` if no match is found.
+    """
     try:
         tokens = shlex.split(command)
     except ValueError:


### PR DESCRIPTION
- Extract mock repo setup from e2e tests into a shared ymir/common/mock_repos.py module so the same mocking infrastructure can be reused for all mocking
- Add RunShellCommandTool URL blocking via MOCK_BLOCKED_URLS to prevent agents from bypassing mocked repos with curl/wget, replacing the previous shell wrapper approach
- Add scripts/run-mock-triage.py launcher and claude-triage-mock.md guide for running the triage skill against mocked JIRA data locally