### PR TITLE
fix stale working directory on agent re-runs

### DIFF
--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -50,14 +50,16 @@ async def fork_and_prepare_dist_git(
     available_tools: list[Tool],
     with_fedora: bool = False,
 ) -> tuple[Path, str, str, Path | None]:
+    if not jira_issue or Path(jira_issue).is_absolute() or ".." in jira_issue:
+        raise ValueError(f"Invalid jira_issue: {jira_issue}")
     working_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / jira_issue
+    if working_dir.is_dir():
+        shutil.rmtree(working_dir, ignore_errors=False)
     working_dir.mkdir(parents=True, exist_ok=True)
     namespace = "centos-stream" if is_cs_branch(dist_git_branch) else "rhel"
     repository = f"https://gitlab.com/redhat/{namespace}/rpms/{package}"
     fork_url = await run_tool("fork_repository", repository=repository, available_tools=available_tools)
     local_clone = working_dir / package
-    if local_clone.is_dir():
-        shutil.rmtree(local_clone, ignore_errors=False)
     if not is_cs_branch(dist_git_branch):
         await run_tool(
             "create_zstream_branch",

--- a/ymir/agents/tests/unit/test_tasks.py
+++ b/ymir/agents/tests/unit/test_tasks.py
@@ -1,0 +1,42 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ymir.agents.tasks import fork_and_prepare_dist_git
+
+
+@pytest.fixture
+def git_repo_basepath(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_REPO_BASEPATH", str(tmp_path))
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_fork_and_prepare_dist_git_wipes_stale_working_dir(git_repo_basepath):
+    """Re-running for the same JIRA issue must remove the previous working directory."""
+    jira_issue = "RHEL-12345"
+    package = "some-package"
+    branch = "rhel-10.0"
+
+    working_dir = git_repo_basepath / jira_issue
+    working_dir.mkdir()
+    stale_file = working_dir / "leftover-artifact.txt"
+    stale_file.write_text("stale")
+
+    mock_tools = [AsyncMock()]
+
+    with (
+        patch("ymir.agents.tasks.run_tool", new_callable=AsyncMock) as mock_run_tool,
+        patch("ymir.agents.tasks.check_subprocess", new_callable=AsyncMock),
+    ):
+        mock_run_tool.return_value = "https://fork.example.com"
+
+        await fork_and_prepare_dist_git(
+            jira_issue=jira_issue,
+            package=package,
+            dist_git_branch=branch,
+            available_tools=mock_tools,
+        )
+
+    assert working_dir.is_dir(), "working_dir should be recreated"
+    assert not stale_file.exists(), "stale artifacts from previous run should be gone"


### PR DESCRIPTION
Wipe the entire per-issue working directory at the start of fork_and_prepare_dist_git so re-runs for the same JIRA issue don't hit stale state from a previous attempt.
