### PR TITLE
Fix missing kerb mock in test

### DIFF
--- a/ymir/tools/privileged/tests/unit/test_lookaside.py
+++ b/ymir/tools/privileged/tests/unit/test_lookaside.py
@@ -37,6 +37,7 @@ async def test_download_sources(branch):
 
         return flexmock(wait=wait)
 
+    _mock_kerberos()
     flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)
     result = (
         await DownloadSourcesTool().run(


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [X] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->
I was trying to setup the environment and when I was running tests and few of them failed (the test_download_source). The args were not right, because kerberos was not mocked, like in test_prep_sources. So I have added _mock_kerberos func call so the environment is prepared. Now the tests pass and don't fail on klist.

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
