### PR TITLE
fix check_distgit_ssh_access: use Kerberos principal as SSH username

### DIFF
--- a/ymir/tools/privileged/gateway.py
+++ b/ymir/tools/privileged/gateway.py
@@ -110,7 +110,7 @@ def check_distgit_ssh_access() -> None:
     krb_username = principal.split("@")[0]
 
     result = subprocess.run(
-        ["ssh", "-o", "BatchMode=yes", "pkgs.devel.redhat.com"],
+        ["ssh", "-o", "BatchMode=yes", f"{krb_username}@pkgs.devel.redhat.com"],
         capture_output=True,
         text=True,
         timeout=30,


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
