### PR TITLE
Add per-agent chat model override via environment variables

### DIFF
--- a/openshift/configmap-chat-env.yml
+++ b/openshift/configmap-chat-env.yml
@@ -1,6 +1,10 @@
 apiVersion: v1
 data:
   CHAT_MODEL: vertexai:claude-sonnet-4-6
+  CHAT_MODEL_TRIAGE: vertexai:claude-opus-4-6
+  CHAT_MODEL_BACKPORT: ""
+  CHAT_MODEL_REBASE: ""
+  CHAT_MODEL_REBUILD: ""
   GOOGLE_APPLICATION_CREDENTIALS: /etc/secrets/jotnar-vertex-prod.json
   GOOGLE_VERTEX_PROJECT: jotnar-bot
   GOOGLE_VERTEX_LOCATION: global

--- a/templates/beeai-agent.env
+++ b/templates/beeai-agent.env
@@ -17,8 +17,16 @@
 # CHAT_MODEL=vertexai:claude-sonnet-4-6
 # Sonnet 4.5:
 # CHAT_MODEL=vertexai:claude-sonnet-4-5
+# Opus 4.6:
+# CHAT_MODEL=vertexai:claude-opus-4-6
 
 CHAT_MODEL=
+
+# Per-agent model overrides (optional, falls back to CHAT_MODEL):
+# CHAT_MODEL_TRIAGE=
+# CHAT_MODEL_BACKPORT=
+# CHAT_MODEL_REBASE=
+# CHAT_MODEL_REBUILD=
 
 # =============================================================================
 # CREDENTIALS - Use based on model prefix above

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -37,6 +37,7 @@ from ymir.agents.utils import (
     get_tool_call_checker_config,
     mcp_tools,
     render_prompt,
+    resolve_chat_model_override,
     run_tool,
 )
 from ymir.common.base_utils import fix_await, is_cs_branch, redis_client
@@ -931,6 +932,7 @@ async def create_backport_agent(
 
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
+    resolve_chat_model_override("backport")
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -35,6 +35,7 @@ from ymir.agents.utils import (
     get_tool_call_checker_config,
     mcp_tools,
     render_prompt,
+    resolve_chat_model_override,
 )
 from ymir.common.base_utils import fix_await, is_cs_branch, redis_client
 from ymir.common.config import get_package_instructions
@@ -208,6 +209,7 @@ def create_rebase_agent(mcp_tools: list[Tool], local_tool_options: dict[str, Any
 
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
+    resolve_chat_model_override("rebase")
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -19,6 +19,7 @@ from ymir.agents.utils import (
     get_agent_execution_config,
     mcp_tools,
     render_prompt,
+    resolve_chat_model_override,
     run_subprocess,
 )
 from ymir.common.base_utils import fix_await, redis_client
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
+    resolve_chat_model_override("rebuild")
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -30,6 +30,7 @@ from ymir.agents.utils import (
     get_chat_model,
     get_tool_call_checker_config,
     mcp_tools,
+    resolve_chat_model_override,
     run_tool,
 )
 from ymir.common.base_utils import fix_await, redis_client
@@ -1029,6 +1030,7 @@ async def run_workflow(
 
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
+    resolve_chat_model_override("triage")
 
     setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 

--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -12,6 +12,17 @@ from ymir.common.utils import get_absolute_path, mcp_tools, run_tool  # noqa: F4
 logger = logging.getLogger(__name__)
 
 
+def resolve_chat_model_override(agent_type: str) -> None:
+    """Override CHAT_MODEL with a per-agent value if set.
+
+    Call once at container startup so all agents in the process inherit the override.
+    """
+    override = os.environ.get(f"CHAT_MODEL_{agent_type.upper()}", "")
+    if override:
+        logger.info("Using model override for %s: %s", agent_type, override)
+        os.environ["CHAT_MODEL"] = override
+
+
 def get_chat_model() -> ChatModel:
     chat_model = os.environ["CHAT_MODEL"]
     model = ChatModel.from_name(


### PR DESCRIPTION
Allow overriding CHAT_MODEL per agent type (CHAT_MODEL_TRIAGE, CHAT_MODEL_BACKPORT, CHAT_MODEL_REBASE, CHAT_MODEL_REBUILD). Falls back to the default CHAT_MODEL when unset.

Assisted-by: Claude Opus 4.6
