### PR TITLE
Add AnalyzeLogsTool to privileged tools package

### DIFF
--- a/skills_installation.md
+++ b/skills_installation.md
@@ -213,7 +213,9 @@ Replace `<your-home>` with the absolute path to your home directory
         "JIRA_URL": "https://redhat.atlassian.net",
         "JIRA_EMAIL": "you@redhat.com",
         "JIRA_TOKEN": "your-jira-api-token",
-        "KRB5CCNAME": "FILE:/tmp/krb5cc_1000"
+        "KRB5CCNAME": "FILE:/tmp/krb5cc_1000",
+        "LOG_DETECTIVE_URL": "https://logdetective-placeholder-server.com/",
+        "LOG_DETECTIVE_TOKEN": "your-log-detective-api-token"
       }
     },
     "ymir-unprivileged": {

--- a/ymir/tools/privileged/gateway.py
+++ b/ymir/tools/privileged/gateway.py
@@ -40,6 +40,7 @@ from ymir.tools.privileged.jira import (
     SetPreliminaryTestingTool,
     VerifyIssueAuthorTool,
 )
+from ymir.tools.privileged.logdetective import AnalyzeLogsTool
 from ymir.tools.privileged.lookaside import (
     DownloadSourcesTool,
     PrepSourcesTool,
@@ -126,6 +127,7 @@ def main():
             PrepSourcesTool(),
             UploadSourcesTool(),
             ZStreamSearchTool(),
+            AnalyzeLogsTool(),
         ]
     )
 

