### PR TITLE
Add CVE-specific verification to triage agent

### DIFF
--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -350,6 +350,17 @@ TRIAGE_PROMPT = """
               - The fix directly addresses the root cause identified in your analysis
               - The code changes align with the symptoms described in the Jira issue
               - The modified functions/files match those mentioned in the issue
+           3. **For CVE issues - Verify CVE ID match**: If the issue is a CVE (contains CVE-YYYY-NNNNN):
+              - Check if the patch content or commit message mentions the EXACT CVE ID
+              - If the CVE ID is NOT mentioned in the patch, verify that:
+                * The vulnerability description in the CVE matches what the patch fixes
+                * The code changes address the specific vulnerability type
+                  (buffer overflow, integer overflow, etc.)
+                * The affected functions/files align with the CVE details
+              - **WARNING**: Patches from bundled CVE updates (e.g., Oracle CPU, bundled library updates)
+                may fix MULTIPLE CVEs - verify you have the correct patch for THIS specific CVE
+              - If you cannot confirm the patch matches the CVE, search for alternative patches or
+                request clarification
          * Only proceed with URLs that contain valid patch content AND address the specific issue
          * If the content is not a proper patch or doesn't fix the issue, continue searching for other fixes
          * **Only use merged/accepted fixes**: Patches must come from commits that have been

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -190,7 +190,11 @@ class BackportData(BaseModel):
         "that were validated using the get_patch_from_url tool"
     )
     justification: str = Field(
-        description="Clear explanation of why this patch fixes the issue, linking it to the root cause"
+        description=(
+            "Clear explanation of why this patch fixes the issue, linking it to the root cause. "
+            "For CVE issues: explicitly state whether the patch mentions the CVE ID, and if not, "
+            "explain how you verified the patch addresses the specific vulnerability described in the CVE."
+        )
     )
     jira_issue: str = Field(description="Jira issue identifier")
     cve_id: str | None = Field(description="CVE identifier", default=None)


### PR DESCRIPTION
Enhanced the triage agent to verify that chosen patches actually fix the correct CVE by:

1. Added mandatory CVE ID verification step in patch validation that:
   - Checks if patch content/commit mentions the exact CVE ID
   - Requires verification that vulnerability matches if CVE ID absent
   - Warns about bundled updates (Oracle CPU) fixing multiple CVEs
   - Prevents accepting wrong patches for similar vulnerabilities

2. Updated BackportData.justification field description to require explicit documentation of CVE verification process.

This prevents issues like RHEL-170461 where the agent selected a patch for CVE-2025-64505 instead of CVE-2026-22020 because both were libpng buffer overflow fixes from the same upstream.
