### PR TITLE
Change bot identity from jotnar to ymir

### DIFF
--- a/files/internal_dist-git_ssh.conf
+++ b/files/internal_dist-git_ssh.conf
@@ -1,6 +1,6 @@
 Host iad2
    Hostname bastion-iad2.corp.redhat.com
    GSSAPIAuthentication yes
-   User jotnar-bot
+   User redhat-ymir-agent
 Host pkgs.devel.redhat.com
    ProxyJump iad2


### PR DESCRIPTION
Alongside with this change you also need to use the rehat-ymir-agent keytab and update the gitlab token in the mcp-gateway.env file with the redhat-ymir-agent token