### PR TITLE
Migrate build config from .secrets/build.env to .env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,8 @@ COMPOSE_SUPERVISOR=$(COMPOSE) -f $(COMPOSE_FILE) --profile=supervisor
 
 .PHONY: build
 build:
-	if [ -f .secrets/build.env ]; then \
-		set -a && . ./.secrets/build.env && set +a; \
-	fi && \
+	@if [ -f .secrets/build.env ]; then echo "Warning: .secrets/build.env is deprecated, please move its contents to .env"; fi
+	if [ -f .secrets/build.env ] && [ ! -f .env ]; then set -a && . ./.secrets/build.env && set +a; fi && \
 	$(COMPOSE) -f $(COMPOSE_FILE) --profile=agents --profile=supervisor build
 
 .PHONY: run-beeai-bash

--- a/README.md
+++ b/README.md
@@ -86,13 +86,12 @@ In an IDE, select .venv/bin/python as the Python interpreter.
 Some tools are only available from internal repos that cannot be committed
 to this upstream repository. To include them in your local container builds:
 
-1. Copy the template: `cp templates/build.env .secrets/build.env`
-2. Fill in the internal repo URLs and package names in `.secrets/build.env`
-3. Run `make build` as usual — the Makefile sources `.secrets/build.env`
-   automatically if it exists, passing the values as build args to the
-   Containerfiles.
+1. Copy the template: `cp -n templates/build.env .env` (or append its contents to your existing `.env` file)
+2. Fill in the internal repo URLs and package names in `.env`
+3. Run `make build` or `podman-compose build` — podman-compose automatically
+   loads `.env` and passes the values as build args to the Containerfiles.
 
-Without `.secrets/build.env`, containers build normally but without any
+Without `.env`, containers build normally but without any
 internal-only packages.
 
 ## Contact & Feedback

--- a/templates/build.env
+++ b/templates/build.env
@@ -1,9 +1,9 @@
 # Internal build configuration for RHEL packaging agent containers.
-# Copy this file to .secrets/build.env and fill in the values.
+# Copy this file to .env in the project root (e.g., `cp -n templates/build.env .env` or append to it) and fill in the values.
 #
 # These variables inject internal repos and packages into the container
-# build via podman-compose build args. Without .secrets/build.env, containers
-# build normally without any internal-only packages.
+# build via podman-compose build args. podman-compose automatically loads
+# the .env file. Without .env, containers build normally without any internal-only packages.
 
 # Repo URL for CentOS Stream 9 agent image (curl'd into the container)
 INTERNAL_REPO_URL_C9S=


### PR DESCRIPTION
Move build-time configuration from .secrets/build.env to .env so that podman-compose automatically loads it without requiring Makefile.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>

