### PR TITLE
Improve CVE metrics report format

### DIFF
--- a/scripts/ymir_cve_metrics.py
+++ b/scripts/ymir_cve_metrics.py
@@ -81,16 +81,23 @@ def _paginate_gitlab_mrs(
 ) -> list[dict]:
     encoded = quote(group, safe="")
     url = f"{GITLAB_API_URL}/groups/{encoded}/merge_requests"
+    # GitLab API filter params are created_after/updated_after (no _at),
+    # but order_by uses created_at/updated_at.
+    filter_prefix = date_field.removesuffix("_at")
     params = {
         "state": state,
         "author_username": author,
-        f"{date_field}_after": date_from.isoformat(),
-        f"{date_field}_before": date_to.isoformat(),
+        f"{filter_prefix}_after": date_from.isoformat(),
         "per_page": PER_PAGE,
         "order_by": date_field,
         "sort": "asc",
         "include_subgroups": "true",
     }
+    # For non-merged states, constrain the upper bound via the API.
+    # For merged MRs we skip this — updated_at can drift past the range
+    # (e.g. post-merge comments), and the in-code merged_at filter handles it.
+    if state != "merged":
+        params[f"{filter_prefix}_before"] = date_to.isoformat()
 
     result = []
     page = 1
@@ -273,31 +280,84 @@ def fetch_active_triage(
 # ─── Reporting ─────────────────────────────────────────────────────────────────
 
 
-def print_summary(
+def _gitlab_mr_search_url(
+    authors: list[str],
+    *,
+    state: str,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+) -> str:
+    # GitLab web UI only supports a single author_username filter.
+    base = "https://gitlab.com/groups/redhat/-/merge_requests"
+    params = f"?state={state}&author_username={authors[0]}&first_page_size=20"
+    if state == "merged" and date_from and date_to:
+        params += (
+            f"&merged_after={date_from.strftime('%Y-%m-%d')}"
+            f"&merged_before={date_to.strftime('%Y-%m-%d')}"
+            f"&sort=merged_at_desc"
+        )
+    elif state == "opened":
+        params += "&sort=created_date"
+    return base + params
+
+
+def _jira_search_url(jira_url: str, jira_keys: set[str]) -> str:
+    if not jira_keys:
+        return ""
+    keys_csv = ",".join(sorted(jira_keys))
+    jql = quote(f"issuekey in ({keys_csv})", safe="")
+    return f"{jira_url.rstrip('/')}/issues/?jql={jql}"
+
+
+def _md_link(text: str, url: str) -> str:
+    return f"[{text}]({url})" if url else text
+
+
+def print_report(
     date_from: datetime,
     date_to: datetime,
     merged_mrs: int,
     jiras_from_mrs: int,
-    triage_closures: int,
     total_solved: int,
     non_merged_mrs: int,
-    active_triage: int,
+    *,
+    authors: list[str],
+    jira_url: str,
+    resolved_jira_keys: set[str],
+    triage_closure_keys: set[str],
+    pending_jira_keys: set[str],
+    active_triage_keys: set[str],
 ) -> None:
     from_str = date_from.strftime("%Y-%m-%d")
     to_str = date_to.strftime("%Y-%m-%d")
 
-    print(f"\nYmir CVE Activity Report: {from_str} → {to_str}")
-    print("─" * 50)
+    merged_url = _gitlab_mr_search_url(authors, state="merged", date_from=date_from, date_to=date_to)
+    opened_url = _gitlab_mr_search_url(authors, state="opened")
+    resolved_url = _jira_search_url(jira_url, resolved_jira_keys)
+    closure_url = _jira_search_url(jira_url, triage_closure_keys)
+    pending_url = _jira_search_url(jira_url, pending_jira_keys)
+    active_url = _jira_search_url(jira_url, active_triage_keys)
 
-    print("Solved Jiras:")
-    print(f"  {'Resolved by MRs:':<38} {jiras_from_mrs:>6} Jiras  ({merged_mrs} MRs)")
-    print(f"  {'Not-affected (closed):':<38} {triage_closures:>6}")
-    print(f"  {'Total solved:':<38} {total_solved:>6}")
+    open_mrs_line = f"- {_md_link('Open MRs', opened_url)} (pending merge): {non_merged_mrs}"
+    if pending_jira_keys:
+        open_mrs_line += f" ({_md_link(f'{len(pending_jira_keys)} Jiras', pending_url)})"
 
-    print()
-    print("In Progress Jiras:")
-    print(f"  {'Open MRs (pending merge):':<38} {non_merged_mrs:>6}")
-    print(f"  {'Not-affected (pending closure):':<38} {active_triage:>6}")
+    lines = [
+        f"# Ymir CVE Activity Report: {from_str} → {to_str}",
+        "",
+        "## Solved Jiras",
+        f"- Resolved by MRs: {_md_link(f'{jiras_from_mrs} Jiras', resolved_url)}"
+        f" ({_md_link(f'{merged_mrs} MRs', merged_url)})",
+        f"- Not-affected (closed): {_md_link(str(len(triage_closure_keys)), closure_url)}",
+        f"- Total solved: {total_solved}",
+        "",
+        "## In Progress Jiras",
+        open_mrs_line,
+        f"- Not-affected (pending closure): {_md_link(str(len(active_triage_keys)), active_url)}",
+        "",
+    ]
+
+    print("\n".join(lines))
 
 
 # ─── CLI ───────────────────────────────────────────────────────────────────────
@@ -345,6 +405,7 @@ def main() -> None:
         help=f"GitLab username to filter MRs (default: {GITLAB_AUTHOR_DEFAULT}). "
         "Can be specified multiple times for multiple authors.",
     )
+
     args = parser.parse_args()
 
     if args.gitlab_author is None:
@@ -359,8 +420,6 @@ def main() -> None:
     session = get_gitlab_session()
 
     print("Fetching merged MRs from GitLab...")
-    # GitLab doesn't support filtering by merged_at directly, so we use updated_at
-    # as a proxy and then filter by merged_at in the pagination loop.
     merged_mrs = _fetch_mrs(
         session,
         GITLAB_GROUPS,
@@ -384,6 +443,9 @@ def main() -> None:
         date_field="created_at",
     )
 
+    print("Extracting pending Jiras from open MRs...")
+    pending_jiras, _ = extract_resolved_jiras(session, opened_mrs)
+
     triage_closures: list[dict] = []
     active_triage: list[dict] = []
 
@@ -406,17 +468,22 @@ def main() -> None:
     # ── Deduplicate & report ──
     jiras_from_mrs = len(resolved_jiras) + unmatched_mrs
     triage_keys = {issue["key"] for issue in triage_closures}
+    active_triage_keys = {issue["key"] for issue in active_triage}
     total_solved = len(resolved_jiras | triage_keys) + unmatched_mrs
 
-    print_summary(
+    print_report(
         date_from,
         date_to,
         merged_mrs=len(merged_mrs),
         jiras_from_mrs=jiras_from_mrs,
-        triage_closures=len(triage_closures),
         total_solved=total_solved,
         non_merged_mrs=len(opened_mrs),
-        active_triage=len(active_triage),
+        authors=args.gitlab_author,
+        jira_url=jira_url,
+        resolved_jira_keys=resolved_jiras,
+        triage_closure_keys=triage_keys,
+        pending_jira_keys=pending_jiras,
+        active_triage_keys=active_triage_keys,
     )
 
 

--- a/scripts/ymir_cve_metrics.py
+++ b/scripts/ymir_cve_metrics.py
@@ -289,15 +289,14 @@ def print_summary(
     print(f"\nYmir CVE Activity Report: {from_str} → {to_str}")
     print("─" * 50)
 
-    print("Solved:")
-    print(f"  {'MRs merged:':<38} {merged_mrs:>6}")
-    print(f"  {'Jiras resolved (from MRs):':<38} {jiras_from_mrs:>6}")
+    print("Solved Jiras:")
+    print(f"  {'Resolved by MRs:':<38} {jiras_from_mrs:>6} Jiras  ({merged_mrs} MRs)")
     print(f"  {'Not-affected (closed):':<38} {triage_closures:>6}")
-    print(f"  {'Total Jiras solved:':<38} {total_solved:>6}")
+    print(f"  {'Total solved:':<38} {total_solved:>6}")
 
     print()
-    print("Active:")
-    print(f"  {'MRs opened (not yet merged):':<38} {non_merged_mrs:>6}")
+    print("In Progress Jiras:")
+    print(f"  {'Open MRs (pending merge):':<38} {non_merged_mrs:>6}")
     print(f"  {'Not-affected (pending closure):':<38} {active_triage:>6}")
 
 

--- a/scripts/ymir_cve_metrics.py
+++ b/scripts/ymir_cve_metrics.py
@@ -313,13 +313,30 @@ def _md_link(text: str, url: str) -> str:
     return f"[{text}]({url})" if url else text
 
 
+YMIR_ACTION_LABELS = ["ymir_backport", "ymir_rebuild", "ymir_rebase"]
+
+
+def _mr_category_summary(mrs: list[dict]) -> str:
+    counts: dict[str, int] = {}
+    for mr in mrs:
+        labels = mr.get("labels", [])
+        for action in YMIR_ACTION_LABELS:
+            if action in labels:
+                short = action.removeprefix("ymir_")
+                counts[short] = counts.get(short, 0) + 1
+    if not counts:
+        return ""
+    parts = [f"{count} {name}" for name, count in counts.items()]
+    return " — " + ", ".join(parts)
+
+
 def print_report(
     date_from: datetime,
     date_to: datetime,
-    merged_mrs: int,
+    merged_mrs: list[dict],
     jiras_from_mrs: int,
     total_solved: int,
-    non_merged_mrs: int,
+    opened_mrs: list[dict],
     *,
     authors: list[str],
     jira_url: str,
@@ -338,7 +355,18 @@ def print_report(
     pending_url = _jira_search_url(jira_url, pending_jira_keys)
     active_url = _jira_search_url(jira_url, active_triage_keys)
 
-    open_mrs_line = f"- {_md_link('Open MRs', opened_url)} (pending merge): {non_merged_mrs}"
+    merged_count = len(merged_mrs)
+    opened_count = len(opened_mrs)
+
+    resolved_line = (
+        f"- Resolved by MRs: {_md_link(f'{jiras_from_mrs} Jiras', resolved_url)}"
+        f" ({_md_link(f'{merged_count} MRs', merged_url)}{_mr_category_summary(merged_mrs)})"
+    )
+
+    open_mrs_line = (
+        f"- {_md_link('Open MRs', opened_url)} (pending merge):"
+        f" {opened_count}{_mr_category_summary(opened_mrs)}"
+    )
     if pending_jira_keys:
         open_mrs_line += f" ({_md_link(f'{len(pending_jira_keys)} Jiras', pending_url)})"
 
@@ -346,8 +374,7 @@ def print_report(
         f"# Ymir CVE Activity Report: {from_str} → {to_str}",
         "",
         "## Solved Jiras",
-        f"- Resolved by MRs: {_md_link(f'{jiras_from_mrs} Jiras', resolved_url)}"
-        f" ({_md_link(f'{merged_mrs} MRs', merged_url)})",
+        resolved_line,
         f"- Not-affected (closed): {_md_link(str(len(triage_closure_keys)), closure_url)}",
         f"- Total solved: {total_solved}",
         "",
@@ -474,10 +501,10 @@ def main() -> None:
     print_report(
         date_from,
         date_to,
-        merged_mrs=len(merged_mrs),
+        merged_mrs=merged_mrs,
         jiras_from_mrs=jiras_from_mrs,
         total_solved=total_solved,
-        non_merged_mrs=len(opened_mrs),
+        opened_mrs=opened_mrs,
         authors=args.gitlab_author,
         jira_url=jira_url,
         resolved_jira_keys=resolved_jiras,


### PR DESCRIPTION
Example output:

# Ymir CVE Activity Report: 2026-05-04 → 2026-05-11

## Solved Jiras
- Resolved by MRs: [4 Jiras](https://redhat.atlassian.net/issues/?jql=issuekey%20in%20%28RHEL-166518%2CRHEL-167379%2CRHEL-167541%2CRHEL-167738%29) ([2 MRs](https://gitlab.com/groups/redhat/-/merge_requests?state=merged&author_username=jotnar-bot&first_page_size=20&merged_after=2026-05-04&merged_before=2026-05-11&sort=merged_at_desc))
- Not-affected (closed): [2](https://redhat.atlassian.net/issues/?jql=issuekey%20in%20%28RHEL-158620%2CRHEL-158869%29)
- Total solved: 6

## In Progress Jiras
- [Open MRs](https://gitlab.com/groups/redhat/-/merge_requests?state=opened&author_username=jotnar-bot&first_page_size=20&sort=updated_desc) (pending merge): 19 ([36 Jiras](https://redhat.atlassian.net/issues/?jql=issuekey%20in%20%28RHEL-140551%2CRHEL-145420%2CRHEL-146105%2CRHEL-149641%2CRHEL-158476%2CRHEL-158488%2CRHEL-158493%2CRHEL-158499%2CRHEL-158638%2CRHEL-158720%2CRHEL-158735%2CRHEL-158759%2CRHEL-158763%2CRHEL-158771%2CRHEL-158781%2CRHEL-158789%2CRHEL-158874%2CRHEL-165008%2CRHEL-165036%2CRHEL-165336%2CRHEL-165350%2CRHEL-167239%2CRHEL-167487%2CRHEL-167489%2CRHEL-167497%2CRHEL-167501%2CRHEL-167504%2CRHEL-167663%2CRHEL-167674%2CRHEL-167676%2CRHEL-167680%2CRHEL-167685%2CRHEL-167688%2CRHEL-170123%2CRHEL-170401%2CRHEL-170460%29))
- Not-affected (pending closure): 0

---

Follow-up:
- storing these here or in internal Gitlab in a dedicated repo (potentially automate)