--- a/ymir/tools/privileged/logdetective.py
+++ b/ymir/tools/privileged/logdetective.py
@@ -1,0 +1,230 @@
+import logging
+import os
+
+import aiohttp
+from beeai_framework.context import RunContext
+from beeai_framework.emitter import Emitter
+from beeai_framework.tools import JSONToolOutput, ToolError, ToolRunOptions
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from ymir.tools.base import CloneableTool as Tool
+
+logger = logging.getLogger(__name__)
+
+LOG_DETECTIVE_URL = os.getenv("LOG_DETECTIVE_URL")
+LOG_DETECTIVE_TOKEN = os.getenv("LOG_DETECTIVE_TOKEN")
+MAX_LOG_DETECTIVE_FILES = int(os.getenv("MAX_LOG_DETECTIVE_FILES", 5))
+LOG_DETECTIVE_TIMEOUT = int(os.getenv("LOG_DETECTIVE_TIMEOUT", 180))
+
+
+# --- Input models ---
+
+
+class LogDetectiveFile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(description="Unique name identifying this file")
+    url: str = Field(description="URL to fetch file content from")
+
+
+class LogDetectiveBuildMetadata(BaseModel):
+    specfile: str | None = Field(default=None, description="RPM specfile content")
+    last_patch: str | None = Field(default=None, description="Content of the last applied patch")
+    commentary: str | None = Field(default=None, description="Additional context about the build")
+    infra_status: str | None = Field(default=None, description="Infrastructure status information")
+
+
+class AnalyzeLogsToolInput(BaseModel):
+    files: list[LogDetectiveFile] = Field(
+        description=f"List of log files to analyze (1-{MAX_LOG_DETECTIVE_FILES} items, unique names). "
+        "Each file must have a 'name' and a 'url' pointing to the log content.",
+        min_length=1,
+        max_length=MAX_LOG_DETECTIVE_FILES,
+    )
+    build_metadata: LogDetectiveBuildMetadata | None = Field(
+        default=None,
+        description="Optional build metadata providing context for the analysis",
+    )
+
+
+# --- Output models ---
+
+
+class LogDetectiveSnippet(BaseModel):
+    text: str = Field(description="The relevant build artifact snippet text")
+    line_number: int = Field(description="Line number in the source file")
+    source_file: str | None = Field(default=None, description="Source file name")
+    snippet_analysis: str | None = Field(default=None, description="Analysis of this snippet")
+
+
+class LogDetectiveResult(BaseModel):
+    explanation: str = Field(description="Explanation of the build failure")
+    snippets: list[LogDetectiveSnippet] | None = Field(
+        default=None, description="Relevant build artifact snippets identified"
+    )
+    solution: str | None = Field(default=None, description="Suggested solution")
+    no_issue_found: bool = Field(description="Whether no issues were found in build artifacts")
+
+
+class AnalyzeLogsToolOutput(JSONToolOutput[LogDetectiveResult]):
+    def get_text_content(self) -> str:
+        """Build more token efficient version of the API response."""
+        result: LogDetectiveResult = self.result
+        if result.no_issue_found:
+            parts = ["No issues found.", f"Explanation: {result.explanation}"]
+        else:
+            parts = [f"Explanation: {result.explanation}"]
+
+        if result.snippets:
+            parts.append("Snippets:")
+            for s in result.snippets:
+                loc = f"{s.source_file}:{s.line_number}" if s.source_file else f"line {s.line_number}"
+                parts.append(f"- {loc}: {s.text}")
+                if s.snippet_analysis:
+                    parts.append(f"  Analysis: {s.snippet_analysis}")
+
+        if result.solution:
+            parts.append(f"Solution: {result.solution}")
+
+        return "\n".join(parts)
+
+
+# --- Internal API response models ---
+
+
+class _APITextField(BaseModel):
+    text: str
+
+
+class _APISnippet(BaseModel):
+    text: str
+    line_number: int
+    source_file: str | None = None
+    snippet_analysis: str | None = None
+
+
+class _APIResponse(BaseModel):
+    explanation: _APITextField
+    snippets: list[_APISnippet] | None = None
+    solution: _APITextField | None = None
+    no_issue_found: bool = False
+
+
+# --- Tool ---
+
+
+class AnalyzeLogsTool(Tool[AnalyzeLogsToolInput, ToolRunOptions, AnalyzeLogsToolOutput]):
+    _description = """
+        Analyzes at most {max_log_detective_files} build log files using the Log Detective service.
+        Pass each file as a URL pointing to the hosted log (e.g. Koji, COPR build artifacts).
+        Optionally attach build_metadata (specfile, last_patch, commentary, infra_status)
+        to give the analysis additional context.
+        Returns an explanation of the failure, relevant log snippets with line numbers,
+        and a suggested solution.
+    """
+
+    @property
+    def name(self) -> str:
+        return "analyze_logs"
+
+    @property
+    def description(self) -> str:
+        return self._description.format(max_log_detective_files=MAX_LOG_DETECTIVE_FILES)
+
+    @property
+    def input_schema(self) -> type[AnalyzeLogsToolInput]:
+        return AnalyzeLogsToolInput
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "logdetective", self.name],
+            creator=self,
+        )
+
+    async def _run(
+        self,
+        input: AnalyzeLogsToolInput,
+        options: ToolRunOptions | None,
+        context: RunContext,
+    ) -> AnalyzeLogsToolOutput:
+        if not LOG_DETECTIVE_URL:
+            raise ToolError(
+                "Log Detective URL not configured. Set the LOGDETECTIVE_URL environment variable."
+            )
+
+        names = [f.name for f in input.files]
+        if len(names) != len(set(names)):
+            raise ToolError("File names must be unique.")
+
+        files_payload = [f.model_dump() for f in input.files]
+
+        payload: dict = {"files": files_payload}
+        if input.build_metadata is not None:
+            metadata = input.build_metadata.model_dump(exclude_none=True)
+            if metadata:
+                payload["build_metadata"] = metadata
+
+        headers: dict = {"Content-Type": "application/json"}
+        if LOG_DETECTIVE_TOKEN:
+            headers["Authorization"] = f"Bearer {LOG_DETECTIVE_TOKEN}"
+
+        analyze_url = f"{LOG_DETECTIVE_URL.rstrip('/')}/analyze"
+        logger.info("Sending analysis request to Log Detective: %s", analyze_url)
+
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=LOG_DETECTIVE_TIMEOUT)
+        ) as session:
+            try:
+                async with session.post(
+                    analyze_url,
+                    json=payload,
+                    headers=headers,
+                ) as response:
+                    if response.status == 401:
+                        raise ToolError(
+                            "Authentication failed: invalid or missing token for Log Detective API."
+                        )
+                    if response.status == 422:
+                        error_text = await response.text()
+                        raise ToolError(f"Log Detective API validation error (422): {error_text}")
+                    if response.status == 503:
+                        raise ToolError(
+                            "Log Detective service is temporarily unavailable (503). Please try again later."
+                        )
+                    if response.status >= 400:
+                        error_text = await response.text()
+                        raise ToolError(f"Log Detective API request failed ({response.status}): {error_text}")
+                    data = await response.json()
+            except ToolError:
+                raise
+            except (aiohttp.ContentTypeError, ValueError) as e:
+                raise ToolError(f"Log Detective returned invalid or a non-JSON response: {e}") from e
+            except aiohttp.ClientError as e:
+                raise ToolError(f"Failed to connect to Log Detective service: {e}") from e
+            except TimeoutError as e:
+                raise ToolError("Timeout while contacting Log Detective service") from e
+
+        try:
+            api_response = _APIResponse(**data)
+        except (ValidationError, TypeError) as e:
+            raise ToolError(f"Unexpected response from Log Detective API: {e}") from e
+
+        snippets = None
+        if api_response.snippets is not None:
+            snippets = [
+                LogDetectiveSnippet(
+                    text=s.text,
+                    line_number=s.line_number,
+                    source_file=s.source_file,
+                    snippet_analysis=s.snippet_analysis,
+                )
+                for s in api_response.snippets
+            ]
+
+        result = LogDetectiveResult(
+            explanation=api_response.explanation.text,
+            snippets=snippets,
+            solution=api_response.solution.text if api_response.solution else None,
+            no_issue_found=api_response.no_issue_found,
+        )
+        return AnalyzeLogsToolOutput(result=result)

