### PR TITLE
Add explicit GitPython dependency into agent images

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -55,7 +55,8 @@ RUN pip3 install --no-cache-dir \
       redis \
       specfile \
       pytest \
-      pytest-asyncio
+      pytest-asyncio \
+      GitPython>=3.1.0
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -56,7 +56,8 @@ RUN python3.11 -m venv --system-site-packages /opt/beeai-venv \
          arize-phoenix-otel \
          redis \
          specfile \
-         koji
+         koji \
+         GitPython>=3.1.0
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \


### PR DESCRIPTION
Recent changes unfortunately listed GitPython dependency in python package dependencies but as we copy the files and do not use pip yet for installation of project, it broke c9s images.
