### PR TITLE
OpenShift deployment: stop building rhpkg images, fix git safe.directory, set agent identity

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -22,44 +22,45 @@ jobs:
           docker_context: "."
           image_name: "goose"
 
-  build-and-push-beeai-containers:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - dockerfile: "Containerfile.c9s"
-            tag: "c9s"
-            description: "CentOS Stream 9"
-          - dockerfile: "Containerfile.c10s"
-            tag: "c10s"
-            description: "CentOS Stream 10"
-    steps:
-      - name: Build and push beeai:${{ matrix.tag }} to quay.io registry (${{ matrix.description }})
-        uses: sclorg/build-and-push-action@adf1dee2b786ccbb2e2a708c3510a90e2ab3392d # v4.1.5
-        with:
-          registry: "quay.io"
-          registry_namespace: "jotnar"
-          registry_username: ${{ secrets.REGISTRY_LOGIN }}
-          registry_token: ${{ secrets.REGISTRY_TOKEN }}
-          dockerfile: ${{ matrix.dockerfile }}
-          docker_context: "."
-          image_name: "beeai"
-          tag: ${{ matrix.tag }}
-
-  build-and-push-mcp-server:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Build and push mcp-server to quay.io registry
-        uses: sclorg/build-and-push-action@adf1dee2b786ccbb2e2a708c3510a90e2ab3392d # v4.1.5
-        with:
-          registry: "quay.io"
-          registry_namespace: "jotnar"
-          registry_username: ${{ secrets.REGISTRY_LOGIN }}
-          registry_token: ${{ secrets.REGISTRY_TOKEN }}
-          dockerfile: "Containerfile.mcp"
-          docker_context: "."
-          image_name: "mcp-server"
-          # tag: "staging"
+#   # these are built internally because we need rhpkg
+#   build-and-push-beeai-containers:
+#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         include:
+#           - dockerfile: "Containerfile.c9s"
+#             tag: "c9s"
+#             description: "CentOS Stream 9"
+#           - dockerfile: "Containerfile.c10s"
+#             tag: "c10s"
+#             description: "CentOS Stream 10"
+#     steps:
+#       - name: Build and push beeai:${{ matrix.tag }} to quay.io registry (${{ matrix.description }})
+#         uses: sclorg/build-and-push-action@adf1dee2b786ccbb2e2a708c3510a90e2ab3392d # v4.1.5
+#         with:
+#           registry: "quay.io"
+#           registry_namespace: "jotnar"
+#           registry_username: ${{ secrets.REGISTRY_LOGIN }}
+#           registry_token: ${{ secrets.REGISTRY_TOKEN }}
+#           dockerfile: ${{ matrix.dockerfile }}
+#           docker_context: "."
+#           image_name: "beeai"
+#           tag: ${{ matrix.tag }}
+#
+#   build-and-push-mcp-server:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Build and push mcp-server to quay.io registry
+#         uses: sclorg/build-and-push-action@adf1dee2b786ccbb2e2a708c3510a90e2ab3392d # v4.1.5
+#         with:
+#           registry: "quay.io"
+#           registry_namespace: "jotnar"
+#           registry_username: ${{ secrets.REGISTRY_LOGIN }}
+#           registry_token: ${{ secrets.REGISTRY_TOKEN }}
+#           dockerfile: "Containerfile.mcp"
+#           docker_context: "."
+#           image_name: "mcp-server"
+#           # tag: "staging"
 
   build-and-push-testing-farm-sse-bridge:
     runs-on: ubuntu-latest

--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -93,7 +93,7 @@ WORKDIR $HOME
 ENV PYTHONPATH=$HOME:$PYTHONPATH
 
 # so that we can start working with gitlab.com immediately
-RUN git config --global user.email "jotnar@redhat.com" \
+RUN git config --global user.email "redhat-ymir-agent@redhat.com" \
     && git config --global user.name "RHEL Packaging Agent" \
     && git config --global core.editor "true"
 

--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -95,6 +95,8 @@ ENV PYTHONPATH=$HOME:$PYTHONPATH
 # so that we can start working with gitlab.com immediately
 RUN git config --global user.email "redhat-ymir-agent@redhat.com" \
     && git config --global user.name "RHEL Packaging Agent" \
-    && git config --global core.editor "true"
+    && git config --global core.editor "true" \
+    && git config --global --add safe.directory '/git-repos/*' \
+    && git config --global --add safe.directory '/git-repos/applicability/*'
 
 CMD ["/bin/bash"]

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -99,6 +99,8 @@ ENV PYTHONPATH=$HOME:$PYTHONPATH
 # so that we can start working with gitlab.com immediately
 RUN git config --global user.email "redhat-ymir-agent@redhat.com" \
     && git config --global user.name "RHEL Packaging Agent" \
-    && git config --global core.editor "true"
+    && git config --global core.editor "true" \
+    && git config --global --add safe.directory '/git-repos/*' \
+    && git config --global --add safe.directory '/git-repos/applicability/*'
 
 CMD ["/bin/bash"]

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -97,7 +97,7 @@ WORKDIR $HOME
 ENV PYTHONPATH=$HOME:$PYTHONPATH
 
 # so that we can start working with gitlab.com immediately
-RUN git config --global user.email "jotnar@redhat.com" \
+RUN git config --global user.email "redhat-ymir-agent@redhat.com" \
     && git config --global user.name "RHEL Packaging Agent" \
     && git config --global core.editor "true"
 

--- a/Containerfile.mcp
+++ b/Containerfile.mcp
@@ -42,7 +42,13 @@ COPY ymir/tools/ /home/mcp/ymir/tools/
 COPY ymir/common/ /home/mcp/ymir/common/
 COPY files/ipa_redhat_com /etc/krb5.conf.d/ipa_redhat_com
 RUN chgrp -R root /home/mcp && chmod -R g+rwX /home/mcp
-RUN mkdir /git-repos && chmod -R o+rwX /git-repos
+
+# "fatal: detected dubious ownership in repository at '/git-repos/"
+# we tell git that all repos in /git-repos/* and .../applicability/* are safe to fetch into
+# because this is a volume that has different owner than our container process
+RUN mkdir /git-repos && chmod -R o+rwX /git-repos && \
+    git config --system --add safe.directory '/git-repos/*' && \
+    git config --system --add safe.directory '/git-repos/applicability/*'
 
 # Configure jump host for internal dist-git
 COPY files/internal_dist-git_ssh.conf /etc/ssh/ssh_config.d/00-dist-git.conf


### PR DESCRIPTION
## Summary

Three deployment fixes for the OpenShift setup:

- **Stop building/pushing images that require `rhpkg`** — these images depend
  on Red Hat internal tooling and cannot be built in CI. They are now excluded
  from the build-and-push workflow.

- **Set git identity in agent containers** — configure `user.email` and
  `user.name` in `Containerfile.c9s` and `Containerfile.c10s` so agents can
  commit without needing runtime git config.

- **Fix "dubious ownership" on `/git-repos` volume** — the shared git-repos
  volume is owned by a different UID than the container process. Added
  `safe.directory` entries for `/git-repos/*` and `/git-repos/applicability/*`
  to all three Containerfiles (c9s, c10s: via `--global` after the user
  switch; mcp: via `--system` since git config runs before `USER mcp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)