### PR TITLE
openshift: deployment improvements (keytab migration, Recreate strategy, dist-git SSH fix)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -163,7 +163,7 @@
         "filename": "openshift/deployment-backport-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 76,
+        "line_number": 78,
         "is_secret": false
       }
     ],
@@ -173,7 +173,7 @@
         "filename": "openshift/deployment-backport-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 76,
+        "line_number": 78,
         "is_secret": false
       }
     ],
@@ -183,7 +183,7 @@
         "filename": "openshift/deployment-rebase-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 79,
         "is_secret": false
       }
     ],
@@ -193,7 +193,7 @@
         "filename": "openshift/deployment-rebase-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 79,
         "is_secret": false
       }
     ],
@@ -203,7 +203,7 @@
         "filename": "openshift/deployment-rebuild-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 77,
         "is_secret": false
       }
     ],
@@ -213,7 +213,7 @@
         "filename": "openshift/deployment-rebuild-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 77,
         "is_secret": false
       }
     ],
@@ -233,7 +233,7 @@
         "filename": "openshift/deployment-triage-agent.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 77,
         "is_secret": false
       }
     ],
@@ -348,5 +348,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T15:51:45Z"
+  "generated_at": "2026-05-18T08:11:18Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -163,7 +163,7 @@
         "filename": "openshift/deployment-backport-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 79,
+        "line_number": 76,
         "is_secret": false
       }
     ],
@@ -173,7 +173,7 @@
         "filename": "openshift/deployment-backport-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 79,
+        "line_number": 76,
         "is_secret": false
       }
     ],
@@ -183,7 +183,7 @@
         "filename": "openshift/deployment-rebase-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 77,
         "is_secret": false
       }
     ],
@@ -193,7 +193,7 @@
         "filename": "openshift/deployment-rebase-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 77,
         "is_secret": false
       }
     ],
@@ -203,7 +203,7 @@
         "filename": "openshift/deployment-rebuild-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 75,
         "is_secret": false
       }
     ],
@@ -213,7 +213,7 @@
         "filename": "openshift/deployment-rebuild-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 75,
         "is_secret": false
       }
     ],
@@ -223,7 +223,7 @@
         "filename": "openshift/deployment-supervisor-processor.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 76,
+        "line_number": 73,
         "is_secret": false
       }
     ],
@@ -233,7 +233,7 @@
         "filename": "openshift/deployment-triage-agent.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 78,
+        "line_number": 75,
         "is_secret": false
       }
     ],
@@ -348,5 +348,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-14T07:13:43Z"
+  "generated_at": "2026-05-14T15:51:45Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,14 +151,6 @@
       {
         "type": "Secret Keyword",
         "filename": "openshift/cronjob-supervisor-collector.yml",
-        "hashed_secret": "2f19b33175a0177192f368f143936cb1c04a2127",
-        "is_verified": false,
-        "line_number": 78,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "openshift/cronjob-supervisor-collector.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
         "line_number": 81,
@@ -182,16 +174,6 @@
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
         "line_number": 79,
-        "is_secret": false
-      }
-    ],
-    "openshift/deployment-mcp-gateway.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "openshift/deployment-mcp-gateway.yml",
-        "hashed_secret": "2f19b33175a0177192f368f143936cb1c04a2127",
-        "is_verified": false,
-        "line_number": 84,
         "is_secret": false
       }
     ],
@@ -236,14 +218,6 @@
       }
     ],
     "openshift/deployment-supervisor-processor.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "openshift/deployment-supervisor-processor.yml",
-        "hashed_secret": "2f19b33175a0177192f368f143936cb1c04a2127",
-        "is_verified": false,
-        "line_number": 73,
-        "is_secret": false
-      },
       {
         "type": "Secret Keyword",
         "filename": "openshift/deployment-supervisor-processor.yml",
@@ -374,5 +348,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-13T08:26:25Z"
+  "generated_at": "2026-05-14T07:13:43Z"
 }

--- a/files/internal_dist-git_ssh.conf
+++ b/files/internal_dist-git_ssh.conf
@@ -4,3 +4,4 @@ Host iad2
    User redhat-ymir-agent
 Host pkgs.devel.redhat.com
    ProxyJump iad2
