### PR TITLE
Avoid incorrect transition based on gating tests

### DIFF
--- a/ymir/supervisor/issue_handler.py
+++ b/ymir/supervisor/issue_handler.py
@@ -276,8 +276,7 @@ class IssueHandler(WorkItemHandler):
 
                 if related_erratum.status == ErrataStatus.NEW_FILES:
                     return self.resolve_wait(
-                        "Erratum is still in NEW_FILES status, "
-                        "waiting for QE testing to begin",
+                        "Erratum is still in NEW_FILES status, waiting for QE testing to begin",
                     )
 
                 baseline_tests = BaselineTests.load_from_issue(self.issue)

--- a/ymir/supervisor/issue_handler.py
+++ b/ymir/supervisor/issue_handler.py
@@ -16,6 +16,7 @@ from .jira_utils import (
     update_issue_comment,
 )
 from .supervisor_types import (
+    ErrataStatus,
     Erratum,
     FullIssue,
     IssueStatus,
@@ -272,6 +273,12 @@ class IssueHandler(WorkItemHandler):
                     return await self.resolve_check_reproduction()
 
                 related_erratum = get_erratum_for_link(issue.errata_link, full=True)
+
+                if related_erratum.status == ErrataStatus.NEW_FILES:
+                    return self.resolve_wait(
+                        "Erratum is still in NEW_FILES status, "
+                        "waiting for QE testing to begin",
+                    )
 
                 baseline_tests = BaselineTests.load_from_issue(self.issue)
                 if baseline_tests is not None:

--- a/ymir/supervisor/testing_analyst.py
+++ b/ymir/supervisor/testing_analyst.py
@@ -70,6 +70,12 @@ results from the TCMS test run posted by EWA.
 In all other cases, if the tests are supposed to be started by NEWA, ignore any comments with
 links to TCMS or Beaker.
 
+IMPORTANT: OSCI gating tests run as part of the GitLab merge request pipeline and
+they do NOT constitute final testing. You must find evidence of full integration
+and regression testing triggered by NEWA or EWA (posted as comments on the erratum)
+before concluding tests-passed or tests-waived. If only OSCI gating results are
+available, return tests-pending.
+
 You cannot assume that tests have passed just because a comment says they have
 finished, it is mandatory to check the actual test results in the JIRA issue or TCMS.
 Make sure that the JIRA issue or TCMS Test Run is the correct one for the latest build in the


### PR DESCRIPTION
Explicit instructions that OSCI gating tests do NOT constitute final testing. The testing analyst must now find evidence of NEWA or EWA-triggered integration/regression testing before concluding tests-passed or tests-waived. If the erratum is still in NEW_FILES status, the supervisor waits instead of calling the testing analyst. Full QE testing only starts when the erratum moves to QE, so analyzing testing before that is premature. This avoid transitioning Jira issues to Release Pending from Integration based on successful OSCI gating alone.
