### PR TITLE
Fix TOCTOU ymir_triage_in_progress race

### DIFF
--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -286,6 +286,20 @@ async def change_jira_status(
     )
 
 
+async def get_jira_labels(jira_issue: str) -> list[str]:
+    try:
+        async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
+            details = await run_tool(
+                "get_jira_details",
+                issue_key=jira_issue,
+                available_tools=gateway_tools,
+            )
+            return details.get("fields", {}).get("labels", [])
+    except Exception as e:
+        logger.warning(f"Failed to get labels for {jira_issue}: {e}")
+        return []
+
+
 _FAILURE_LABEL_SUFFIXES = ("_failed", "_errored")
 
 

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1086,6 +1086,20 @@ async def main() -> None:
             input = InputSchema.model_validate(task.metadata)
             logger.info(f"Processing triage for JIRA issue: {input.issue}, attempt: {task.attempts + 1}")
 
+            current_labels = await tasks.get_jira_labels(input.issue)
+            all_labels = JiraLabels.all_labels()
+            terminal_ymir_labels = [
+                label
+                for label in current_labels
+                if label in all_labels and label != JiraLabels.TRIAGE_IN_PROGRESS.value
+            ]
+            if terminal_ymir_labels and JiraLabels.RETRY_NEEDED.value not in current_labels:
+                logger.info(
+                    f"Skipping duplicate triage for {input.issue} — "
+                    f"already has labels: {terminal_ymir_labels}"
+                )
+                continue
+
             async def retry(task, error, input=input):
                 task.attempts += 1
                 if task.attempts < max_retries:


### PR DESCRIPTION
The jira_issue_fetcher  can push the same issue to triage_queue twice due to a TOCTOU race between the fetcher's dedup checks and the triage agent setting ymir_triage_in_progress. Since there's a single triage agent instance processing sequentially, a pre-flight label check after popping from the queue is sufficient to catch duplicates so that by the time the second copy is popped, the first triage has already completed and set a terminal label. This is a rare condition and should not normally happen but we did run into it in production.