+   User redhat-ymir-agent

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -96,3 +96,11 @@ oc rsh deployment/valkey redis-cli LPUSH triage_queue '{"metadata": {"issue": "R
 ```
 
 Set `force_cve_triage` to `false` for a normal triage run. This mirrors the `make trigger-pipeline` target used locally.
+
+## Image rebuilds of MCP Gateway and agent images
+
+They are built internally. If you need a rebuild right now, head over
+to [the Gitlab jobs view](https://gitlab.cee.redhat.com/jotnar-project/deployment/-/jobs?kind=BUILD)
+and respin those that you need.
+
+Otherwise they are rebuilt nightly at 3:00.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -20,9 +20,9 @@ Agents are deployed in the `jotnar-ymir--jotnar-ymir` project.
   JIRA_TOKEN
   ```
 
-  `jotnar-bot-keytab`:
+  `redhat-ymir-agent-keytab`:
   ```
-  oc create secret generic jotnar-bot-keytab --from-file=jotnar-bot.keytab
+  oc create secret generic redhat-ymir-agent-keytab --from-file=redhat-ymir-agent.keytab
   ```
 
   `testing-farm-env`:

--- a/openshift/configmap-kerberos-env.yml
+++ b/openshift/configmap-kerberos-env.yml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  KEYTAB_FILE: /etc/secrets/jotnar-bot.keytab
+  KEYTAB_FILE: /etc/secrets/redhat-ymir-agent.keytab
   KRB5CCNAME: /tmp/krb5cc
 immutable: false
 kind: ConfigMap

--- a/openshift/cronjob-supervisor-collector.yml
+++ b/openshift/cronjob-supervisor-collector.yml
@@ -59,9 +59,9 @@ spec:
                 drop:
                 - ALL
             volumeMounts:
-            - mountPath: /etc/secrets/jotnar-bot.keytab
-              name: jotnar-bot-keytab
-              subPath: jotnar-bot.keytab
+            - mountPath: /etc/secrets/redhat-ymir-agent.keytab
+              name: redhat-ymir-agent-keytab
+              subPath: redhat-ymir-agent.keytab
             - mountPath: /etc/secrets/jotnar-vertex-prod.json
               name: vertex-key
               subPath: jotnar-vertex-prod.json
@@ -73,9 +73,9 @@ spec:
           schedulerName: default-scheduler
           terminationGracePeriodSeconds: 30
           volumes:
-          - name: jotnar-bot-keytab
+          - name: redhat-ymir-agent-keytab
             secret:
-              secretName: jotnar-bot-keytab
+              secretName: redhat-ymir-agent-keytab  # pragma: allowlist secret
           - name: vertex-key
             secret:
               secretName: vertex-key

--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -43,7 +43,9 @@ spec:
           protocol: TCP
         resources:
           limits:
-            memory: 4Gi
+            memory: 5Gi
+          requests:
+            memory: 2Gi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: backport-agent-c10s
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-backport-agent-c9s.yml
+++ b/openshift/deployment-backport-agent-c9s.yml
@@ -43,7 +43,9 @@ spec:
           protocol: TCP
         resources:
           limits:
-            memory: 4Gi
+            memory: 5Gi
+          requests:
+            memory: 2Gi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/openshift/deployment-backport-agent-c9s.yml
+++ b/openshift/deployment-backport-agent-c9s.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: backport-agent-c9s
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-mcp-gateway.yml
+++ b/openshift/deployment-mcp-gateway.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: mcp-gateway
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-mcp-gateway.yml
+++ b/openshift/deployment-mcp-gateway.yml
@@ -61,9 +61,9 @@ spec:
         volumeMounts:
         - mountPath: /git-repos  # NOTE: This path must match GIT_REPO_BASEPATH in configmap/agents-env
           name: mcp-server-git-repos
-        - mountPath: /etc/secrets/jotnar-bot.keytab
-          name: jotnar-bot-keytab
-          subPath: jotnar-bot.keytab
+        - mountPath: /etc/secrets/redhat-ymir-agent.keytab
+          name: redhat-ymir-agent-keytab
+          subPath: redhat-ymir-agent.keytab
         - mountPath: /home/mcp/rhel-config.json
           name: rhel-config
           subPath: rhel-config.json
@@ -79,9 +79,9 @@ spec:
       - name: mcp-server-git-repos
         persistentVolumeClaim:
           claimName: mcp-server-git-repos
