### PR TITLE
Rebuild phoenix and redis-commander ourselves

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -91,6 +91,34 @@ jobs:
           image_name: "jira-issue-fetcher"
           # tag: "staging"
 
+  build-and-push-redis-commander:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and push redis-commander to quay.io registry
+        uses: sclorg/build-and-push-action@adf1dee2b786ccbb2e2a708c3510a90e2ab3392d # v4.1.5
+        with:
+          registry: "quay.io"
+          registry_namespace: "jotnar"
+          registry_username: ${{ secrets.REGISTRY_LOGIN }}
+          registry_token: ${{ secrets.REGISTRY_TOKEN }}
+          dockerfile: "Containerfile.redis-commander"
+          docker_context: "."
+          image_name: "redis-commander"
+
+  build-and-push-phoenix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and push phoenix to quay.io registry
+        uses: sclorg/build-and-push-action@adf1dee2b786ccbb2e2a708c3510a90e2ab3392d # v4.1.5
+        with:
+          registry: "quay.io"
+          registry_namespace: "jotnar"
+          registry_username: ${{ secrets.REGISTRY_LOGIN }}
+          registry_token: ${{ secrets.REGISTRY_TOKEN }}
+          dockerfile: "Containerfile.phoenix"
+          docker_context: "."
+          image_name: "phoenix"
+
   build-and-push-supervisor:
     runs-on: ubuntu-latest
     steps:

--- a/Containerfile.phoenix
+++ b/Containerfile.phoenix
@@ -1,0 +1,9 @@
+# we have our own image for phoenix because the upstream one has CVEs in it that our CVE scanner picks up
+FROM fedora:44
+RUN dnf install -y python3-pip python3-numpy python3-scipy \
+    && dnf clean all \
+    && pip3 install --no-cache-dir arize-phoenix \
+    && useradd -u 1001 -g 0 -m -s /sbin/nologin phoenix
+USER 1001
+EXPOSE 6006 4317
+CMD ["phoenix", "serve"]

--- a/Containerfile.redis-commander
+++ b/Containerfile.redis-commander
@@ -1,0 +1,13 @@
+FROM fedora:44
+ENV NODE_ENV=production
+
+# the tilde means to update to latest patch releases
+RUN dnf install -y nodejs npm \
+    && dnf clean all \
+    && npm install -g redis-commander@~0.9.0 \
+    && npm cache clean --force \
+    && useradd -u 1001 -g 0 -m -s /sbin/nologin rediscommander
+
+USER 1001
+EXPOSE 8081
+CMD exec redis-commander --redis-host $REDIS_HOST --redis-port $REDIS_PORT

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,26 @@ COMPOSE ?= $(shell if podman compose ls >/dev/null 2>&1; then echo "podman compo
 COMPOSE_AGENTS=$(COMPOSE) -f $(COMPOSE_FILE) --profile=agents
 COMPOSE_SUPERVISOR=$(COMPOSE) -f $(COMPOSE_FILE) --profile=supervisor
 
+# Extract container tool (podman or docker) from COMPOSE
+CONTAINER_TOOL ?= $(shell command -v podman >/dev/null 2>&1 && echo "podman" || echo "docker")
+REGISTRY ?= quay.io/jotnar
+
 .PHONY: build
 build:
 	if [ -f .secrets/build.env ]; then \
 		set -a && . ./.secrets/build.env && set +a; \
 	fi && \
 	$(COMPOSE) -f $(COMPOSE_FILE) --profile=agents --profile=supervisor build
+
+.PHONY: push
+push:
+	@echo "Pushing images to $(REGISTRY)..."
+	$(CONTAINER_TOOL) push $(REGISTRY)/phoenix:latest
+	$(CONTAINER_TOOL) push $(REGISTRY)/redis-commander:latest
+	@echo "All images pushed successfully!"
+
+.PHONY: build-and-push
+build-and-push: build push
 
 .PHONY: run-beeai-bash
 run-beeai-bash:

--- a/compose.yaml
+++ b/compose.yaml
@@ -133,9 +133,13 @@ services:
     profiles: ["agents", "supervisor", "e2e-test"]
 
   redis-commander:
-    image: ghcr.io/joeferner/redis-commander:0.9.0
+    image: quay.io/jotnar/redis-commander
+    build:
+      context: .
+      dockerfile: Containerfile.redis-commander
     environment:
-      - REDIS_HOSTS=local:valkey:6379
+      - REDIS_HOST=valkey
+      - REDIS_PORT=6379
     ports:
       - "8081:8081"
     depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -122,7 +122,10 @@ services:
     profiles: ["agents", "supervisor", "e2e-test"]
 
   phoenix:
-    image: docker.io/arizephoenix/phoenix:version-11.6.2
+    image: quay.io/jotnar/phoenix:latest
+    build:
+      context: .
+      dockerfile: Containerfile.phoenix
     ports:
       - "0.0.0.0:6006:6006"
     environment:

--- a/openshift/deployment-phoenix.yml
+++ b/openshift/deployment-phoenix.yml
@@ -2,6 +2,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: phoenix
+  annotations:
+    image.openshift.io/triggers: |
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "phoenix:prod"
+          },
+          "fieldPath": "spec.template.spec.containers[?(@.name==\"phoenix\")].image"
+        }
+      ]
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -27,7 +38,7 @@ spec:
         - name: PHOENIX_PORT
           value: "6006"
         image: phoenix:prod
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: phoenix
         ports:
         - containerPort: 4317

