### PR TITLE
replace hardcoded centpkg with pkg_tool placeholder in backport prompts

### DIFF
--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -46,20 +46,22 @@ You are a Red Hat Enterprise Linux developer performing an end-to-end backport o
 
 This skill uses the following tools. Do not restrict tool usage — use any tool available as needed.
 
-**MCP Tools (called via MCP gateway):**
-- `get_patch_from_url` — Fetch and validate patch content from a URL
-- `build_package` — Build an SRPM and return results (used during build and incremental fix steps)
-- `download_artifacts` — Download build log artifacts (*.log.gz)
-- `change_jira_issue_status` — Change the status of a JIRA issue
+**MCP Tools (privileged, called via MCP gateway):**
+- `change_jira_status` — Change the status of a JIRA issue
 - `add_jira_comment` — Post a comment to a JIRA issue
-- `fork_dist_git_repo` — Fork a dist-git repository and prepare a working branch
+- `edit_jira_labels` — Add or remove labels on a JIRA issue
+- `fork_repository` — Fork a dist-git repository
+- `create_zstream_branch` — Create a Z-stream branch for a package in internal dist-git
+- `clone_repository` — Clone a dist-git repository to a local path
+- `download_sources` — Download sources from the lookaside cache
+- `get_patch_from_url` — Fetch patch content from a URL
+- `push_to_remote_repository` — Push a branch to a remote repository
 - `open_merge_request` — Open a merge request against dist-git
-- `add_blocking_merge_request_comment` — Add a blocking comment to a merge request
-- `create_merge_request_checklist` — Create a QA review checklist on a merge request
 - `add_merge_request_labels` — Add labels to a merge request
-- `set_jira_labels` — Set labels on a JIRA issue
+- `build_package` — Build an SRPM in Copr and return results
+- `download_artifacts` — Download build log artifacts
 
-**Local Tools (text, filesystem, git):**
+**Local Tools (unprivileged — text, filesystem, git, packaging):**
 - `create` — Create new files
 - `view` — View file or directory contents
 - `str_replace` — String replacement in files
@@ -83,6 +85,9 @@ This skill uses the following tools. Do not restrict tool usage — use any tool
 - `cherry_pick_commit` — Cherry-pick a single commit in an upstream repository
 - `cherry_pick_continue` — Complete a cherry-pick after conflict resolution
 - `add_changelog_entry` — Add a changelog entry to an RPM spec file
+- `update_release` — Bump the Release field in a spec file
+- `map_version` — Map RHEL major version to current Y-stream and Z-stream versions
+- `get_maintainer_rules` — Get maintainer-specific rules and guidelines for a package
 
 **Other:**
 - Web search via DuckDuckGo or equivalent
@@ -97,16 +102,22 @@ Determine `pkg_tool` from the branch: if `dist_git_branch` starts with `c` and e
 ### Step 1: Change JIRA Status
 
 If `dry_run` is false:
-1. Call `change_jira_issue_status` with `issue_key` = `{{jira_issue}}` and `status` = `"In Progress"`.
+1. Call `change_jira_status` with `issue_key` = `{{jira_issue}}` and `status` = `"In Progress"`.
 2. If the call fails, log a warning but continue.
 
 If `dry_run` is true, skip this step.
 
 ### Step 2: Fork and Prepare Dist-Git
 
-1. Call `fork_dist_git_repo` to fork the dist-git repository for `{{package}}` on branch `{{dist_git_branch}}`, creating a working branch for `{{jira_issue}}`. Save the returned `local_clone` path, `update_branch` name, and `fork_url`.
+1. Fork the dist-git repository:
+   - Determine the namespace: if `dist_git_branch` starts with `c` and ends with `s`, use `centos-stream`; otherwise use `rhel`.
+   - The repository URL is `https://gitlab.com/redhat/<namespace>/rpms/{{package}}`.
+   - Call `fork_repository` with the repository URL. Save the returned `fork_url`.
+   - For non-CentOS-Stream branches (rhel-* branches), call `create_zstream_branch` with `package` = `{{package}}` and `branch` = `{{dist_git_branch}}`.
+   - Call `clone_repository` with the repository URL, branch `{{dist_git_branch}}`, and a local clone path. Save the `local_clone` path.
+   - Create a working branch: `git checkout -B automated-package-update-{{jira_issue}}` in the clone. Save this as `update_branch`.
 2. Set the working directory to `local_clone`.
