### PR TITLE
fix supervisor image build

### DIFF
--- a/Containerfile.supervisor
+++ b/Containerfile.supervisor
@@ -54,12 +54,8 @@ COPY ymir/common/ /home/beeai/ymir/common/
 COPY ymir/supervisor/ /home/beeai/ymir/supervisor/
 RUN chgrp -R root /home/beeai && chmod -R g+rX /home/beeai
 
-COPY <<EOF /etc/nitrate.conf
-[nitrate]
-url = https://tcms.engineering.redhat.com/xmlrpc/
-username=anon
-password=whatever
-EOF
+COPY files/nitrate.conf /etc/nitrate.conf
+RUN sed -i 's/^username[[:space:]]*=.*/username=anon/; s/^password[[:space:]]*=.*/password=whatever/' /etc/nitrate.conf
 
 USER beeai
 ENV HOME=/home/beeai

--- a/files/nitrate.conf
+++ b/files/nitrate.conf
@@ -1,0 +1,4 @@
+[nitrate]
+url = https://tcms.engineering.redhat.com/xmlrpc/
+username =
+password =


### PR DESCRIPTION
> the COPY <<EOF heredoc syntax (line 57) requires BuildKit support,
> but the buildah version in CI doesn't support it.

~~secret checker refused the commit unless I put those pragma comments in it~~

and gemini says that inline comments are not support so `sed` it is