--- a/openshift/deployment-redis-commander.yml
+++ b/openshift/deployment-redis-commander.yml
@@ -2,6 +2,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-commander
+  annotations:
+    image.openshift.io/triggers: |
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "redis-commander:prod"
+          },
+          "fieldPath": "spec.template.spec.containers[?(@.name==\"redis-commander\")].image"
+        }
+      ]
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -27,7 +38,7 @@ spec:
         - name: REDIS_PORT
           value: "6379"
         image: redis-commander:prod
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         name: redis-commander
         ports:
         - containerPort: 8081

--- a/openshift/deployment-redis-commander.yml
+++ b/openshift/deployment-redis-commander.yml
@@ -22,8 +22,10 @@ spec:
     spec:
       containers:
       - env:
-        - name: REDIS_HOSTS
-          value: local:valkey:6379
+        - name: REDIS_HOST
+          value: valkey
+        - name: REDIS_PORT
+          value: "6379"
         image: redis-commander:prod
         imagePullPolicy: IfNotPresent
         name: redis-commander

--- a/openshift/imagestream-redis-commander.yml
+++ b/openshift/imagestream-redis-commander.yml
@@ -7,7 +7,7 @@ spec:
     - name: prod
       from:
         kind: DockerImage
-        name: ghcr.io/joeferner/redis-commander:0.9.0
+        name: quay.io/jotnar/redis-commander:latest
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
         scheduled: true


### PR DESCRIPTION
## Summary

- Add `Containerfile.redis-commander` and `Containerfile.phoenix` based on Fedora so images are periodically rebuilt and free of CVEs
- Switch `compose.yaml` and OpenShift manifests to use the new images from `quay.io/jotnar/`; update redis-commander env vars from `REDIS_HOSTS` to `REDIS_HOST`/`REDIS_PORT`
- Add CI jobs in `build-and-push.yml` to build and push both images to quay.io

## Test plan

- [ ] `make build` builds both new images without errors
- [ ] `make start` brings up redis-commander and connects to valkey correctly (check `http://localhost:8081`)
- [ ] CI `build-and-push-redis-commander` and `build-and-push-phoenix` jobs pass on merge

Supersedes: https://github.com/packit/ai-workflows/pull/409

🤖 Generated with [Claude Code](https://claude.com/claude-code)