### PR TITLE
Use per-patch strip levels from spec instead of hardcoded -p1

### DIFF
--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -317,7 +317,8 @@ and must remain unchanged.
 
       3b. Get package information from dist-git:
           - Use `get_package_info` tool with the spec file path from <UNPACKED_SOURCES>
-          - This provides the package version and list of existing patch filenames
+          - This provides the package version, list of existing patch filenames,
+            and per-patch strip levels (patch_strip_levels)
 
       3c. Clone the upstream repository to a SEPARATE directory:
           - Use `clone_upstream_repository` tool with:
@@ -338,6 +339,7 @@ and must remain unchanged.
             * repo_path: <UPSTREAM_REPO> (where to apply)
             * patches_directory: current working directory (dist-git root where patch files are located)
             * patch_files: list from step 3b
+            * patch_strip_levels: dict from step 3b (maps each patch filename to its -p strip level)
           - This recreates the current package state in <UPSTREAM_REPO>
           - The tool automatically records the base commit for patch generation
           - If any patch fails to apply, immediately fall back to approach B
@@ -530,7 +532,8 @@ and must remain unchanged.
 
       4b. Get package information from dist-git:
           - Use `get_package_info` tool with the spec file path from <UNPACKED_SOURCES>
-          - This provides the package version and list of existing patch filenames
+          - This provides the package version, list of existing patch filenames,
+            and per-patch strip levels (patch_strip_levels)
 
       4c. Clone the upstream repository to a SEPARATE directory:
           - Use `clone_upstream_repository` tool with:
@@ -551,6 +554,7 @@ and must remain unchanged.
             * repo_path: <UPSTREAM_REPO> (where to apply)
             * patches_directory: current working directory (dist-git root where patch files are located)
             * patch_files: list from step 4b
+            * patch_strip_levels: dict from step 4b (maps each patch filename to its -p strip level)
           - This recreates the current package state in <UPSTREAM_REPO>
           - The tool automatically records the base commit for patch generation
           - If any patch fails to apply, immediately fall back to approach B

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -148,7 +148,8 @@ BACKPORT_INSTRUCTIONS = """
 
             4b. Get package information from dist-git:
                 - Use `get_package_info` tool with the spec file path from <UNPACKED_SOURCES>
-                - This provides the package version and list of existing patch filenames
+                - This provides the package version, list of existing patch filenames,
+                  and per-patch strip levels (patch_strip_levels)
 
             4c. Clone the upstream repository to a SEPARATE directory:
                 - Use `clone_upstream_repository` tool with:
@@ -169,6 +170,7 @@ BACKPORT_INSTRUCTIONS = """
                   * repo_path: <UPSTREAM_REPO> (where to apply)
                   * patches_directory: current working directory (dist-git root where patch files are located)
                   * patch_files: list from step 4b
+                  * patch_strip_levels: dict from step 4b (maps each patch filename to its -p strip level)
                 - This recreates the current package state in <UPSTREAM_REPO>
                 - The tool automatically records the base commit for patch generation
                 - If any patch fails to apply, immediately fall back to approach B
@@ -372,7 +374,8 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
 
             3f. Get package information from dist-git:
                 - Use `get_package_info` tool with the spec file path from <UNPACKED_SOURCES>
-                - This provides the package version and list of existing patch filenames
+                - This provides the package version, list of existing patch filenames,
+                  and per-patch strip levels (patch_strip_levels)
 
             3g. Clone the upstream repository to a SEPARATE directory:
                 - Use `clone_upstream_repository` tool with:
@@ -393,6 +396,7 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
                   * repo_path: <UPSTREAM_REPO> (where to apply)
                   * patches_directory: current working directory (dist-git root where patch files are located)
                   * patch_files: list from step 3f
+                  * patch_strip_levels: dict from step 3f (maps each patch filename to its -p strip level)
                 - This recreates the current package state in <UPSTREAM_REPO>
                 - The tool automatically records the base commit for patch generation
                 - If any patch fails to apply, immediately fall back to approach C

--- a/ymir/tools/unprivileged/specfile.py
+++ b/ymir/tools/unprivileged/specfile.py
@@ -13,6 +13,7 @@ from beeai_framework.tools import (
 )
 from pydantic import BaseModel, Field
 from specfile import Specfile