--- a/ymir/tools/privileged/tests/unit/test_logdetective.py
+++ b/ymir/tools/privileged/tests/unit/test_logdetective.py
@@ -1,0 +1,307 @@
+from contextlib import asynccontextmanager
+
+import aiohttp
+import pytest
+from beeai_framework.tools import ToolError
+from flexmock import flexmock
+from pydantic import ValidationError
+
+from ymir.tools.privileged import logdetective as logdetective_module
+from ymir.tools.privileged.logdetective import (
+    AnalyzeLogsTool,
+    AnalyzeLogsToolOutput,
+    LogDetectiveFile,
+    LogDetectiveResult,
+    LogDetectiveSnippet,
+)
+
+SAMPLE_RESPONSE = {
+    "explanation": {"text": "Build failed due to missing dependency libfoo."},
+    "snippets": [
+        {
+            "text": "error: nothing provides libfoo needed by bar-1.0-1.el10.x86_64",
+            "line_number": 42,
+            "source_file": "build.log",
+            "snippet_analysis": "Missing dependency in the buildroot.",
+        },
+    ],
+    "solution": {"text": "Add libfoo to BuildRequires in the spec file."},
+    "no_issue_found": False,
+}
+
+SAMPLE_RESPONSE_NO_ISSUE = {
+    "explanation": {"text": "Build completed successfully."},
+    "snippets": None,
+    "solution": None,
+    "no_issue_found": True,
+}
+
+BASE_URL = "http://logdetective.example.com"
+TOKEN = "test-token-123"
+
+
+@pytest.fixture(autouse=True)
+def _patch_module_constants(monkeypatch):
+    monkeypatch.setattr(logdetective_module, "LOG_DETECTIVE_URL", BASE_URL)
+    monkeypatch.setattr(logdetective_module, "LOG_DETECTIVE_TOKEN", TOKEN)
+    monkeypatch.setattr(logdetective_module, "MAX_LOG_DETECTIVE_FILES", 5)
+
+
+def _mock_post(status, response_data=None, response_text=""):
+    @asynccontextmanager
+    async def post(url, json=None, headers=None):
+        async def json_response():
+            return response_data
+
+        async def text():
+            return response_text
+
+        yield flexmock(status=status, json=json_response, text=text)
+
+    return post
+
+
+def _mock_post_capturing(status, response_data, captured):
+    @asynccontextmanager
+    async def post(url, json=None, headers=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+
+        async def json_response():
+            return response_data
+
+        yield flexmock(status=status, json=json_response)
+
+    return post
+
+
+@pytest.mark.asyncio
+async def test_analyze_logs_success():
+    captured = {}
+    flexmock(aiohttp.ClientSession).should_receive("post").replace_with(
+        _mock_post_capturing(200, SAMPLE_RESPONSE, captured)
+    )
+
+    out = await AnalyzeLogsTool().run(
+        input={
+            "files": [
+                {"name": "build.log", "url": "https://example.com/build.log"},
+                {"name": "root.log", "url": "https://example.com/root.log"},
+            ],
+            "build_metadata": {"commentary": "PR #42 rebuild"},
+        }
+    )
+
+    result = out.result
+    assert result.explanation == "Build failed due to missing dependency libfoo."
+    assert result.no_issue_found is False
+    assert result.solution == "Add libfoo to BuildRequires in the spec file."
+    assert len(result.snippets) == 1
+    assert result.snippets[0].text == "error: nothing provides libfoo needed by bar-1.0-1.el10.x86_64"
+    assert result.snippets[0].line_number == 42
+    assert result.snippets[0].source_file == "build.log"
+    assert result.snippets[0].snippet_analysis == "Missing dependency in the buildroot."
+
+    assert captured["url"] == f"{BASE_URL}/analyze"
+    assert captured["headers"]["Authorization"] == f"Bearer {TOKEN}"
+    assert len(captured["json"]["files"]) == 2
+    assert captured["json"]["files"][0] == {"name": "build.log", "url": "https://example.com/build.log"}
+    assert captured["json"]["files"][1] == {"name": "root.log", "url": "https://example.com/root.log"}
+    assert captured["json"]["build_metadata"] == {"commentary": "PR #42 rebuild"}
+
+
+@pytest.mark.asyncio
+async def test_analyze_logs_no_issue_found():
+    flexmock(aiohttp.ClientSession).should_receive("post").replace_with(
+        _mock_post(200, SAMPLE_RESPONSE_NO_ISSUE)
+    )
+
+    out = await AnalyzeLogsTool().run(
+        input={"files": [{"name": "build.log", "url": "https://example.com/build.log"}]}
+    )
+
+    result = out.result
+    assert result.no_issue_found is True
+    assert result.snippets is None
+    assert result.solution is None
+    assert result.explanation == "Build completed successfully."
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,expected_msg",
+    [
+        (401, "Authentication failed"),
+        (503, "temporarily unavailable"),
+        (422, "validation error"),
+        (500, r"request failed \(500\)"),
+    ],
+)
+async def test_analyze_logs_http_errors(status, expected_msg):
+    flexmock(aiohttp.ClientSession).should_receive("post").replace_with(
+        _mock_post(status, response_text="error details")
+    )
+
+    with pytest.raises(ToolError, match=expected_msg):
+        await AnalyzeLogsTool().run(
+            input={"files": [{"name": "build.log", "url": "https://example.com/build.log"}]}
+        )
+
+
+@pytest.mark.asyncio
+async def test_analyze_logs_no_files():
+    with pytest.raises(ToolError, match="Tool input validation error"):
+        await AnalyzeLogsTool().run(input={"files": []})
+
+
+@pytest.mark.asyncio
+async def test_analyze_logs_duplicate_names():
+    with pytest.raises(ToolError, match="unique"):
+        await AnalyzeLogsTool().run(
+            input={
+                "files": [
+                    {"name": "build.log", "url": "https://example.com/1.log"},
+                    {"name": "build.log", "url": "https://example.com/2.log"},
+                ]
+            }
+        )
+
+
+def test_file_input_rejects_missing_url():
+    with pytest.raises(ValidationError):
+        LogDetectiveFile(name="build.log")
+
+
+def test_file_input_rejects_extra_fields():
+    with pytest.raises(ValidationError):
+        LogDetectiveFile(name="build.log", url="https://example.com/build.log", content="data")
+
+
+@pytest.mark.asyncio
+async def test_analyze_logs_no_url_configured(monkeypatch):
+    monkeypatch.setattr(logdetective_module, "LOG_DETECTIVE_URL", None)
+
+    with pytest.raises(ToolError, match="URL not configured"):
+        await AnalyzeLogsTool().run(
+            input={"files": [{"name": "build.log", "url": "https://example.com/build.log"}]}
+        )
+
+
+@pytest.mark.asyncio
+async def test_analyze_logs_without_token(monkeypatch):
+    captured = {}
+    flexmock(aiohttp.ClientSession).should_receive("post").replace_with(
+        _mock_post_capturing(200, SAMPLE_RESPONSE, captured)
+    )
+
+    monkeypatch.setattr(logdetective_module, "LOG_DETECTIVE_TOKEN", None)
+
+    await AnalyzeLogsTool().run(
+        input={"files": [{"name": "build.log", "url": "https://example.com/build.log"}]}
+    )
+
+    assert "Authorization" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_analyze_logs_malformed_response():
+    flexmock(aiohttp.ClientSession).should_receive("post").replace_with(
+        _mock_post(200, {"unexpected": "structure"})
+    )
+
+    with pytest.raises(ToolError, match="Unexpected response"):
+        await AnalyzeLogsTool().run(
+            input={"files": [{"name": "build.log", "url": "https://example.com/build.log"}]}
+        )
+
+
+@pytest.mark.asyncio
+async def test_analyze_logs_non_json_response():
+    @asynccontextmanager
+    async def post(url, json=None, headers=None):
+        async def bad_json():
+            raise aiohttp.ContentTypeError(
+                flexmock(real_url="http://example.com"),
+                (),
+                message="Attempt to decode JSON with unexpected mimetype: text/html",
+            )
+
+        yield flexmock(status=200, json=bad_json)
+
+    flexmock(aiohttp.ClientSession).should_receive("post").replace_with(post)
+
+    with pytest.raises(ToolError, match="non-JSON response"):
+        await AnalyzeLogsTool().run(
+            input={"files": [{"name": "build.log", "url": "https://example.com/build.log"}]}
+        )
+
+
+@pytest.mark.asyncio
+async def test_analyze_logs_max_files_exceeded():
+    files = [{"name": f"file{i}.log", "url": f"https://example.com/{i}.log"} for i in range(6)]
+
+    with pytest.raises(ToolError, match="Tool input validation error"):
+        await AnalyzeLogsTool().run(input={"files": files})
+
+
+class TestGetTextContent:
+    def test_full_response(self):
+        result = LogDetectiveResult(
+            explanation="Build failed due to missing dependency libfoo.",
+            snippets=[
+                LogDetectiveSnippet(
+                    text="error: nothing provides libfoo",
+                    line_number=42,
+                    source_file="build.log",
+                    snippet_analysis="Missing dependency.",
+                ),
+                LogDetectiveSnippet(
+                    text="RPM build errors:",
+                    line_number=100,
+                    source_file="build.log",
+                    snippet_analysis=None,
+                ),
+            ],
+            solution="Add libfoo to BuildRequires.",
+            no_issue_found=False,
+        )
+        text = AnalyzeLogsToolOutput(result=result).get_text_content()
+        assert text.startswith("Explanation: Build failed")
+        assert "- build.log:42: error: nothing provides libfoo" in text
+        assert "  Analysis: Missing dependency." in text
+        assert "- build.log:100: RPM build errors:" in text
+        assert "Analysis:" not in text.split("RPM build errors:")[1].split("\n")[0]
+        assert "Solution: Add libfoo to BuildRequires." in text
+
+    def test_no_issue_found(self):
+        result = LogDetectiveResult(
+            explanation="Build completed successfully.",
+            snippets=None,
+            solution=None,
+            no_issue_found=True,
+        )
+        text = AnalyzeLogsToolOutput(result=result).get_text_content()
+        lines = text.split("\n")
+        assert lines[0] == "No issues found."
+        assert lines[1] == "Explanation: Build completed successfully."
+        assert "Snippets:" not in text
+        assert "Solution:" not in text
+
+    def test_no_source_file(self):
+        result = LogDetectiveResult(
+            explanation="Error detected.",
+            snippets=[
+                LogDetectiveSnippet(
+                    text="segfault",
+                    line_number=7,
+                    source_file=None,
+                    snippet_analysis=None,
+                ),
+            ],
+            solution=None,
+            no_issue_found=False,
+        )
+        text = AnalyzeLogsToolOutput(result=result).get_text_content()
+        assert "- line 7: segfault" in text
+        assert "Solution:" not in text

--- a/ymir/tools/pyproject.toml
+++ b/ymir/tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-tools"
-version = "0.3.2"
+version = "0.4.0"
 description = "Ymir MCP tools for AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]


### PR DESCRIPTION
Tool uses API calls to Log Detective server to analyze build logs.

The input for the tool follows Log Detective API, with notable exception of only allowing URLs.
This way we won't get model hallucinating logs into the call. We may still get hallucinated URLs though.

I did go relatively hard on the validation of input and output for the API, maybe even too hard. My intention was to make any inconsistencies in responses immediately obvious, so that the agent doesn't go off the rails from the unintended response.

The somewhat convoluted `get_text_content` of the output model is meant to minimize the amount of tokens that will pass into the context. Simple Json dump would be a bit too much. I do want to implement something similar in Log Detective agent itself. 

Tests are all passing. And I've tested the tool on randomly selected build from copr. It seems to work reasonably well.

<img width="1891" height="503" alt="image" src="https://github.com/user-attachments/assets/ecded0ed-d659-4c1d-82e4-12dd4e5c7318" />


RELEASE NOTES BEGIN

Log Detective can now be queried for analysis of logs using the `analyze_logs` tool. 

RELEASE NOTES END