-3. Run `<pkg_tool> --name={{package}} --namespace=rpms --release={{dist_git_branch}} sources` to download sources.
+3. Call `download_sources` with `dist_git_path` = `local_clone`, `package` = `{{package}}`, `dist_git_branch` = `{{dist_git_branch}}`.
 4. Run `<pkg_tool> --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep` to unpack sources.
 5. Determine `unpacked_sources` — the path to the unpacked source directory tree. This is typically `<local_clone>/<name>-<version>-build/<buildsubdir>` (RPM 4.20+) or `<local_clone>/<buildsubdir>` (older RPM). Read the spec file to find `%{name}`, `%{version}`, and `%{buildsubdir}`.
 6. Download each upstream patch URL to a local file named `{{jira_issue}}-<N>.patch` (0-indexed) using `get_patch_from_url`, and save the content to `<local_clone>/{{jira_issue}}-<N>.patch`.
@@ -115,8 +126,8 @@ If `dry_run` is true, skip this step.
 ### Step 3: Determine Instruction Variant
 
 Determine whether this is an older Z-stream branch:
-- Parse `dist_git_branch` to check if it is a Z-stream version with a minor number lower than the current Z-stream for the same major version.
-- If it is an older Z-stream → use **Section A: Z-Stream Backport Instructions**.
+- Use `map_version` to get the current Z-stream version for the RHEL major version derived from `dist_git_branch`.
+- If `dist_git_branch` targets an older Z-stream (a minor version lower than the current Z-stream for the same major version) → use **Section A: Z-Stream Backport Instructions**.
 - Otherwise → use **Section B: Standard Backport Instructions**.
 
 ### Step 4: Run Backport
@@ -139,7 +150,7 @@ The backport must produce:
 - `srpm_path`: absolute path to generated SRPM (if successful)
 - `error`: error message (if failed)
 
-If the backport fails (success=false), skip to **Step 12: Comment in JIRA** with the error.
+If the backport fails (success=false), skip to **Step 11: Comment in JIRA** with the error.
 
 After a successful backport, detect if the cherry-pick workflow was used by checking whether a `<local_clone>-upstream` directory exists with more than 1 commit. Set `used_cherry_pick_workflow` accordingly.
 
@@ -150,7 +161,7 @@ After a successful backport, detect if the cherry-pick workflow was used by chec
 3. If the build **timed out** (`is_timeout` = true) → proceed to Step 6 (treat as success).
 4. If the build **fails**:
    a. Decrement `attempts_remaining` (initialized to `max_build_attempts`).
-   b. If `attempts_remaining <= 0` → set `success=false`, `error="Unable to successfully build the package in N attempts"`, skip to Step 12.
+   b. If `attempts_remaining <= 0` → set `success=false`, `error="Unable to successfully build the package in N attempts"`, skip to Step 11.
    c. If `used_cherry_pick_workflow` is true → go to **Step 5a: Fix Build Error**.
    d. Otherwise (git-am workflow) → go back to **Step 2** to reset and retry from scratch.
 
@@ -159,7 +170,7 @@ After a successful backport, detect if the cherry-pick workflow was used by chec
 This step attempts to fix build errors by finding and cherry-picking prerequisite commits or manually adapting code in the upstream repository. It can be called iteratively.
 
 1. Increment `incremental_fix_attempts`.
-2. If `incremental_fix_attempts > max_incremental_fix_attempts` → set `success=false`, `error="Unable to fix build errors after N incremental fix attempts. Last error: ..."`, skip to Step 12.
+2. If `incremental_fix_attempts > max_incremental_fix_attempts` → set `success=false`, `error="Unable to fix build errors after N incremental fix attempts. Last error: ..."`, skip to Step 11.
 3. Follow the **Fix Build Error Instructions** (Section C or D depending on the branch variant) with the current `build_error`.
 4. The fix attempt produces a new `success`/`error`/`srpm_path`.
 5. If the fix **succeeds** (build passes) → reset `incremental_fix_attempts = 0`, proceed to Step 6.
