### PR TITLE
Add operation-type labels to MRs for tracking statistics

### DIFF
--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -1342,6 +1342,7 @@ async def main() -> None:
                         ),
                         available_tools=gateway_tools,
                         commit_only=dry_run,
+                        labels=["ymir_backport"],
                     )
                 except Exception as e:
                     logger.warning(f"Error committing and opening MR: {e}")

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -415,6 +415,7 @@ async def main() -> None:
                         ),
                         available_tools=gateway_tools,
                         commit_only=dry_run,
+                        labels=["ymir_rebase"],
                     )
                 except Exception as e:
                     logger.warning(f"Error committing and opening MR: {e}")

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -224,6 +224,7 @@ async def main() -> None:
                         available_tools=gateway_tools,
                         commit_only=dry_run,
                         allow_empty=is_empty_commit,
+                        labels=["ymir_rebuild"],
                     )
                     state.rebuild_success = True
                 except Exception as e:

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -198,6 +198,7 @@ async def commit_push_and_open_mr(
     available_tools: list[Tool],
     commit_only: bool = False,
     allow_empty: bool = False,
+    labels: list[str] | None = None,
 ) -> tuple[str | None, bool]:
     """
     Commits the changes to the local clone and opens a merge request.
@@ -226,6 +227,16 @@ async def commit_push_and_open_mr(
         available_tools=available_tools,
     )
     mr = OpenMergeRequestResult.model_validate(result)
+    if mr.url and labels:
+        try:
+            await run_tool(
+                "add_merge_request_labels",
+                merge_request_url=mr.url,
+                labels=labels,
+                available_tools=available_tools,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to add labels {labels} to MR {mr.url}: {e}")
     return mr.url, mr.is_new_mr
 
 


### PR DESCRIPTION
Label each MR with ymir_backport, ymir_rebase, or ymir_rebuild so we can query GitLab for per-operation statistics.

Assisted-by: Claude Opus 4.6

