### PR TITLE
Add triage justification to MR descriptions for all agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ run-rebase-agent-c9s-standalone:
 		-e DRY_RUN=$(DRY_RUN) \
 		-e MOCK_JIRA=$(MOCK_JIRA) \
 		-e JIRA_DRY_RUN=$(JIRA_DRY_RUN) \
+		-e "JUSTIFICATION=$(JUSTIFICATION)" \
 		rebase-agent-c9s
 
 .PHONY: run-rebase-agent-c10s-standalone
@@ -76,6 +77,7 @@ run-rebase-agent-c10s-standalone:
 		-e DRY_RUN=$(DRY_RUN) \
 		-e MOCK_JIRA=$(MOCK_JIRA) \
 		-e JIRA_DRY_RUN=$(JIRA_DRY_RUN) \
+		-e "JUSTIFICATION=$(JUSTIFICATION)" \
 		rebase-agent-c10s
 
 .PHONY: run-rebase-agent-standalone
@@ -96,6 +98,7 @@ run-backport-agent-c9s-standalone:
 		-e MOCK_JIRA=$(MOCK_JIRA) \
 		-e JIRA_DRY_RUN=$(JIRA_DRY_RUN) \
 		-e CVE_ID=$(CVE_ID) \
+		-e "JUSTIFICATION=$(JUSTIFICATION)" \
 		backport-agent-c9s
 
 .PHONY: run-backport-agent-c10s-standalone
@@ -109,6 +112,7 @@ run-backport-agent-c10s-standalone:
 		-e MOCK_JIRA=$(MOCK_JIRA) \
 		-e JIRA_DRY_RUN=$(JIRA_DRY_RUN) \
 		-e CVE_ID=$(CVE_ID) \
+		-e "JUSTIFICATION=$(JUSTIFICATION)" \
 		backport-agent-c10s
 
 .PHONY: run-backport-agent-standalone
@@ -127,6 +131,7 @@ run-rebuild-agent-c9s-standalone:
 		-e DEPENDENCY_COMPONENT=$(DEPENDENCY_COMPONENT) \
 		-e CONSOLIDATED_ISSUES=$(CONSOLIDATED_ISSUES) \
 		-e JIRA_DRY_RUN=$(JIRA_DRY_RUN) \
+		-e "JUSTIFICATION=$(JUSTIFICATION)" \
 		rebuild-agent-c9s
 
 .PHONY: run-rebuild-agent-c10s-standalone
@@ -141,6 +146,7 @@ run-rebuild-agent-c10s-standalone:
 		-e DEPENDENCY_COMPONENT=$(DEPENDENCY_COMPONENT) \
 		-e CONSOLIDATED_ISSUES=$(CONSOLIDATED_ISSUES) \
 		-e JIRA_DRY_RUN=$(JIRA_DRY_RUN) \
+		-e "JUSTIFICATION=$(JUSTIFICATION)" \
 		rebuild-agent-c10s
 
 .PHONY: run-rebuild-agent-standalone

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ internal-only packages.
 
 **Questions or issues with the agents?**
 
-- **Email**: jotnar@redhat.com
+- **Email**: redhat-ymir-agent@redhat.com
 - **Slack**: #forum-ymir-package-automation
 - **Report AI Issues**: [Jira Issues](https://issues.redhat.com/) (project: Packit, component: jotnar) or [GitHub Issues](https://github.com/packit/ai-workflows/issues)
 

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -31,6 +31,7 @@ from ymir.agents.observability import setup_observability
 from ymir.agents.package_update_steps import PackageUpdateState, PackageUpdateStep
 from ymir.agents.utils import (
     check_subprocess,
+    format_mr_justification,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -1012,6 +1013,7 @@ async def main() -> None:
     class State(PackageUpdateState):
         upstream_patches: list[str]
         cve_id: str | None
+        justification: str | None = Field(default=None)
         unpacked_sources: Path | None = Field(default=None)
         backport_log: list[str] = Field(default=[])
         backport_result: BackportOutputSchema | None = Field(default=None)
@@ -1026,6 +1028,7 @@ async def main() -> None:
         upstream_patches,
         jira_issue,
         cve_id,
+        justification=None,
         fix_version=None,
         redis_conn=None,
     ):
@@ -1385,6 +1388,7 @@ async def main() -> None:
             async def commit_push_and_open_mr(state):
                 try:
                     formatted_patches = "\n".join(f" - {p}" for p in state.upstream_patches)
+                    justification_text = format_mr_justification(state.justification)
                     (
                         state.merge_request_url,
                         state.merge_request_newly_created,
@@ -1407,7 +1411,8 @@ async def main() -> None:
                         mr_title=state.log_result.title,
                         mr_description=(
                             f"{state.log_result.description}\n\n"
-                            f"Upstream patches:\n{formatted_patches}\n"
+                            f"Upstream patches:\n{formatted_patches}\n\n"
+                            f"{justification_text}"
                             f"Resolves: {state.jira_issue}\n\n"
                             f"Backporting steps:\n\n{state.backport_log[-1]}"
                             f"\n\n{MR_DESCRIPTION_FOOTER}"
@@ -1471,6 +1476,7 @@ async def main() -> None:
                     upstream_patches=upstream_patches,
                     jira_issue=jira_issue,
                     cve_id=cve_id,
+                    justification=justification,
                     fix_version=fix_version,
                 ),
             )
@@ -1490,6 +1496,7 @@ async def main() -> None:
             upstream_patches=upstream_patches,
             jira_issue=jira_issue,
             cve_id=os.getenv("CVE_ID", None),
+            justification=os.getenv("JUSTIFICATION", None),
             fix_version=branch,
             redis_conn=None,
         )