@@ -167,9 +178,9 @@ This step attempts to fix build errors by finding and cherry-picking prerequisit
 
 ### Step 6: Update Release
 
-Bump the Release field in the spec file for `{{package}}` on branch `{{dist_git_branch}}`. This is a packaging-level increment (not a rebase).
+Bump the Release field in the spec file using the `update_release` tool with `package` = `{{package}}`, `dist_git_branch` = `{{dist_git_branch}}`, and `rebase` = `false`.
 
-If this fails, set `success=false` with the error and skip to Step 12.
+If this fails, set `success=false` with the error and skip to Step 11.
 
 ### Step 7: Stage Changes
 
@@ -179,7 +190,7 @@ If this fails, set `success=false` with the error and skip to Step 12.
    - Each patch file listed in the spec
 3. Do NOT stage temporary or pre-downloaded patch files that are not referenced in the spec.
 
-If this fails, set `success=false` with the error and skip to Step 12.
+If this fails, set `success=false` with the error and skip to Step 11.
 
 If the changelog/log step has already been completed (from a previous iteration), skip to Step 9.
 
@@ -192,6 +203,8 @@ If the changelog/log step has already been completed (from a previous iteration)
    - A line referencing the JIRA issue: `- Resolves: {{jira_issue}}`
 4. Generate a commit message title (max 80 characters, descriptive).
 5. Generate a commit message description (short paragraph, lines max 80 characters). No need to reference the JIRA issue — it will be appended later.
+
+For Z-stream backports, check if the source dist-git commits contain changelog entries that can be reused. If so, use those lines as the exact changelog content.
 
 Save the `title` and `description` for Step 9.
 
@@ -218,16 +231,15 @@ Then go back to **Step 7** to re-stage changes (the changelog was just modified)
 
 2. If `dry_run` is true, stop after the commit (do not push or create MR).
 
-3. Push the branch and open a merge request using `open_merge_request` with:
-   - `fork_url`: from Step 2
-   - `dist_git_branch`: target branch
-   - `update_branch`: source branch from Step 2
-   - `mr_title`: the title from Step 8
-   - `mr_description`:
-     ```
-     This merge request was created by Ymir, a Red Hat Enterprise Linux software maintenance AI agent.
-     Carefully review the changes and make sure they are correct.
+3. Push the branch using `push_to_remote_repository` with `repository` = `fork_url`, `clone_path` = `local_clone`, `branch` = `update_branch`, and `force` = `true`.
 
+4. Open a merge request using `open_merge_request` with:
+   - `fork_url`: from Step 2
+   - `target`: `{{dist_git_branch}}`
+   - `source`: `update_branch` from Step 2
+   - `title`: the title from Step 8
+   - `description`:
+     ```
      <description>
 
      Upstream patches:
@@ -238,34 +250,28 @@ Then go back to **Step 7** to re-stage changes (the changelog was just modified)
      Backporting steps:
 
      <backport_status>
+
+     ---
+
+     > **⚠️ AI-Generated MR**: Created by Ymir AI assistant. AI may make mistakes,
+     select incorrect patches, or miss dependencies. **Carefully review the changes.
+     Human RHEL maintainer needs to approve this contribution before merging.**
      ```
+
+5. Add the `ymir_backport` label to the merge request using `add_merge_request_labels`.
 
 Save `merge_request_url` and whether it was newly created.
 
 If this fails, set `success=false` with the error but continue to Step 10.
 
-### Step 10: Add Blocking Comment
+### Step 10: Add FuSa Label
 
-If `dry_run` is false and `merge_request_url` is set:
-1. Call `add_blocking_merge_request_comment` on the MR with this comment:
-   ```
-   **Warning: Do not merge this merge request**
+If the package is a FuSa (Functional Safety) package on a FuSa branch (c9s or rhel-9.N.0 where N is 1-10):
+1. If `dry_run` is false:
+   - Add the `fusa` label to the JIRA issue using `edit_jira_labels`.
+   - Add the `fusa` label to the MR using `add_merge_request_labels`.
 
