### PR TITLE
Fix log agent reverting Release field changes during rebuild

### DIFF
--- a/ymir/agents/log_agent.py
+++ b/ymir/agents/log_agent.py
@@ -63,7 +63,8 @@ def get_instructions() -> str:
 
       - Never change anything in the spec file changelog, you are only allowed to add
         a single changelog entry.
-      - Never change the Release field in the spec file. Release bumping is handled separately.
+      - Never modify the Release field in the spec file. The Release field has already been
+        updated by a previous workflow step - do not revert or modify it.
       - Prefer native tools, if available, the `run_shell_command` tool should be
         the last resort.
     """


### PR DESCRIPTION
Sometimes release changes don't appear in the MR or they disappear after an agent re-run.

This fixed the problem in these two MRs:
https://gitlab.com/redhat/rhel/rpms/ignition/-/merge_requests/45
https://gitlab.com/redhat/rhel/rpms/delve/-/merge_requests/3