@@ -1559,6 +1566,7 @@ async def main() -> None:
                     upstream_patches=backport_data.patch_urls,
                     jira_issue=backport_data.jira_issue,
                     cve_id=backport_data.cve_id,
+                    justification=backport_data.justification,
                     fix_version=backport_data.fix_version,
                     redis_conn=redis,
                 )

--- a/ymir/agents/constants.py
+++ b/ymir/agents/constants.py
@@ -32,7 +32,7 @@ MR_DESCRIPTION_FOOTER = (
     "\n"
     "## 📞 Questions or Issues?\n"
     "\n"
-    "**Contact:** jotnar@redhat.com | **Slack:** #forum-ymir-package-automation | "
+    "**Contact:** redhat-ymir-agent@redhat.com | **Slack:** #forum-ymir-package-automation | "
     "**Report AI Issues:** [Jira](https://issues.redhat.com/) "
     "(project: Packit, component: jotnar) "
     "or [GitHub](https://github.com/packit/ai-workflows/issues)\n"

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -28,6 +28,7 @@ from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
 from ymir.agents.package_update_steps import PackageUpdateState, PackageUpdateStep
 from ymir.agents.utils import (
+    format_mr_justification,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -214,13 +215,16 @@ async def main() -> None:
 
     class State(PackageUpdateState):
         version: str
+        justification: str | None = Field(default=None)
         fedora_clone: Path | None = Field(default=None)
         rebase_log: list[str] = Field(default=[])
         rebase_result: RebaseOutputSchema | None = Field(default=None)
         attempts_remaining: int = Field(default=max_build_attempts)
         all_files_git_to_add: set[str] = Field(default_factory=set)
 
-    async def run_workflow(package, dist_git_branch, version, jira_issue, redis_conn=None):
+    async def run_workflow(
+        package, dist_git_branch, version, jira_issue, justification=None, redis_conn=None
+    ):
         local_tool_options["working_directory"] = None
 
         async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
@@ -385,6 +389,7 @@ async def main() -> None:
 
             async def commit_push_and_open_mr(state):
                 try:
+                    justification_text = format_mr_justification(state.justification)
                     (
                         state.merge_request_url,
                         state.merge_request_newly_created,
@@ -403,6 +408,7 @@ async def main() -> None:
                         mr_title=state.log_result.title,
                         mr_description=(
                             f"{state.log_result.description}\n\n"
+                            f"{justification_text}"
                             f"Resolves: {state.jira_issue}\n\n"
                             f"Status of the rebase:\n\n{state.rebase_log[-1]}"
                             f"\n\n{MR_DESCRIPTION_FOOTER}"
@@ -463,6 +469,7 @@ async def main() -> None:
                     dist_git_branch=dist_git_branch,
                     version=version,
                     jira_issue=jira_issue,
+                    justification=justification,
                 ),
             )
             return response.state
@@ -479,6 +486,7 @@ async def main() -> None:
             dist_git_branch=branch,
             version=version,
             jira_issue=jira_issue,
+            justification=os.getenv("JUSTIFICATION", None),
             redis_conn=None,
         )
         logger.info(f"Direct run completed: {state.rebase_result.model_dump_json(indent=4)}")
@@ -546,6 +554,7 @@ async def main() -> None:
                     dist_git_branch=dist_git_branch,
                     version=rebase_data.version,
                     jira_issue=rebase_data.jira_issue,
+                    justification=rebase_data.justification,
                     redis_conn=redis,
                 )
                 logger.info(

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -16,6 +16,7 @@ from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
 from ymir.agents.package_update_steps import PackageUpdateState
 from ymir.agents.utils import (
+    format_mr_justification,
     get_agent_execution_config,
     mcp_tools,
     render_prompt,
@@ -50,6 +51,7 @@ async def main() -> None:
     class State(PackageUpdateState):
         rebuild_success: bool = Field(default=False)
         rebuild_error: str | None = Field(default=None)
+        justification: str | None = Field(default=None)
         dependency_issue: str | None = Field(default=None)
         dependency_component: str | None = Field(default=None)
         consolidated_issues: list[ConsolidatedIssue] = Field(default_factory=list)
@@ -59,6 +61,7 @@ async def main() -> None:
         package,
         dist_git_branch,
         jira_issue,
+        justification=None,
         dependency_issue=None,
         dependency_component=None,
         consolidated_issues=None,
@@ -196,6 +199,8 @@ async def main() -> None:
                             f"\nSibling consolidation analysis:\n{state.consolidation_summary}\n"
                         )
 
+                    justification_text = format_mr_justification(state.justification)
+
                     (
                         state.merge_request_url,
                         state.merge_request_newly_created,
@@ -215,6 +220,7 @@ async def main() -> None:
                         mr_title=state.log_result.title,
                         mr_description=(
                             f"{state.log_result.description}\n\n"
+                            f"{justification_text}"
                             f"{dep_text}"
                             f"{dep_issues_text}"
                             f"{resolves_text}\n"
@@ -275,6 +281,7 @@ async def main() -> None:
                     package=package,
                     dist_git_branch=dist_git_branch,
                     jira_issue=jira_issue,
+                    justification=justification,
                     dependency_issue=dependency_issue,
                     dependency_component=dependency_component,
                     consolidated_issues=consolidated_issues or [],
@@ -298,6 +305,7 @@ async def main() -> None:
             package=package,
             dist_git_branch=branch,
             jira_issue=jira_issue,
+            justification=os.getenv("JUSTIFICATION", None),
             dependency_issue=dependency_issue,
             dependency_component=dependency_component,
             consolidated_issues=consolidated_issues,
@@ -382,6 +390,7 @@ async def main() -> None:
                     package=rebuild_data.package,
                     dist_git_branch=dist_git_branch,
                     jira_issue=rebuild_data.jira_issue,
+                    justification=rebuild_data.justification,
                     dependency_issue=rebuild_data.dependency_issue,
                     dependency_component=rebuild_data.dependency_component,
                     consolidated_issues=rebuild_data.consolidated_issues,

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -241,6 +241,7 @@ TRIAGE_PROMPT = """
          * A Rebase is only to be chosen when the issue explicitly instructs you to "rebase" or "update"
            to a newer/specific upstream version. Do not infer this.
          * Identify the <package_version> the package should be updated or rebased to.
+         * You must provide a clear justification explaining why this version addresses the issue.
          * Set the Jira fields as per the instructions below.
 
       2. **Backport a Patch OR Request Clarification**
@@ -441,7 +442,9 @@ TRIAGE_PROMPT = """
            and set pending_issues to the dependency issue key.
            Also set package, fix_version, cve_id, dependency_issue, and dependency_component
            (same values as you would for a rebuild resolution).
-         3.3. If rebuild: set Jira fields as per the instructions below.
+         3.3. You must provide a clear justification explaining why a rebuild is needed
+              and how it addresses the issue.
+         3.4. If rebuild: set Jira fields as per the instructions below.
 
       4. **Open-Ended Analysis**
          This is the catch-all for issues that are NOT bugs or CVEs
@@ -712,6 +715,20 @@ async def run_workflow(
                     }}
                     ```
 
+                    **Correct example for a 'rebase' resolution:**
+                    ```json
+                    {{
+                        "resolution": "rebase",
+                        "data": {{
+                        "package": "some-package",
+                        "version": "2.4.1",
+                        "justification": "The issue is fixed in upstream version 2.4.1 available in Fedora.",
+                        "jira_issue": "RHEL-12345",
+                        "fix_version": "rhel-X.Y.Z"
+                        }}
+                    }}
+                    ```
+
                     **Correct example for a 'rebuild' resolution:**
                     ```json
                     {{
@@ -720,6 +737,7 @@ async def run_workflow(
                         "package": "some-package",
                         "jira_issue": "RHEL-12345",
                         "cve_id": "CVE-1234-98765",
+                        "justification": "Rebuild needed, links against golang which received security fix.",
                         "dependency_issue": "RHEL-67890",
                         "dependency_component": "golang",
                         "fix_version": "rhel-X.Y.Z"

--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -124,3 +124,18 @@ def build_agent_factory_with_mock_repos(
         return agent_factory(gateway_tools, {"env": git_env})
 
     return _factory
+
+
+def format_mr_justification(justification: str | None) -> str:
+    """Format justification text for MR descriptions.
+
+    Args:
+        justification: Optional justification text from triage agent
+
+    Returns:
+        Formatted string with "Justification:" header and trailing newlines,
+        or empty string if justification is None
+    """
+    if justification:
+        return f"Justification:\n{justification}\n\n"
+    return ""

--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -137,5 +137,5 @@ def format_mr_justification(justification: str | None) -> str:
         or empty string if justification is None
     """
     if justification:
-        return f"Justification:\n{justification}\n\n"
+        return f"Triage Decision Justification:\n{justification}\n\n"
     return ""

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -177,6 +177,9 @@ class RebaseData(BaseModel):
 
     package: str = Field(description="Package name")
     version: str = Field(description="Target upstream package version to rebase to (e.g., '2.4.1')")
+    justification: str | None = Field(
+        default=None, description="Clear explanation of why this version fixes the issue"
+    )
     jira_issue: str = Field(description="Jira issue identifier")
     fix_version: str | None = Field(description="Fix version in Jira (e.g., 'rhel-9.8')", default=None)
 
@@ -221,6 +224,10 @@ class RebuildData(BaseModel):
     package: str = Field(description="Package name")
     jira_issue: str = Field(description="Jira issue identifier")
     cve_id: str | None = Field(description="CVE identifier", default=None)
+    justification: str | None = Field(
+        default=None,
+        description="Clear explanation of why a rebuild is needed and how it addresses the issue",
+    )
     dependency_issue: str | None = Field(
         description="Key of the dependency Jira issue that triggered the rebuild",
         default=None,
@@ -401,11 +408,15 @@ class TriageOutputSchema(BaseModel):
                 fix_version_text = (
                     f"\n*Fix Version*: {self.data.fix_version}" if self.data.fix_version else ""
                 )
+                justification_text = (
+                    f"\n*Justification*: {self.data.justification}" if self.data.justification else ""
+                )
 
                 return (
                     f"{resolution}"
                     f"*Package*: {self.data.package}\n"
-                    f"*Version*: {self.data.version}{fix_version_text}"
+                    f"*Version*: {self.data.version}"
+                    f"{justification_text}{fix_version_text}"
                     f"{follow_up_note}"
                     f"{TRIAGE_DISCLAIMER}"
                 )
@@ -413,6 +424,9 @@ class TriageOutputSchema(BaseModel):
             case RebuildData():
                 fix_version_text = (
                     f"\n*Fix Version*: {self.data.fix_version}" if self.data.fix_version else ""
+                )
+                justification_text = (
+                    f"\n*Justification*: {self.data.justification}" if self.data.justification else ""
                 )
                 dep_text = (
                     f"\n*Dependency Issue*: {self.data.dependency_issue}"
@@ -434,6 +448,7 @@ class TriageOutputSchema(BaseModel):
                 return (
                     f"{resolution}"
                     f"*Package*: {self.data.package}"
+                    f"{justification_text}"
                     f"{dep_comp_text}"
                     f"{dep_text}"
                     f"{fix_version_text}"

--- a/ymir/common/tests/unit/test_models.py
+++ b/ymir/common/tests/unit/test_models.py
@@ -60,6 +60,7 @@ def test_rebase_formatting():
         version="2.4.55",
         jira_issue="RHEL-67890",
         fix_version="rhel-9.5",
+        justification="Update to upstream version 2.4.55 to fix the issue",
     )
     result = TriageOutputSchema(resolution=Resolution.REBASE, data=data)
 
@@ -67,6 +68,7 @@ def test_rebase_formatting():
         "*Resolution*: rebase\n"
         "*Package*: httpd\n"
         "*Version*: 2.4.55\n"
+        "*Justification*: Update to upstream version 2.4.55 to fix the issue\n"
         "*Fix Version*: rhel-9.5"
         "\n\n_Automated individual follow-up workflow for this "
         "resolution type is planned for Q2 2026. Stay tuned._"
@@ -80,12 +82,29 @@ def test_rebase_formatting_auto_chain():
         version="2.4.55",
         jira_issue="RHEL-67890",
         fix_version="rhel-9.5",
+        justification="Update to upstream version 2.4.55 to fix the issue",
     )
     result = TriageOutputSchema(resolution=Resolution.REBASE, data=data)
 
     comment = result.format_for_comment(auto_chain=True)
     assert "planned for Q2 2026" not in comment
     assert "*Resolution*: rebase" in comment
+
+
+def test_rebase_formatting_without_justification():
+    """Test backward compatibility for RebaseData without justification field."""
+    data = RebaseData(
+        package="httpd",
+        version="2.4.55",
+        jira_issue="RHEL-67890",
+        fix_version="rhel-9.5",
+    )
+    result = TriageOutputSchema(resolution=Resolution.REBASE, data=data)
+
+    comment = result.format_for_comment()
+    assert "*Justification*" not in comment
+    assert "*Package*: httpd" in comment
+    assert "*Version*: 2.4.55" in comment
 
 
 def test_clarification_needed_formatting():
@@ -295,6 +314,7 @@ def test_rebuild_data_all_jira_issues_no_consolidated():
         package="git-lfs",
         jira_issue="RHEL-100",
         fix_version="rhel-9.8",
+        justification="Rebuild needed against updated dependency",
     )
     assert data.all_jira_issues == ["RHEL-100"]
 
@@ -304,6 +324,7 @@ def test_rebuild_data_all_jira_issues_with_consolidated():
         package="git-lfs",
         jira_issue="RHEL-100",
         fix_version="rhel-9.8",
+        justification="Rebuild needed against updated dependency",
         consolidated_issues=[
             ConsolidatedIssue(
                 issue_key="RHEL-101",
@@ -325,6 +346,7 @@ def test_rebuild_data_backward_compat():
         "dependency_issue": "RHEL-50",
         "dependency_component": "golang",
         "fix_version": "rhel-9.8",
+        "justification": "Rebuild needed against updated dependency",
     }
     data = RebuildData.model_validate(payload)
     assert data.consolidated_issues == []
@@ -336,6 +358,7 @@ def test_rebuild_data_serialization_roundtrip():
         package="git-lfs",
         jira_issue="RHEL-100",
         fix_version="rhel-9.8",
+        justification="Rebuild needed against updated dependency",
         consolidated_issues=[
             ConsolidatedIssue(
                 issue_key="RHEL-101",
@@ -347,3 +370,17 @@ def test_rebuild_data_serialization_roundtrip():
     restored = RebuildData.model_validate_json(json_str)
     assert restored.all_jira_issues == ["RHEL-100", "RHEL-101"]
     assert restored.consolidated_issues[0].dependency_component == "golang"
+
+
+def test_rebuild_data_without_justification():
+    """Test backward compatibility for RebuildData without justification field."""
+    data = RebuildData(
+        package="git-lfs",
+        jira_issue="RHEL-100",
+        fix_version="rhel-9.8",
+    )
+    result = TriageOutputSchema(resolution=Resolution.REBUILD, data=data)
+
+    comment = result.format_for_comment()
+    assert "*Justification*" not in comment
+    assert "*Package*: git-lfs" in comment

--- a/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -374,7 +374,12 @@ async def test_run_full_workflow_with_labeled_issues(fetcher, mock_redis_context
         "jira_issue": "ISSUE-2",
         "triage_result": {
             "resolution": "rebase",
-            "data": RebaseData(jira_issue="ISSUE-2", package="test-package", version="1.0.0").model_dump(),
+            "data": RebaseData(
+                jira_issue="ISSUE-2",
+                package="test-package",
+                version="1.0.0",
+                justification="Update to latest upstream version",
+            ).model_dump(),
         },
     }
     task_for_rebase = Task(metadata=triage_state_for_rebase).model_dump_json()


### PR DESCRIPTION
Include the triage agent's justification field in MR descriptions for backport, rebuild, and rebase agents. The justification explains why a specific patch/version/rebuild was chosen and how it addresses the issue, especially for CVE fixes.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>