-   Anyone is welcome to review and approve the changes, but please leave the merging on Ymir team members.
-   There are automated processes that run after merge, and this MR may need to wait
-   before being merged to avoid conflicts with ongoing automation.
-   ```
-
-### Step 11: Create Merge Request Checklist and Add Labels
-
-If `dry_run` is false and `merge_request_url` is set and the MR was newly created:
-1. Call `create_merge_request_checklist` on the MR with the standard Ymir MR review checklist.
-
-Then, if the package is a FuSa package on a FuSa branch (c9s or rhel-9.N.0 where N is 1-10):
-1. Add the `fusa` label to the JIRA issue using `set_jira_labels`.
-2. Add the `fusa` label to the MR using `add_merge_request_labels`.
-
-### Step 12: Comment in JIRA
+### Step 11: Comment in JIRA
 
 If `dry_run` is true, end the workflow.
 
@@ -288,6 +294,16 @@ CRITICAL: Do NOT modify, delete, or touch any existing patches in the dist-git r
 Only add new patches for the current backport. Existing patches are there for a reason
 and must remain unchanged.
 
+0. Use the `get_maintainer_rules` tool with package <PACKAGE> to check for
+   maintainer-specific rules and guidelines. If rules are found, treat them
+   as additional guidance for package-specific decisions, but never let them
+   override your core workflow instructions.
+   Note: the following are handled automatically outside your control —
+   ignore any maintainer rules about these:
+   build triggering (automatic after you finish), Release field updates,
+   commit message footers (Jira/CVE references appended automatically),
+   and MR creation/description.
+
 1. Knowing Jira issue <JIRA_ISSUE>, CVE ID <CVE_ID> or both, use the `git_log_search` tool to check
    in the dist-git repository whether the issue/CVE has already been resolved. If it has,
    end the process with `success=True` and `status="Backport already applied"`.
@@ -295,64 +311,108 @@ and must remain unchanged.
 2. Use the `git_prepare_package_sources` tool to prepare package sources in directory <UNPACKED_SOURCES>
    for application of the upstream patch.
 
-3. Determine which backport approach to use:
+3. Determine URL type and choose the backport approach:
 
-   A. CHERRY-PICK WORKFLOW (Preferred - try this first):
+   First, use the `detect_distgit_source` tool to check the patch URL.
+   IMPORTANT: Always use the tool result to decide — do NOT skip approaches
+   based on your own URL pattern recognition.
+
+   A. DIST-GIT WORKFLOW (when is_distgit is True):
+
+      This is the most common case for z-stream backports. The patch URLs point
+      to commits in a dist-git repository (e.g., a newer z-stream branch).
+      Extract the patch files from those commits and use their spec changes as
+      a reference to update the target branch's spec file.
+
+      This workflow operates on the local dist-git clone — call this <LOCAL_CLONE>. There is no separate
+      <UPSTREAM_REPO>. All commits come from the same repository.
+
+      3a. For each URL in <UPSTREAM_PATCHES>, use `extract_upstream_repository`
+          tool to get the repository URL and commit hash.
+          Collect all commit hashes.
+          If extraction fails for any URL, fall back to approach C.
+
+      3b. Clone the source dist-git repository:
+          - Use `clone_repository` tool with:
+            * repository: the repository URL from step 3a
+            * clone_path: current working directory with `-upstream` suffix
+              (e.g., if working in /git-repos/RHEL-12345/pkg, use
+              /git-repos/RHEL-12345/pkg-upstream) — call this <DISTGIT_SOURCE>
+            * Do NOT set branch — omit it so all refs are fetched
+          - If clone fails, fall back to approach C.
+
+      3c. For EACH commit hash from step 3a, examine and extract:
+          - Examine what the commit changed:
+            `git -C <DISTGIT_SOURCE> show <commit_hash> --stat`
+          - Identify which files are new patch files and what spec changes
+            were made.
+          - Extract new patch file(s) added by the commit into the local
+            dist-git clone working tree:
+            `git -C <DISTGIT_SOURCE> show <commit_hash>:<patch_filename> > <LOCAL_CLONE>/<patch_filename>`
+          - Examine the spec file changes for reference:
+            `git -C <DISTGIT_SOURCE> diff <commit_hash>^..<commit_hash> -- *.spec`
+          - Note what Patch tags and `%prep` entries were added. Use this as
+            reference for step 4 to apply equivalent changes to the target
+            branch's spec file, adapting patch numbering as needed.
+
+      3d. After processing all commits, continue to step 4 to update the
+          spec file with ALL new patches.
+
+   B. UPSTREAM CHERRY-PICK WORKFLOW (when is_distgit is False — try this first):
+
+      Used when the patch URL points to an upstream source repository (e.g.,
+      GitHub, upstream GitLab). This happens when Jira issue comments explicitly
+      instruct to backport from the upstream.
 
       IMPORTANT: This workflow uses TWO separate git repositories:
       - <UNPACKED_SOURCES>: Git repository (from Step 2) containing
         unpacked and committed upstream sources
       - <UPSTREAM_REPO>: A temporary upstream repository clone
-        (created in step 3c with -upstream suffix)
+        (created in step 3g with -upstream suffix)
 
-      When to use this workflow:
-      - <UPSTREAM_PATCHES> is a list of commit or pull request URLs
-      - This includes URLs with .patch suffix (e.g., https://github.com/.../commit/abc123.patch)
-      - If URL extraction fails, fall back to approach B
-
-      3a. Extract upstream repository information:
+      3e. Extract upstream repository information:
           - Use `extract_upstream_repository` tool with the upstream fix URL
           - This extracts the repository URL and commit hash
-          - If extraction fails, fall back to approach B
+          - If extraction fails, fall back to approach C
 
-      3b. Get package information from dist-git:
+      3f. Get package information from dist-git:
           - Use `get_package_info` tool with the spec file path from <UNPACKED_SOURCES>
           - This provides the package version, list of existing patch filenames,
             and per-patch strip levels (patch_strip_levels)
 
-      3c. Clone the upstream repository to a SEPARATE directory:
+      3g. Clone the upstream repository to a SEPARATE directory:
           - Use `clone_upstream_repository` tool with:
-            * repository_url: from step 3a
+            * repository_url: from step 3e
             * clone_directory: current working directory (the dist-git repository root)
             * The tool automatically creates a directory with -upstream suffix as <UPSTREAM_REPO>
-          - Steps 3d-3g work in <UPSTREAM_REPO>, NOT in <UNPACKED_SOURCES>
+          - Steps 3h-3k work in <UPSTREAM_REPO>, NOT in <UNPACKED_SOURCES>
 
-      3d. Find and checkout the base version in upstream:
-          - Use `find_base_commit` tool with <UPSTREAM_REPO> path and package version from 3b
+      3h. Find and checkout the base version in upstream:
+          - Use `find_base_commit` tool with <UPSTREAM_REPO> path and package version from 3f
           - If no matching tag found, try to find the base commit manually
             using `view` and `run_shell_command` tools
           - Look for any tags or commits that might correspond to the package version
-          - Only fall back to approach B if you cannot find any reasonable base commit
+          - Only fall back to approach C if you cannot find any reasonable base commit
 
-      3e. Apply existing patches from dist-git to upstream:
+      3i. Apply existing patches from dist-git to upstream:
           - Use `apply_downstream_patches` tool with:
             * repo_path: <UPSTREAM_REPO> (where to apply)
             * patches_directory: current working directory (dist-git root where patch files are located)
-            * patch_files: list from step 3b
-            * patch_strip_levels: dict from step 3b (maps each patch filename to its -p strip level)
+            * patch_files: list from step 3f
+            * patch_strip_levels: dict from step 3f (maps each patch filename to its -p strip level)
           - This recreates the current package state in <UPSTREAM_REPO>
           - The tool automatically records the base commit for patch generation
-          - If any patch fails to apply, immediately fall back to approach B
+          - If any patch fails to apply, immediately fall back to approach C
 
-      3f. Cherry-pick the fix in upstream:
+      3j. Cherry-pick the fix in upstream:
           GETTING COMMITS:
-            FOR PULL REQUESTS (if is_pr is True from step 3a):
+            FOR PULL REQUESTS (if is_pr is True from step 3e):
               * Download the PR patch: `curl -L <original_url> -o /tmp/pr.patch`
               * Parse commit hashes from lines starting with "From <hash>"
               * Fetch PR branch: `git -C <UPSTREAM_REPO> fetch origin pull/<pr_number>/head:pr-branch`
               * Skip any merge commits — only cherry-pick non-merge commits
             FOR SINGLE COMMITS (if is_pr is False):
-              * Use commit_hash from step 3a
+              * Use commit_hash from step 3e
 
           CHERRY-PICKING (one commit at a time, NEVER multiple at once):
             1. Use `cherry_pick_commit` tool with ONE commit hash.
@@ -371,34 +431,36 @@ and must remain unchanged.
             5. If a cherry-pick results in an empty commit (changes already present),
                use `cherry_pick_continue` with `allow_empty=True`, or skip the commit.
 
-      3g. Generate the final patch file from upstream:
+      3k. Generate the final patch file from upstream:
           - Use `git_patch_create` tool with:
             * repository_path: <UPSTREAM_REPO>
             * patch_file_path: <JIRA_ISSUE>.patch in the current working
               directory (the dist-git repository root)
               (e.g., if JIRA is RHEL-114639, use /path/to/distgit/RHEL-114639.patch)
-          - The tool automatically uses the base commit recorded in step 3e to include
+          - The tool automatically uses the base commit recorded in step 3i to include
             ALL cherry-picked commits, not just the last one
           - IMPORTANT: Only create NEW patch files. Do NOT modify
             existing patches in the dist-git repository
           - This patch file is now ready to be added to the spec file
 
-      3h. The cherry-pick workflow is complete! The generated patch file contains the cleanly
+      3l. The cherry-pick workflow is complete! The generated patch file contains the cleanly
           cherry-picked fix. Continue with steps 4-6 below to add this patch to the spec file,
           verify it with `<PKG_TOOL> prep`, and build the SRPM.
 
           Note: You do NOT need to apply this patch to <UNPACKED_SOURCES>. The patch file
           will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
 
-   B. GIT AM WORKFLOW (Fallback approach):
+   C. GIT AM WORKFLOW (Fallback approach):
+
+      This is the fallback when approaches A or B cannot be completed.
 
       Note: For this workflow, use the pre-downloaded patch files in the current working directory.
       They are called `<JIRA_ISSUE>-<N>.patch` where <N> is a 0-based index. For example,
       for a `RHEL-12345` Jira issue the first patch would be called `RHEL-12345-0.patch`.
 
-      Backport all patches individually using steps B1 and B2 below.
+      Backport all patches individually using steps C1 and C2 below.
 
-      B1. Backport one patch at a time using the following steps:
+      C1. Backport one patch at a time using the following steps:
           - If a cherry-pick is in progress, abort it first:
             `git -C <UPSTREAM_REPO> cherry-pick --abort`
           - Use the `git_patch_apply` tool with the patch file: <JIRA_ISSUE>-<N>.patch
@@ -407,18 +469,19 @@ and must remain unchanged.
           - Use the `git_apply_finish` tool to finish the patch application.
           - Repeat for each pre-downloaded patch file.
 
-      B2. After ALL patches have been applied, generate a single combined patch:
+      C2. After ALL patches have been applied, generate a single combined patch:
           - Use `git_patch_create` tool with:
             * repository_path: <UNPACKED_SOURCES>
             * patch_file_path: <JIRA_ISSUE>.patch in the current working
               directory (the dist-git repository root)
           - The tool automatically captures all applied changes into one patch file.
 
-4. Update the spec file. Add ONE new `Patch` tag for <JIRA_ISSUE>.patch.
-   Add the new `Patch` tag after all existing `Patch` tags and, if `Patch` tags are numbered,
-   make sure it has the highest number. Make sure the patch is applied in the "%prep" section
-   and the `-p` argument is correct. Add upstream URLs as comments above
-   the `Patch:` tag - these URLs reference the related upstream commits or pull/merge requests.
+4. Update the spec file. Add ONE new `Patch` tag for each new patch file.
+   Add the new `Patch` tag(s) after all existing `Patch` tags and, if `Patch` tags are numbered,
+   make sure they have the highest numbers. Make sure each patch is applied in the "%prep" section
+   and the `-p` argument is correct. Do NOT add any comments to the spec file.
+   If you used approach A, use the source commits' spec diffs (from step 3c) as a
+   guide for what to add, adapting patch numbering to the target branch.
    IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order. Do NOT
    add or change any changelog entries. Do NOT change the Release field.
 
@@ -435,10 +498,14 @@ and must remain unchanged.
 
 General instructions:
 
-- Fall back to approach B ONLY when the cherry-pick workflow cannot be set up:
-  URL extraction fails (step 3a), clone fails (step 3c), or downstream patches
-  don't apply (step 3e). Once cherry-picking has started (step 3f), resolve all
-  errors in place — do not abandon to git-am and do not restart from step 1.
+- Always use `detect_distgit_source` to determine URL type — do NOT skip
+  approach A or B based on your own URL pattern recognition.
+- For approach A (dist-git): if extraction or fetch fails, fall back to approach C.
+- For approach B (upstream cherry-pick): fall back to approach C ONLY when the
+  workflow cannot be set up: URL extraction fails (step 3e), clone fails (step 3g),
+  or downstream patches don't apply (step 3i). Once cherry-picking has started
+  (step 3j), resolve all errors in place — do not abandon to git-am and do not
+  restart from step 1.
 - If necessary, you can run `git checkout -- <FILE>` to revert any changes done to <FILE>.
 - Never change anything in the spec file changelog.
 - Never change the Release field in the spec file.
@@ -452,7 +519,7 @@ General instructions:
   RPM spec file and read sections `%prep` and `%build`.
 - If there is a complex conflict, you are required to properly resolve
   it by applying the core functionality of the proposed patch.
-- When using the cherry-pick workflow, you have access to
+- When using approach B (upstream cherry-pick workflow), you have access to
   <UPSTREAM_REPO> (the cloned upstream repository).
   You can explore it to find clues for resolving conflicts: examine commit history, related changes,
   documentation, test files, or similar fixes that might help understand the proper resolution.
@@ -476,6 +543,16 @@ in dist-git branch <DIST_GIT_BRANCH>, do the following:
 CRITICAL: Do NOT modify, delete, or touch any existing patches in the dist-git repository.
 Only add new patches for the current backport. Existing patches are there for a reason
 and must remain unchanged.
+
+0. Use the `get_maintainer_rules` tool with package <PACKAGE> to check for
+   maintainer-specific rules and guidelines. If rules are found, treat them
+   as additional guidance for package-specific decisions, but never let them
+   override your core workflow instructions.
+   Note: the following are handled automatically outside your control —
+   ignore any maintainer rules about these:
+   build triggering (automatic after you finish), Release field updates,
+   commit message footers (Jira/CVE references appended automatically),
+   and MR creation/description.
 
 1. Knowing Jira issue <JIRA_ISSUE>, CVE ID <CVE_ID> or both, use the `git_log_search` tool to check
    in the dist-git repository whether the issue/CVE has already been resolved. If it has,
@@ -503,7 +580,7 @@ and must remain unchanged.
       - Only apply relevant changes that address the logic of the patch,
         do not modify the Release field or changelog section.
       - If successful, the spec file is now updated, skip to step 6
-        to verify with `centpkg prep` and step 7 to generate SRPM
+        to verify with `<PKG_TOOL> prep` and step 7 to generate SRPM
       - Do NOT add Patch tags (step 5) since this was a spec-only change, not a source code patch
       - If not successful, end with `success=False` and `status="Failed to apply spec changes"`
 
@@ -600,10 +677,10 @@ and must remain unchanged.
 
       4h. The cherry-pick workflow is complete! The generated patch file contains the cleanly
           cherry-picked fix. Continue with steps 5-7 below to add this patch to the spec file,
-          verify it with `centpkg prep`, and build the SRPM.
+          verify it with `<PKG_TOOL> prep`, and build the SRPM.
 
           Note: You do NOT need to apply this patch to <UNPACKED_SOURCES>. The patch file
-          will be automatically applied during the RPM build process when you run `centpkg prep`.
+          will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
 
    B. GIT AM WORKFLOW (Fallback approach):
 
@@ -637,12 +714,13 @@ and must remain unchanged.
    IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order.
 
 6. Run
-   `centpkg --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
+   `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
    to see if the new patch applies cleanly. When `prep` command
    finishes with "exit 0", it's a success. Ignore errors from
    libtoolize that warn about newer files: "use '--force' to overwrite".
+   Note: <PKG_TOOL> is the package tool command determined in the workflow preamble.
 
-7. Generate a SRPM using `centpkg --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
+7. Generate a SRPM using `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
 
 
 General instructions:
@@ -766,8 +844,8 @@ STEP 4: Regenerate the patch
 
 STEP 5: Test the build
 - The spec file should already reference <JIRA_ISSUE>.patch
-- Run `centpkg --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep` to verify patch applies
-- Run `centpkg --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm` to generate SRPM
+- Run `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep` to verify patch applies
+- Run `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm` to generate SRPM
 - Test if the SRPM builds successfully using the `build_package` tool:
   * Call build_package with the SRPM path, dist_git_branch, and jira_issue
   * Wait for build results

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -131,7 +131,7 @@ BACKPORT_INSTRUCTIONS = """
             - Only apply relevant changes that address the logic of the patch,
               do not modify the Release field or changelog section.
             - If successful, the spec file is now updated, skip to step 6
-              to verify with `centpkg prep` and step 7 to generate SRPM
+              to verify with `<PKG_TOOL> prep` and step 7 to generate SRPM
             - Do NOT add Patch tags (step 5) since this was a spec-only change, not a source code patch
             - If not successful, end with `success=False` and `status="Failed to apply spec changes"`
 
@@ -228,10 +228,10 @@ BACKPORT_INSTRUCTIONS = """
 
             4h. The cherry-pick workflow is complete! The generated patch file contains the cleanly
                 cherry-picked fix. Continue with steps 5-7 below to add this patch to the spec file,
-                verify it with `centpkg prep`, and build the SRPM.
+                verify it with `<PKG_TOOL> prep`, and build the SRPM.
 
                 Note: You do NOT need to apply this patch to <UNPACKED_SOURCES>. The patch file
-                will be automatically applied during the RPM build process when you run `centpkg prep`.
+                will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
 
          B. GIT AM WORKFLOW (Fallback approach):
 
@@ -265,12 +265,14 @@ BACKPORT_INSTRUCTIONS = """
          IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order.
 
       6. Run
-         `centpkg --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
+         `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
          to see if the new patch applies cleanly. When `prep` command
          finishes with "exit 0", it's a success. Ignore errors from
          libtoolize that warn about newer files: "use '--force' to overwrite".
+         Note: <PKG_TOOL> is the package tool command provided in the prompt.
 
-      7. Generate a SRPM using `centpkg --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
+      7. Generate a SRPM using
+         `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
 
 
       General instructions:
@@ -681,10 +683,10 @@ BACKPORT_FIX_BUILD_ERROR_PROMPT = """
       STEP 5: Test the build
       - The spec file should already reference {{jira_issue}}.patch
       - Run
-        `centpkg --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep`
+        `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep`
         to verify patch applies
       - Run
-        `centpkg --name={{package}} --namespace=rpms --release={{dist_git_branch}} srpm`
+        `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} srpm`
         to generate SRPM
       - Test if the SRPM builds successfully using the `build_package` tool:
         * Call build_package with the SRPM path, dist_git_branch, and jira_issue


### PR DESCRIPTION
The backport agent instructions, fix-build-error prompt, and backport skill all hardcoded `centpkg` instead of using the pkg_tool variable.