+from specfile.prep import AutopatchMacro, AutosetupMacro, PatchMacro
 from specfile.utils import EVR
 from specfile.value_parser import (
     EnclosedMacroSubstitution,
@@ -35,20 +36,60 @@ class PackageInfo(BaseModel):
 
     version: str = Field(description="Package version from Version field")
     patch_files: list[str] = Field(description="List of patch filenames in order (Patch0, Patch1, etc.)")
+    patch_strip_levels: dict[str, int] = Field(
+        description="Mapping of patch filename to its strip level (-p value) from the spec's %prep section"
+    )
 
 
 class GetPackageInfoToolOutput(JSONToolOutput[PackageInfo]):
     pass
 
 
+_DEFAULT_STRIP_LEVEL = 1
+
+
+def _extract_strip_levels(spec: Specfile, number_to_filename: dict[int, str]) -> dict[str, int]:
+    """Build a mapping of patch filename to strip level from %prep macros.
+
+    Handles %autosetup (global -p), %autopatch (global -p), and
+    individual %patch macros (per-patch -p).  Falls back to 1 for any
+    patch not covered by a macro (e.g. conditionally applied patches).
+    """
+    strip_levels: dict[str, int] = {}
+
+    try:
+        with spec.prep() as prep:
+            for macro in prep.macros:
+                if isinstance(macro, (AutosetupMacro, AutopatchMacro)):
+                    p = macro.options.get("p")
+                    level = p if isinstance(p, int) else _DEFAULT_STRIP_LEVEL
+                    for filename in number_to_filename.values():
+                        strip_levels[filename] = level
+                elif isinstance(macro, PatchMacro):
+                    p = macro.options.get("p")
+                    level = p if isinstance(p, int) else _DEFAULT_STRIP_LEVEL
+                    filename = number_to_filename.get(macro.number)
+                    if filename is not None:
+                        strip_levels[filename] = level
+    except Exception:
+        pass
+
+    for filename in number_to_filename.values():
+        strip_levels.setdefault(filename, _DEFAULT_STRIP_LEVEL)
+
+    return strip_levels
+
+
 class GetPackageInfoTool(Tool[GetPackageInfoToolInput, ToolRunOptions, GetPackageInfoToolOutput]):
     name = "get_package_info"
     description = """
-    Extract package version and patch files from a spec file.
+    Extract package version, patch files, and patch strip levels from a spec file.
 
     Returns:
     - version: The package version (from Version: field)
     - patch_files: List of patch filenames in the order they appear (Patch0:, Patch1:, etc.)
+    - patch_strip_levels: Mapping of each patch filename to its strip level (-p value)
+      extracted from the %prep section (%autosetup, %autopatch, or individual %patch macros)
 
     This is useful for determining the base version to checkout in upstream repository
     and which existing patches need to be applied before cherry-picking a new fix.
@@ -73,9 +114,19 @@ class GetPackageInfoTool(Tool[GetPackageInfoToolInput, ToolRunOptions, GetPackag
             with Specfile(spec_path) as spec:
                 version = spec.version
                 with spec.patches() as patches:
-                    patch_files = [p.expanded_location for p in patches if p.valid and p.expanded_location]
+                    valid_patches = [p for p in patches if p.valid and p.expanded_location]
+                    patch_files = [p.expanded_location for p in valid_patches]
+                    number_to_filename = {p.number: p.expanded_location for p in valid_patches}
 
-                return GetPackageInfoToolOutput(result=PackageInfo(version=version, patch_files=patch_files))
+                strip_levels = _extract_strip_levels(spec, number_to_filename)
+
+                return GetPackageInfoToolOutput(
+                    result=PackageInfo(
+                        version=version,
+                        patch_files=patch_files,
+                        patch_strip_levels=strip_levels,
+                    )
+                )
 
         except Exception as e:
             raise ToolError(f"Failed to extract package info from {spec_path}: {e}") from e

--- a/ymir/tools/unprivileged/tests/unit/test_specfile.py
+++ b/ymir/tools/unprivileged/tests/unit/test_specfile.py
@@ -111,6 +111,146 @@ def spec_with_macro_patches(tmp_path):
     return spec
 
 
+@pytest.fixture
+def spec_with_autosetup_gendiff(tmp_path):
+    spec = tmp_path / "gendiff.spec"
+    source_file = tmp_path / "source.tar.gz"
+    source_file.touch()
+    spec.write_text(
+        dedent(
+            """
+            Name:           test
+            Version:        5.0.0
+            Release:        1%{?dist}
+            Summary:        Test package
+
+            License:        MIT
+
+            Source0:        source.tar.gz
+            Patch0:         fix-one.patch
+            Patch1:         fix-two.patch
+
+            %description
+            Test package with autosetup gendiff
+
+            %prep
+            %autosetup -p1 -S gendiff
+
+            %changelog
+            * Thu Jan 13 3770 Test User <test@redhat.com> - 5.0.0-1
+            - first version
+            """
+        )
+    )
+    return spec
+
+
+@pytest.fixture
+def spec_with_autosetup_no_p(tmp_path):
+    spec = tmp_path / "no_p.spec"
+    source_file = tmp_path / "source.tar.gz"
+    source_file.touch()
+    spec.write_text(
+        dedent(
+            """
+            Name:           test
+            Version:        6.0.0
+            Release:        1%{?dist}
+            Summary:        Test package
+
+            License:        MIT
+
+            Source0:        source.tar.gz
+            Patch0:         only-fix.patch
+
+            %description
+            Test package with bare autosetup (no -p flag)
+
+            %prep
+            %autosetup
+
+            %changelog
+            * Thu Jan 13 3770 Test User <test@redhat.com> - 6.0.0-1
+            - first version
+            """
+        )
+    )
+    return spec
+
+
+@pytest.fixture
+def spec_with_individual_patch_strips(tmp_path):
+    spec = tmp_path / "individual_strips.spec"
+    source_file = tmp_path / "source.tar.gz"
+    source_file.touch()
+    spec.write_text(
+        dedent(
+            """
+            Name:           test
+            Version:        2.0.0
+            Release:        1%{?dist}
+            Summary:        Test package
+
+            License:        MIT
+
+            Source0:        source.tar.gz
+            Patch0:         fix-p0.patch
+            Patch1:         fix-p2.patch
+            Patch2:         fix-default.patch
+
+            %description
+            Test package with individual patch macros using different strip levels
+
+            %prep
+            %setup -q
+            %patch 0 -p0
+            %patch 1 -p2
+            %patch 2 -p1
+
+            %changelog
+            * Thu Jan 13 3770 Test User <test@redhat.com> - 2.0.0-1
+            - first version
+            """
+        )
+    )
+    return spec
+
+
+@pytest.fixture
+def spec_with_autopatch(tmp_path):
+    spec = tmp_path / "autopatch.spec"
+    source_file = tmp_path / "source.tar.gz"
+    source_file.touch()
+    spec.write_text(
+        dedent(
+            """
+            Name:           test
+            Version:        4.1.0
+            Release:        1%{?dist}
+            Summary:        Test package
+
+            License:        MIT
+
+            Source0:        source.tar.gz
+            Patch0:         backport-fix.patch
+            Patch1:         memory-fix.patch
+
+            %description
+            Test package with autopatch
+
+            %prep
+            %setup -q
+            %autopatch -p2
+
+            %changelog
+            * Thu Jan 13 3770 Test User <test@redhat.com> - 4.1.0-1
+            - first version
+            """
+        )
+    )
+    return spec
+
+
 @pytest.mark.asyncio
 async def test_add_changelog_entry(minimal_spec):
     content = ["- some change", "  second line"]
@@ -137,7 +277,7 @@ async def test_add_changelog_entry(minimal_spec):
 
 
 @pytest.mark.parametrize(
-    "spec_fixture, expected_version, expected_patches",
+    "spec_fixture, expected_version, expected_patches, expected_strip_levels",
     [
         (
             "spec_with_patches",
@@ -147,6 +287,11 @@ async def test_add_changelog_entry(minimal_spec):
                 "fix-memory-leak.patch",
                 "update-documentation.patch",
             ],
+            {
+                "fix-cve-2024-1234.patch": 1,
+                "fix-memory-leak.patch": 1,
+                "update-documentation.patch": 1,
+            },
         ),
         (
             "spec_with_macro_patches",
@@ -154,12 +299,57 @@ async def test_add_changelog_entry(minimal_spec):
             [
                 "mypackage-3.5.3-Fix-CVE-2026-4111.patch",
             ],
+            {
+                "mypackage-3.5.3-Fix-CVE-2026-4111.patch": 1,
+            },
         ),
-        ("minimal_spec", "0.1", []),
+        ("minimal_spec", "0.1", [], {}),
+        (
+            "spec_with_individual_patch_strips",
+            "2.0.0",
+            ["fix-p0.patch", "fix-p2.patch", "fix-default.patch"],
+            {
+                "fix-p0.patch": 0,
+                "fix-p2.patch": 2,
+                "fix-default.patch": 1,
+            },
+        ),
+        (
+            "spec_with_autopatch",
+            "4.1.0",
+            ["backport-fix.patch", "memory-fix.patch"],
+            {
+                "backport-fix.patch": 2,
+                "memory-fix.patch": 2,
+            },
+        ),
+        (
+            "spec_with_autosetup_gendiff",
+            "5.0.0",
+            ["fix-one.patch", "fix-two.patch"],
+            {
+                "fix-one.patch": 1,
+                "fix-two.patch": 1,
+            },
+        ),
+        (
+            "spec_with_autosetup_no_p",
+            "6.0.0",
+            ["only-fix.patch"],
+            {
+                "only-fix.patch": 1,
+            },
+        ),
     ],
 )
 @pytest.mark.asyncio
-async def test_get_package_info(spec_fixture, expected_version, expected_patches, request):
+async def test_get_package_info(
+    spec_fixture,
+    expected_version,
+    expected_patches,
+    expected_strip_levels,
+    request,
+):
     spec = request.getfixturevalue(spec_fixture)
     tool = GetPackageInfoTool()
 
@@ -170,6 +360,7 @@ async def test_get_package_info(spec_fixture, expected_version, expected_patches
 
     assert result.version == expected_version
     assert result.patch_files == expected_patches
+    assert result.patch_strip_levels == expected_strip_levels
 
 
 @pytest.mark.parametrize(

--- a/ymir/tools/unprivileged/upstream_tools.py
+++ b/ymir/tools/unprivileged/upstream_tools.py
@@ -473,6 +473,11 @@ class ApplyDownstreamPatchesToolInput(BaseModel):
     patches_directory: AbsolutePath = Field(
         description="Absolute directory path containing the patch files (usually the dist-git clone)"
     )
+    patch_strip_levels: dict[str, int] | None = Field(
+        default=None,
+        description="Mapping of patch filename to strip level (-p value). "
+        "Obtained from get_package_info. Falls back to -p1 when not provided.",
+    )
 
 
 class ApplyDownstreamPatchesTool(Tool[ApplyDownstreamPatchesToolInput, ToolRunOptions, StringToolOutput]):
@@ -535,10 +540,16 @@ class ApplyDownstreamPatchesTool(Tool[ApplyDownstreamPatchesToolInput, ToolRunOp
                         "Downstream patches cannot be applied; cherry-pick workflow is not viable."
                     )
 
-                # Use patch(1) instead of git-apply to match RPM %prep behavior.
-                # Handles gendiff-style patches, trailing whitespace, fuzz
-                # matching, and other quirks that git-apply rejects.
-                cmd = ["patch", "-p1", "-s", "--batch", "--no-backup-if-mismatch", "-i", str(patch_path)]
+                strip = (tool_input.patch_strip_levels or {}).get(patch_file, 1)
+                cmd = [
+                    "patch",
+                    f"-p{strip}",
+                    "-s",
+                    "--batch",
+                    "--no-backup-if-mismatch",
+                    "-i",
+                    str(patch_path),
+                ]
                 exit_code, stdout, stderr = await run_subprocess(cmd, cwd=tool_input.repo_path)
 
                 if exit_code != 0:


### PR DESCRIPTION
apply_downstream_patches hardcoded -p1 when applying downstream patches to the upstream repo. Specs that override it (e.g. %patch -p0 or -p2) caused "can't find file to patch" failures, forcing unnecessary fallback to the git-am workflow.

get_package_info now parses %prep macros (%autosetup, %autopatch, and individual %patch) via the specfile library to extract each patch's strip level and returns a patch_strip_levels dict alongside patch_files. apply_downstream_patches accepts this mapping and applies each patch with the correct -p value.

Made-with: Cursor
