### PR TITLE
Add Java packaging tools to agent containers

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -50,6 +50,9 @@ RUN dnf -y install --allowerasing \
       pyproject-srpm-macros \
       rust-toolset-srpm-macros \
       perl-srpm-macros \
+      javapackages-tools \
+      javapackages-local \
+      xmvn-tools \
       ${EXTRA_PACKAGES} \
     && dnf clean all
 

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -49,6 +49,9 @@ RUN dnf -y install --allowerasing \
       pyproject-srpm-macros \
       rust-srpm-macros \
       perl-srpm-macros \
+      javapackages-tools \
+      javapackages-local \
+      xmvn-tools \
       ${EXTRA_PACKAGES} \
     && dnf clean all
 


### PR DESCRIPTION
Added javapackages-tools and xmvn-tools to c9s and c10s agent containers to support building Java packages during backport operations. These tools provide Maven macros (%mvn_file, etc.) needed by the %prep section when running rhpkg prep.
