### PR TITLE
openshift: deploy all agents, fix RWO deadlock, fix redis-commander permissions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -221,7 +221,7 @@
         "filename": "openshift/deployment-rebuild-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 78,
         "is_secret": false
       }
     ],
@@ -231,7 +231,7 @@
         "filename": "openshift/deployment-rebuild-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 78,
         "is_secret": false
       }
     ],
@@ -374,5 +374,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-20T17:10:02Z"
+  "generated_at": "2026-05-13T08:26:25Z"
 }

--- a/agents_as_skills/README.md
+++ b/agents_as_skills/README.md
@@ -1,5 +1,7 @@
 # These files are skills built from agents
 
+If you want to use these skills, we have documentation in this markdown page: https://github.com/packit/ai-workflows/blob/main/skills_installation.md
+
 ## How to build
 
 ```bash

--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -59,11 +59,12 @@ apply pvc-valkey-data.yml
 apply service-valkey.yml
 apply deployment-valkey.yml
 
-# # Redis Commander
-# apply imagestream-redis-commander.yml
-# import_image redis-commander
-# apply service-redis-commander.yml
-# apply deployment-redis-commander.yml
+# Redis Commander
+apply imagestream-redis-commander.yml
+import_image redis-commander
+apply service-redis-commander.yml
+apply route-redis-commander.yml
+apply deployment-redis-commander.yml
 
 # MCP Server
 apply imagestream-mcp-gateway.yml
@@ -76,10 +77,10 @@ apply deployment-mcp-gateway.yml
 apply imagestream-beeai-agent.yml
 import_image beeai-agent
 apply deployment-triage-agent.yml
-# apply deployment-backport-agent-c9s.yml
-# apply deployment-backport-agent-c10s.yml
-# apply deployment-rebase-agent-c9s.yml
-# apply deployment-rebase-agent-c10s.yml
+apply deployment-backport-agent-c9s.yml
+apply deployment-backport-agent-c10s.yml
+apply deployment-rebase-agent-c9s.yml
+apply deployment-rebase-agent-c10s.yml
 #
 # # Supervisor
 # apply imagestream-supervisor.yml

--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -81,6 +81,8 @@ apply deployment-backport-agent-c9s.yml
 apply deployment-backport-agent-c10s.yml
 apply deployment-rebase-agent-c9s.yml
 apply deployment-rebase-agent-c10s.yml
+apply deployment-rebuild-agent-c9s.yml
+apply deployment-rebuild-agent-c10s.yml
 #
 # # Supervisor
 # apply imagestream-supervisor.yml

--- a/openshift/deployment-phoenix.yml
+++ b/openshift/deployment-phoenix.yml
@@ -21,10 +21,7 @@ spec:
     matchLabels:
       app: phoenix
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -20,8 +20,6 @@ spec:
         app: rebuild-agent-c10s
         deployment: rebuild-agent-c10s
     spec:
-      nodeSelector:
-        kubernetes.io/hostname: ip-10-30-34-89.us-east-1.compute.internal
       containers:
       - args:
         - -m

--- a/openshift/deployment-rebuild-agent-c9s.yml
+++ b/openshift/deployment-rebuild-agent-c9s.yml
@@ -20,8 +20,6 @@ spec:
         app: rebuild-agent-c9s
         deployment: rebuild-agent-c9s
     spec:
-      nodeSelector:
-        kubernetes.io/hostname: ip-10-30-34-89.us-east-1.compute.internal
       containers:
       - args:
         - -m

--- a/openshift/deployment-redis-commander.yml
+++ b/openshift/deployment-redis-commander.yml
@@ -31,6 +31,14 @@ spec:
         app: redis-commander
         deployment: redis-commander
     spec:
+      initContainers:
+      - name: copy-config
+        image: redis-commander:prod
+        imagePullPolicy: Always
+        command: ["sh", "-c", "cp -r /usr/local/lib/node_modules/redis-commander/config/. /config/"]
+        volumeMounts:
+        - name: config
+          mountPath: /config
       containers:
       - env:
         - name: REDIS_HOST
@@ -48,6 +56,12 @@ spec:
             cpu: "200m"
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        volumeMounts:
+        - name: config
+          mountPath: /usr/local/lib/node_modules/redis-commander/config
+      volumes:
+      - name: config
+        emptyDir: {}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/openshift/deployment-valkey.yml
+++ b/openshift/deployment-valkey.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: valkey
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/route-redis-commander.yml
+++ b/openshift/route-redis-commander.yml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    paas.redhat.com/appcode: JTNR-001
+  name: redis-commander
+spec:
+  port:
+    targetPort: 8081-tcp
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: redis-commander
+    weight: 100


### PR DESCRIPTION
## Summary

- Enable redis-commander, backport/rebase agents in `deploy.sh` (were commented out)
- Add redis-commander route to the deploy script
- Wire up rebuild agent deployments (c9s + c10s) matching the backport pattern; remove leftover EC2 `nodeSelector` from both
- Switch valkey and phoenix to `Recreate` deployment strategy — `RollingUpdate` with `ReadWriteOnce` PVCs causes a deadlock where the new pod waits for the volume and the old pod waits for the new pod to be Ready
- Fix redis-commander `EACCES` on startup: use an init container to copy the built-in config directory to a writable `emptyDir`, so the app can persist `local-production.json` without hitting the read-only node_modules path

## Test plan

- [x] `oc apply` the changed deployment files and confirm no pods stuck in `ContainerCreating`
- [x] Confirm redis-commander logs no longer show "Problem saving connection config"
- [x] Confirm rebuild agent pods come up on both c9s and c10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)