### PR TITLE
Allow injecting internal repos and packages at build time

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -8,6 +8,12 @@ RUN dnf -y install epel-release \
 COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 
+ARG INTERNAL_REPO_URL=""
+RUN if [ -n "$INTERNAL_REPO_URL" ]; then \
+      curl -fsSL -o /etc/yum.repos.d/internal.repo "$INTERNAL_REPO_URL"; \
+    fi
+
+ARG EXTRA_PACKAGES=""
 RUN dnf -y install --allowerasing \
       centpkg \
       curl \
@@ -44,6 +50,7 @@ RUN dnf -y install --allowerasing \
       pyproject-srpm-macros \
       rust-toolset-srpm-macros \
       perl-srpm-macros \
+      ${EXTRA_PACKAGES} \
     && dnf clean all
 
 RUN pip3 install --no-cache-dir \

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -8,6 +8,12 @@ RUN dnf -y install epel-release \
 COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 
+ARG INTERNAL_REPO_URL=""
+RUN if [ -n "$INTERNAL_REPO_URL" ]; then \
+      curl -fsSL -o /etc/yum.repos.d/internal.repo "$INTERNAL_REPO_URL"; \
+    fi
+
+ARG EXTRA_PACKAGES=""
 RUN dnf -y install --allowerasing \
       centpkg \
       curl \
@@ -43,6 +49,7 @@ RUN dnf -y install --allowerasing \
       pyproject-srpm-macros \
       rust-srpm-macros \
       perl-srpm-macros \
+      ${EXTRA_PACKAGES} \
     && dnf clean all
 
 # Create Python 3.11 virtual environment and install Python packages

--- a/Containerfile.mcp
+++ b/Containerfile.mcp
@@ -1,5 +1,15 @@
 FROM fedora:42
 
+# Install RH IT Root CAs for access to internal services
+COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
+
+ARG INTERNAL_REPO_URL=""
+RUN if [ -n "$INTERNAL_REPO_URL" ]; then \
+      curl -fsSL -o /etc/yum.repos.d/internal.repo "$INTERNAL_REPO_URL"; \
+    fi
+
+ARG EXTRA_PACKAGES=""
 # Install system dependencies
 RUN dnf -y install \
       python3 \
@@ -17,6 +27,7 @@ RUN dnf -y install \
       krb5-workstation \
       centpkg \
       git \
+      ${EXTRA_PACKAGES} \
     && dnf clean all
 
 # Install beeai mcp server
@@ -32,10 +43,6 @@ COPY ymir/common/ /home/mcp/ymir/common/
 COPY files/ipa_redhat_com /etc/krb5.conf.d/ipa_redhat_com
 RUN chgrp -R root /home/mcp && chmod -R g+rwX /home/mcp
 RUN mkdir /git-repos && chmod -R o+rwX /git-repos
-
-# Install RH IT Root CAs for lookaside cache access
-COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/
-RUN update-ca-trust
 
 # Configure jump host for internal dist-git
 COPY files/internal_dist-git_ssh.conf /etc/ssh/ssh_config.d/00-dist-git.conf

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ COMPOSE_SUPERVISOR=$(COMPOSE) -f $(COMPOSE_FILE) --profile=supervisor
 
 .PHONY: build
 build:
+	if [ -f .secrets/build.env ]; then \
+		set -a && . ./.secrets/build.env && set +a; \
+	fi && \
 	$(COMPOSE) -f $(COMPOSE_FILE) --profile=agents --profile=supervisor build
 
 .PHONY: run-beeai-bash

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ the `rpm` module installed from PyPI is [rpm-shim](https://github.com/packit/rpm
 and just pulls the files from python3-rpm into the venv.
 In an IDE, select .venv/bin/python as the Python interpreter.
 
+### Building with internal repos
+
+Some tools are only available from internal repos that cannot be committed
+to this upstream repository. To include them in your local container builds:
+
+1. Copy the template: `cp templates/build.env .secrets/build.env`
+2. Fill in the internal repo URLs and package names in `.secrets/build.env`
+3. Run `make build` as usual — the Makefile sources `.secrets/build.env`
+   automatically if it exists, passing the values as build args to the
+   Containerfiles.
+
+Without `.secrets/build.env`, containers build normally but without any
+internal-only packages.
+
 ## Contact & Feedback
 
 **Questions or issues with the agents?**

--- a/compose.yaml
+++ b/compose.yaml
@@ -38,6 +38,9 @@ x-beeai-agent-c9s: &beeai-agent-c9s
   build:
     context: .
     dockerfile: Containerfile.c9s
+    args:
+      INTERNAL_REPO_URL: ${INTERNAL_REPO_URL_C9S:-}
+      EXTRA_PACKAGES: ${INTERNAL_PACKAGES_C9S:-}
   environment:
     <<: *beeai-env
     CONTAINER_VERSION: c9s
@@ -49,6 +52,9 @@ x-beeai-agent-c10s: &beeai-agent-c10s
   build:
     context: .
     dockerfile: Containerfile.c10s
+    args:
+      INTERNAL_REPO_URL: ${INTERNAL_REPO_URL_C10S:-}
+      EXTRA_PACKAGES: ${INTERNAL_PACKAGES_C10S:-}
   environment:
     <<: *beeai-env
     CONTAINER_VERSION: c10s
@@ -82,6 +88,9 @@ services:
     build:
       context: .
       dockerfile: Containerfile.mcp
+      args:
+        INTERNAL_REPO_URL: ${INTERNAL_REPO_URL_MCP:-}
+        EXTRA_PACKAGES: ${INTERNAL_PACKAGES_MCP:-}
     environment:
       - SSE_PORT=8000
       - KEYTAB_FILE=/home/mcp/keytab

--- a/templates/build.env
+++ b/templates/build.env
@@ -1,0 +1,20 @@
+# Internal build configuration for RHEL packaging agent containers.
+# Copy this file to .secrets/build.env and fill in the values.
+#
+# These variables inject internal repos and packages into the container
+# build via podman-compose build args. Without .secrets/build.env, containers
+# build normally without any internal-only packages.
+
+# Repo URL for CentOS Stream 9 agent image (curl'd into the container)
+INTERNAL_REPO_URL_C9S=
+
+# Repo URL for CentOS Stream 10 agent image (curl'd into the container)
+INTERNAL_REPO_URL_C10S=
+
+# Repo URL for MCP gateway (Fedora-based, curl'd into the container)
+INTERNAL_REPO_URL_MCP=
+
+# Space-separated list of extra packages to install per container
+INTERNAL_PACKAGES_C9S=
+INTERNAL_PACKAGES_C10S=
+INTERNAL_PACKAGES_MCP=


### PR DESCRIPTION
## Summary

- Add support for injecting internal repos and extra packages at container build time via `.secrets/build.env`
- Containerfiles use `ARG`s with empty defaults, so builds work without the file (no internal references committed)
- `make build` automatically sources `.secrets/build.env` if present
- Added `templates/build.env` documenting the expected variables
- Updated README with setup instructions

## Motivation

Internal tools (like rhpkg) require internal repos that we can't commit to the upstream repository. This lets developers configure them locally without polluting the public codebase.