-      - name: jotnar-bot-keytab
+      - name: redhat-ymir-agent-keytab
         secret:
-          secretName: jotnar-bot-keytab
+          secretName: redhat-ymir-agent-keytab  # pragma: allowlist secret
       - name: rhel-config
         configMap:
           name: rhel-config

--- a/openshift/deployment-rebase-agent-c10s.yml
+++ b/openshift/deployment-rebase-agent-c10s.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: rebase-agent-c10s
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-rebase-agent-c10s.yml
+++ b/openshift/deployment-rebase-agent-c10s.yml
@@ -45,6 +45,8 @@ spec:
         resources:
           limits:
             memory: 1Gi
+          requests:
+            memory: 512Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/openshift/deployment-rebase-agent-c9s.yml
+++ b/openshift/deployment-rebase-agent-c9s.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: rebase-agent-c9s
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-rebase-agent-c9s.yml
+++ b/openshift/deployment-rebase-agent-c9s.yml
@@ -45,6 +45,8 @@ spec:
         resources:
           limits:
             memory: 1Gi
+          requests:
+            memory: 512Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: rebuild-agent-c10s
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -44,6 +44,8 @@ spec:
         resources:
           limits:
             memory: 1Gi
+          requests:
+            memory: 512Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/openshift/deployment-rebuild-agent-c9s.yml
+++ b/openshift/deployment-rebuild-agent-c9s.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: rebuild-agent-c9s
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-rebuild-agent-c9s.yml
+++ b/openshift/deployment-rebuild-agent-c9s.yml
@@ -44,6 +44,8 @@ spec:
         resources:
           limits:
             memory: 1Gi
+          requests:
+            memory: 512Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/openshift/deployment-redis-commander.yml
+++ b/openshift/deployment-redis-commander.yml
@@ -21,10 +21,7 @@ spec:
     matchLabels:
       app: redis-commander
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-supervisor-processor.yml
+++ b/openshift/deployment-supervisor-processor.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: supervisor-processor
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:

--- a/openshift/deployment-supervisor-processor.yml
+++ b/openshift/deployment-supervisor-processor.yml
@@ -52,9 +52,9 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        - mountPath: /etc/secrets/jotnar-bot.keytab
-          name: jotnar-bot-keytab
-          subPath: jotnar-bot.keytab
+        - mountPath: /etc/secrets/redhat-ymir-agent.keytab
+          name: redhat-ymir-agent-keytab
+          subPath: redhat-ymir-agent.keytab
         - mountPath: /etc/secrets/jotnar-vertex-prod.json
           name: vertex-key
           subPath: jotnar-vertex-prod.json
@@ -68,9 +68,9 @@ spec:
       # TODO: this should be reset when we have enough data.
       terminationGracePeriodSeconds: 30
       volumes:
-      - name: jotnar-bot-keytab
+      - name: redhat-ymir-agent-keytab
         secret:
-          secretName: jotnar-bot-keytab
+          secretName: redhat-ymir-agent-keytab  # pragma: allowlist secret
       - name: vertex-key
         secret:
           secretName: vertex-key

--- a/openshift/deployment-triage-agent.yml
+++ b/openshift/deployment-triage-agent.yml
@@ -43,6 +43,8 @@ spec:
         resources:
           limits:
             memory: 1Gi
+          requests:
+            memory: 512Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/openshift/deployment-triage-agent.yml
+++ b/openshift/deployment-triage-agent.yml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       app: triage-agent
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Summary

- Migrate keytab from `jotnar-bot` to `redhat-ymir-agent` in mcp-gateway deployment and kerberos ConfigMap
- Switch all deployments from `RollingUpdate` to `Recreate` strategy — with `replicas=1` and a tight namespace quota, RollingUpdate causes a deadlock where old failing pods hold quota and prevent new pods from being created
- Add `User redhat-ymir-agent` to the dist-git SSH config for `pkgs.devel.redhat.com` (was only set for the bastion)
- Show running pod images and ImageStream import times at end of `deploy.sh`
- Document how to manually trigger image rebuilds via the GitLab CI jobs view

## Test plan

- [ ] `./openshift/deploy.sh` runs cleanly
- [ ] mcp-gateway pod comes up and initializes Kerberos ticket for `redhat-ymir-agent`
- [ ] dist-git SSH access works from the mcp-gateway pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)