### PR TITLE
fix_build_error refactoring

### DIFF
--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -16,6 +16,12 @@ arguments:
   - name: cve_id
     description: "CVE identifier if the JIRA issue is a CVE (e.g., CVE-2025-12345). Default: null"
     required: false
+  - name: justification
+    description: "Justification text for the backport, included in the merge request description. Default: null"
+    required: false
+  - name: fix_version
+    description: "Fix version string used to determine Z-stream instruction variant (e.g., 'rhel-9.4.0'). Default: same as dist_git_branch"
+    required: false
   - name: dry_run
     description: "If true, skip JIRA status changes, MR creation, and label updates. Default: false"
     required: false
@@ -38,6 +44,8 @@ You are a Red Hat Enterprise Linux developer performing an end-to-end backport o
 - `upstream_patches`: {{upstream_patches}} (comma-separated URLs)
 - `jira_issue`: {{jira_issue}}
 - `cve_id`: {{cve_id}}
+- `justification`: {{justification}}
+- `fix_version`: {{fix_version}} (defaults to `dist_git_branch` if not provided)
 - `dry_run`: {{dry_run}}
 - `max_build_attempts`: {{max_build_attempts}}
 - `max_incremental_fix_attempts`: {{max_incremental_fix_attempts}}
@@ -125,9 +133,9 @@ If `dry_run` is true, skip this step.
 
 ### Step 3: Determine Instruction Variant
 
-Determine whether this is an older Z-stream branch:
-- Use `map_version` to get the current Z-stream version for the RHEL major version derived from `dist_git_branch`.
-- If `dist_git_branch` targets an older Z-stream (a minor version lower than the current Z-stream for the same major version) → use **Section A: Z-Stream Backport Instructions**.
+Determine whether this is an older Z-stream branch using `fix_version` (or `dist_git_branch` if `fix_version` is not set):
+- Use `map_version` to get the current Z-stream version for the RHEL major version derived from `fix_version`.
+- If `fix_version` targets an older Z-stream (a minor version lower than the current Z-stream for the same major version) → use **Section A: Z-Stream Backport Instructions**.
 - Otherwise → use **Section B: Standard Backport Instructions**.
 
 ### Step 4: Run Backport
@@ -245,6 +253,8 @@ Then go back to **Step 7** to re-stage changes (the changelog was just modified)
      Upstream patches:
       - <patch_url_1>
       - <patch_url_2>
+
+     [<justification> — only if justification is set]
      Resolves: {{jira_issue}}
 
      Backporting steps:

--- a/compose.yaml
+++ b/compose.yaml
@@ -218,7 +218,7 @@ services:
     <<: *supervisor
     command: ["sh", "-c", "echo 'This service isn't run directly' && exit 1"]
     profiles: []
-    restart: no
+    restart: "no"
 
 
   jira-issue-fetcher:

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -594,285 +594,65 @@ BACKPORT_FIX_BUILD_ERROR_PROMPT = """
       - {{.}}
       {{/upstream_patches}}
 
-      The backport of upstream patches was initially successful using the cherry-pick workflow,
-      but the build failed with the following error:
+      The cherry-pick workflow succeeded but the build failed:
 
       {{build_error}}
 
-      CRITICAL: The upstream repository ({{local_clone}}-upstream) still exists
-      with all your previous work intact.
-      DO NOT clone it again. DO NOT reset to base commit. DO NOT modify
-      anything in {{local_clone}} dist-git repository.
-      Your cherry-picked commits are still there in {{local_clone}}-upstream.
+      CRITICAL CONSTRAINTS:
+      - The upstream repository at {{local_clone}}-upstream has all your previous work intact.
+        DO NOT clone it again. DO NOT reset to base commit.
+      - DO NOT modify anything in {{local_clone}} dist-git repository except
+        {{jira_issue}}.patch (by regenerating it from upstream repo).
+      - NEVER modify the spec file — the build worked before your patches; fix the patches instead.
+      - Fix BOTH compilation errors AND test failures. NEVER skip or disable tests.
+      - Make ONE attempt — you will be called again if the build still fails.
 
-      The package built successfully before your patches were added -
-      the spec file and build configuration are correct.
-      Your task is to fix this build error by improving the patches - NOT by modifying the spec file.
-      This includes BOTH compilation errors AND test failures during the check section.
-      Make ONE attempt to fix the issue - you will be called again if the build still fails.
+      Before you start: Read {{local_clone}}-upstream/build-logs/fix-attempts.md for a log of
+      previous fix attempts. Do NOT repeat strategies that already failed.
 
-      Follow these steps:
+      WORKFLOW:
 
-      STEP 1: Analyze the build error
-      - Identify if it's a compilation error (undefined symbols, headers) or test failure (in check section)
-      - Identify what's missing: undefined functions, types, macros, symbols, headers, or API changes
-      - Look for patterns like "undefined reference", "implicit declaration", "undeclared identifier", etc.
-      - Note the specific names of missing symbols
+      1. Analyze the build error and identify what's missing (functions, types, headers, etc.)
 
-      STEP 2: Explore the upstream repository for solutions
-      You have FULL ACCESS to the upstream repository ({{local_clone}}-upstream) as a reference:
+      2. Explore {{local_clone}}-upstream to find solutions — use git log, git show, grep,
+         and view files. The full upstream history is available.
 
-      - Examine the history between versions:
-        * `git -C {{local_clone}}-upstream log --oneline <base_version>..<target_commit>`
-
-      - Search for how missing symbols are implemented:
-        * Search in commit messages:
-          `git -C {{local_clone}}-upstream log --all --grep="function_name" --oneline`
-        * Search in code changes:
-          `git -C {{local_clone}}-upstream log --all -S"function_name" --oneline`
-        * Show commit details: `git -C {{local_clone}}-upstream show <commit_hash>`
-
-      - Look at current implementation in newer versions:
-        * View files to see how things work: `view` tool on files in {{local_clone}}-upstream
-        * Understand the context and dependencies
-        * See how the code evolved over time
-
-      - Explore related changes:
-        * Check header files, documentation, tests
-        * Look for API changes, refactorings, helper functions
-        * Understand the bigger picture
-
-      STEP 3: Choose the best fix approach
-      You have TWO options for fixing the issue:
-
-      OPTION A: Cherry-pick prerequisite commits
-      - If you find clean, self-contained commits that add what's missing
-      - Use `cherry_pick_commit` tool ONE commit at a time (chronological order, oldest first)
-      - Resolve conflicts using `str_replace` tool
-      - Stage resolved files: `git -C {{local_clone}}-upstream add <file>`
-      - Complete cherry-pick: use `cherry_pick_continue` tool
-
-      OPTION B: Manually adapt the code
-      - If cherry-picking would pull in too many dependencies
-      - If the commit doesn't apply cleanly and needs significant adaptation
-      - If you need to backport just a small piece of functionality
-      - Directly edit files in {{local_clone}}-upstream using `str_replace` or `insert` tools
-      - Make minimal changes to fix the specific build error
-      - Commit your changes: `git -C {{local_clone}}-upstream add <files>` then
-        `git -C {{local_clone}}-upstream commit -m "Manually backport: <description>"`
-
-      You can MIX both approaches:
-      - Cherry-pick some commits, then manually adapt code where needed
-      - Use the upstream repo as a reference while writing your own backport
+      3. Fix the issue using one or both approaches:
+         A. Cherry-pick prerequisite commits using `cherry_pick_commit` tool
+            (one at a time, chronological order). Resolve conflicts with `str_replace`,
+            then use `cherry_pick_continue`.
+         B. Manually edit files in {{local_clone}}-upstream and commit.
 
       SPECIAL CONSIDERATIONS FOR TEST FAILURES:
-      - Tests validate the fix - they MUST pass
+      - Tests validate the fix — they MUST pass
       - If tests use missing functions/helpers: backport ONLY the minimal necessary test helpers
         (search upstream history for test utility commits and cherry-pick or manually add them)
       - If tests fail due to API changes: adapt test code to work with older APIs
-      - NEVER skip or disable tests - fix them instead
+      - NEVER skip or disable tests — fix them instead
 
-      STEP 4: Regenerate the patch
-      - After making your fixes (cherry-picked or manual), regenerate the patch file
-      - Use `git_patch_create` tool with:
-        * repository_path: {{local_clone}}-upstream
-        * patch_file_path: {{local_clone}}/{{jira_issue}}.patch
-      - The tool automatically uses the base commit to include all changes
-      - This creates a single patch with all changes: original commits + prerequisites/fixes
-      - This improved patch now includes all missing dependencies needed for a successful build
+      4. Regenerate the patch using `git_patch_create` tool with:
+         - repository_path: {{local_clone}}-upstream
+         - patch_file_path: {{local_clone}}/{{jira_issue}}.patch
 
-      STEP 5: Test the build
-      - The spec file should already reference {{jira_issue}}.patch
-      - Run
-        `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep`
-        to verify patch applies
-      - Run
-        `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} srpm`
-        to generate SRPM
-      - Test if the SRPM builds successfully using the `build_package` tool:
-        * Call build_package with the SRPM path, dist_git_branch, and jira_issue
-        * Wait for build results
-        * If build PASSES: Report success=true with the SRPM path
-        * If build FAILS: Use `download_artifacts` to get build logs if available
-        * Extract the new error message from the logs:
-          - IMPORTANT: Before viewing log files, check their size using `wc -l` command
-          - If a log file has more than 2000 lines, use the view tool with offset and limit
-            parameters to read only the LAST 1000 lines
-            (calculate offset as total_lines - 1000, limit as 1000)
-          - Build failures are almost always at the end of logs, avoiding context overflow
-          - Alternatively, use the `search_text` tool to search for error
-            patterns (e.g., "ERROR", "FAILED", "error:", "fatal:")
-            and then use the view tool to read targeted sections around the matching line numbers
-          - Combine strategies as needed to understand the failure without reading the entire file
-        * Report success=false with the extracted error
+      5. Test the build:
+         - `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep`
+         - `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} srpm`
+         - Call `build_package` with the SRPM path, dist_git_branch, and jira_issue
+         - If build fails: use `download_artifacts` to get logs, identify the new error,
+           and save the log files to {{local_clone}}-upstream/build-logs/
 
-      Report your results:
-      - If build passes → Report success=true with the SRPM path
-      - If build fails → Report success=false with the extracted error message
-      - If you can't find a fix → Report success=false explaining why
+      6. Append a summary to {{local_clone}}-upstream/build-logs/fix-attempts.md documenting:
+         - What you identified as the root cause
+         - Which commits you cherry-picked or what manual edits you made
+         - The build result (pass/fail and error if applicable)
 
-      IMPORTANT RULES:
-      - Work in the EXISTING {{local_clone}}-upstream directory (don't clone again)
-      - NEVER modify the spec file - build failures are caused by incomplete patches, not spec issues
-      - The ONLY dist-git file you can modify is {{jira_issue}}.patch
-        (by regenerating it from upstream repo)
-      - Fix build errors (compilation AND test failures) by adding missing
-        prerequisites/dependencies to your patches in upstream repo
-      - For test failures: backport minimal necessary test helpers/functions to make tests pass
-      - You can freely explore, edit, cherry-pick, and commit in the upstream repo - it's your workspace
-      - Use the upstream repo as a rich source of information and examples
-      - Be creative and pragmatic - the goal is a working build with passing tests, not perfect git history
-      - Make ONE solid attempt to fix the issue - if the build fails, report the error clearly
-      - Your work will persist in the upstream repo for the next attempt if needed
+      Report success=true with SRPM path if build passes.
+      Report success=false with the extracted error if build fails or you can't find a fix.
 
-      Remember: Unpacked upstream sources are in {{unpacked_sources}}.
-      The upstream repository at {{local_clone}}-upstream is your playground - explore it freely!
+      Unpacked upstream sources are in {{unpacked_sources}}.
     """
 
-BACKPORT_FIX_BUILD_ERROR_PROMPT_ZSTREAM = """
-      Your working directory is {{local_clone}}, a clone of dist-git repository of package {{package}}.
-      {{dist_git_branch}} dist-git branch has been checked out. You are working on Jira issue {{jira_issue}}
-      {{#cve_id}}(a.k.a. {{.}}){{/cve_id}}.
-
-      Upstream patches that were backported:
-      {{#upstream_patches}}
-      - {{.}}
-      {{/upstream_patches}}
-
-      The backport of upstream patches was initially successful using the cherry-pick workflow,
-      but the build failed with the following error:
-
-      {{build_error}}
-
-      CRITICAL: The upstream repository ({{local_clone}}-upstream) still exists
-      with all your previous work intact.
-      DO NOT clone it again. DO NOT reset to base commit. DO NOT modify
-      anything in {{local_clone}} dist-git repository.
-      Your cherry-picked commits are still there in {{local_clone}}-upstream.
-
-      The package built successfully before your patches were added -
-      the spec file and build configuration are correct.
-      Your task is to fix this build error by improving the patches - NOT by modifying the spec file.
-      This includes BOTH compilation errors AND test failures during the check section.
-      Make ONE attempt to fix the issue - you will be called again if the build still fails.
-
-      Follow these steps:
-
-      STEP 1: Analyze the build error
-      - Identify if it's a compilation error (undefined symbols, headers) or test failure (in check section)
-      - Identify what's missing: undefined functions, types, macros, symbols, headers, or API changes
-      - Look for patterns like "undefined reference", "implicit declaration", "undeclared identifier", etc.
-      - Note the specific names of missing symbols
-
-      STEP 2: Explore the upstream repository for solutions
-      You have FULL ACCESS to the upstream repository ({{local_clone}}-upstream) as a reference:
-
-      - Examine the history between versions:
-        * `git -C {{local_clone}}-upstream log --oneline <base_version>..<target_commit>`
-
-      - Search for how missing symbols are implemented:
-        * Search in commit messages:
-          `git -C {{local_clone}}-upstream log --all --grep="function_name" --oneline`
-        * Search in code changes:
-          `git -C {{local_clone}}-upstream log --all -S"function_name" --oneline`
-        * Show commit details: `git -C {{local_clone}}-upstream show <commit_hash>`
-
-      - Look at current implementation in newer versions:
-        * View files to see how things work: `view` tool on files in {{local_clone}}-upstream
-        * Understand the context and dependencies
-        * See how the code evolved over time
-
-      - Explore related changes:
-        * Check header files, documentation, tests
-        * Look for API changes, refactorings, helper functions
-        * Understand the bigger picture
-
-      STEP 3: Choose the best fix approach
-      You have TWO options for fixing the issue:
-
-      OPTION A: Cherry-pick prerequisite commits
-      - If you find clean, self-contained commits that add what's missing
-      - Use `cherry_pick_commit` tool ONE commit at a time (chronological order, oldest first)
-      - Resolve conflicts using `str_replace` tool
-      - Stage resolved files: `git -C {{local_clone}}-upstream add <file>`
-      - Complete cherry-pick: use `cherry_pick_continue` tool
-
-      OPTION B: Manually adapt the code
-      - If cherry-picking would pull in too many dependencies
-      - If the commit doesn't apply cleanly and needs significant adaptation
-      - If you need to backport just a small piece of functionality
-      - Directly edit files in {{local_clone}}-upstream using `str_replace` or `insert` tools
-      - Make minimal changes to fix the specific build error
-      - Commit your changes: `git -C {{local_clone}}-upstream add <files>` then
-        `git -C {{local_clone}}-upstream commit -m "Manually backport: <description>"`
-
-      You can MIX both approaches:
-      - Cherry-pick some commits, then manually adapt code where needed
-      - Use the upstream repo as a reference while writing your own backport
-
-      SPECIAL CONSIDERATIONS FOR TEST FAILURES:
-      - Tests validate the fix - they MUST pass
-      - If tests use missing functions/helpers: backport ONLY the minimal necessary test helpers
-        (search upstream history for test utility commits and cherry-pick or manually add them)
-      - If tests fail due to API changes: adapt test code to work with older APIs
-      - NEVER skip or disable tests - fix them instead
-
-      STEP 4: Regenerate the patch
-      - After making your fixes (cherry-picked or manual), regenerate the patch file
-      - Use `git_patch_create` tool with:
-        * repository_path: {{local_clone}}-upstream
-        * patch_file_path: {{local_clone}}/{{jira_issue}}.patch
-      - The tool automatically uses the base commit to include all changes
-      - This creates a single patch with all changes: original commits + prerequisites/fixes
-      - This improved patch now includes all missing dependencies needed for a successful build
-
-      STEP 5: Test the build
-      - The spec file should already reference {{jira_issue}}.patch
-      - Run
-        `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep`
-        to verify patch applies
-      - Run
-        `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} srpm`
-        to generate SRPM
-      - Test if the SRPM builds successfully using the `build_package` tool:
-        * Call build_package with the SRPM path, dist_git_branch, and jira_issue
-        * Wait for build results
-        * If build PASSES: Report success=true with the SRPM path
-        * If build FAILS: Use `download_artifacts` to get build logs if available
-        * Extract the new error message from the logs:
-          - IMPORTANT: Before viewing log files, check their size using `wc -l` command
-          - If a log file has more than 2000 lines, use the view tool with offset and limit
-            parameters to read only the LAST 1000 lines
-            (calculate offset as total_lines - 1000, limit as 1000)
-          - Build failures are almost always at the end of logs, avoiding context overflow
-          - Alternatively, use the `search_text` tool to search for error
-            patterns (e.g., "ERROR", "FAILED", "error:", "fatal:")
-            and then use the view tool to read targeted sections around the matching line numbers
-          - Combine strategies as needed to understand the failure without reading the entire file
-        * Report success=false with the extracted error
-
-      Report your results:
-      - If build passes → Report success=true with the SRPM path
-      - If build fails → Report success=false with the extracted error message
-      - If you can't find a fix → Report success=false explaining why
-
-      IMPORTANT RULES:
-      - Work in the EXISTING {{local_clone}}-upstream directory (don't clone again)
-      - NEVER modify the spec file - build failures are caused by incomplete patches, not spec issues
-      - The ONLY dist-git file you can modify is {{jira_issue}}.patch
-        (by regenerating it from upstream repo)
-      - Fix build errors (compilation AND test failures) by adding missing
-        prerequisites/dependencies to your patches in upstream repo
-      - For test failures: backport minimal necessary test helpers/functions to make tests pass
-      - You can freely explore, edit, cherry-pick, and commit in the upstream repo - it's your workspace
-      - Use the upstream repo as a rich source of information and examples
-      - Be creative and pragmatic - the goal is a working build with passing tests, not perfect git history
-      - Make ONE solid attempt to fix the issue - if the build fails, report the error clearly
-      - Your work will persist in the upstream repo for the next attempt if needed
-
-      Remember: Unpacked upstream sources are in {{unpacked_sources}}.
-      The upstream repository at {{local_clone}}-upstream is your playground - explore it freely!
-    """
+BACKPORT_FIX_BUILD_ERROR_PROMPT_ZSTREAM = BACKPORT_FIX_BUILD_ERROR_PROMPT
 
 
 async def get_fix_build_error_prompt(fix_version: str | None = None) -> str:

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -736,6 +736,14 @@ async def create_backport_agent(
     )
 
 
+def _move_build_logs(source_dir: Path, target_dir: Path) -> None:
+    """Move build log files from source_dir into target_dir."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for log_file in source_dir.glob("*.log*"):
+        if log_file.suffix in (".log", ".gz"):
+            log_file.rename(target_dir / log_file.name)
+
+
 def _extract_commit_hash(url: str) -> str | None:
     """Extract a commit hash from a dist-git commit URL."""
     from urllib.parse import urlparse
@@ -998,12 +1006,7 @@ async def main() -> None:
                     log_dir.mkdir(parents=True, exist_ok=True)
                     attempt_num = state.incremental_fix_attempts + 1
 
-                    # Move any leftover logs from previous fix attempt into attempt-N dir
-                    attempt_log_dir = log_dir / f"attempt-{attempt_num}"
-                    attempt_log_dir.mkdir(parents=True, exist_ok=True)
-                    for log_file in state.local_clone.glob("*.log*"):
-                        if log_file.suffix in (".log", ".gz"):
-                            log_file.rename(attempt_log_dir / log_file.name)
+                    _move_build_logs(state.local_clone, log_dir / f"attempt-{attempt_num}")
 
                     attempts_log = log_dir / "fix-attempts.md"
 
@@ -1140,11 +1143,10 @@ async def main() -> None:
                 if state.used_cherry_pick_workflow:
                     upstream_repo = Path(f"{state.local_clone}-upstream")
                     if upstream_repo.exists():
-                        log_dir = upstream_repo / "build-logs" / "attempt-0"
-                        log_dir.mkdir(parents=True, exist_ok=True)
-                        for log_file in state.local_clone.glob("*.log*"):
-                            if log_file.suffix in (".log", ".gz"):
-                                log_file.rename(log_dir / log_file.name)
+                        _move_build_logs(
+                            state.local_clone,
+                            upstream_repo / "build-logs" / "attempt-0",
+                        )
                     logger.info("Cherry-pick workflow was used - starting incremental fix")
                     return "fix_build_error"
                 # Git am workflow was used - reset and try again

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import itertools
 import logging
 import os
 import re
@@ -739,9 +740,11 @@ async def create_backport_agent(
 def _move_build_logs(source_dir: Path, target_dir: Path) -> None:
     """Move build log files from source_dir into target_dir."""
     target_dir.mkdir(parents=True, exist_ok=True)
-    for log_file in source_dir.glob("*.log*"):
-        if log_file.suffix in (".log", ".gz"):
-            log_file.rename(target_dir / log_file.name)
+    for log_file in itertools.chain(
+        source_dir.glob("*.log"),
+        source_dir.glob("*.log.gz"),
+    ):
+        log_file.rename(target_dir / log_file.name)
 
 
 def _extract_commit_hash(url: str) -> str | None:

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -1206,6 +1206,14 @@ async def main() -> None:
                 )
 
                 try:
+                    upstream_repo = Path(f"{state.local_clone}-upstream")
+                    if not upstream_repo.exists():
+                        logger.error(
+                            f"Upstream repo {upstream_repo} missing, cannot do incremental fix — "
+                            "falling back to full reset"
+                        )
+                        return "fork_and_prepare_dist_git"
+
                     # Create a fresh backport agent with build tools enabled for iterative testing
                     fix_agent = await create_backport_agent(
                         gateway_tools,

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -747,6 +747,21 @@ def _move_build_logs(source_dir: Path, target_dir: Path) -> None:
         log_file.rename(target_dir / log_file.name)
 
 
+def _update_fix_attempts_log(log_dir: Path, attempt_num: int, build_error: str) -> None:
+    """Create or append to fix-attempts.md with the current build error."""
+    attempts_log = log_dir / "fix-attempts.md"
+    if not attempts_log.exists():
+        attempts_log.write_text(
+            f"# Fix Attempts Log\n\n"
+            f"## Initial build failure\n\n```\n{build_error}\n```\n\n"
+            f"## Attempt {attempt_num}\n\n"
+            f"**Build error to fix:**\n```\n{build_error}\n```\n\n"
+        )
+    else:
+        with attempts_log.open("a") as f:
+            f.write(f"\n## Attempt {attempt_num}\n\n**Build error to fix:**\n```\n{build_error}\n```\n\n")
+
+
 def _extract_commit_hash(url: str) -> str | None:
     """Extract a commit hash from a dist-git commit URL."""
     from urllib.parse import urlparse
@@ -1010,22 +1025,7 @@ async def main() -> None:
                     attempt_num = state.incremental_fix_attempts + 1
 
                     _move_build_logs(state.local_clone, log_dir / f"attempt-{attempt_num}")
-
-                    attempts_log = log_dir / "fix-attempts.md"
-
-                    if not attempts_log.exists():
-                        attempts_log.write_text(
-                            f"# Fix Attempts Log\n\n"
-                            f"## Initial build failure\n\n```\n{state.build_error}\n```\n\n"
-                            f"## Attempt {attempt_num}\n\n"
-                            f"**Build error to fix:**\n```\n{state.build_error}\n```\n\n"
-                        )
-                    else:
-                        with attempts_log.open("a") as f:
-                            f.write(
-                                f"\n## Attempt {attempt_num}\n\n"
-                                f"**Build error to fix:**\n```\n{state.build_error}\n```\n\n"
-                            )
+                    _update_fix_attempts_log(log_dir, attempt_num, state.build_error)
 
                     # Create a fresh backport agent with build tools enabled for iterative testing
                     fix_agent = await create_backport_agent(

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -1331,6 +1331,13 @@ async def main() -> None:
                 state.build_error = build_result.error
                 # Try to fix build error incrementally if cherry-pick workflow was used
                 if state.used_cherry_pick_workflow:
+                    upstream_repo = Path(f"{state.local_clone}-upstream")
+                    if upstream_repo.exists():
+                        log_dir = upstream_repo / "build-logs" / "attempt-0"
+                        log_dir.mkdir(parents=True, exist_ok=True)
+                        for log_file in state.local_clone.glob("*.log*"):
+                            if log_file.suffix in (".log", ".gz"):
+                                log_file.rename(log_dir / log_file.name)
                     logger.info("Cherry-pick workflow was used - starting incremental fix")
                     return "fix_build_error"
                 # Git am workflow was used - reset and try again

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -1214,6 +1214,33 @@ async def main() -> None:
                         )
                         return "fork_and_prepare_dist_git"
 
+                    log_dir = upstream_repo / "build-logs"
+                    log_dir.mkdir(parents=True, exist_ok=True)
+                    attempt_num = state.incremental_fix_attempts + 1
+
+                    # Move any leftover logs from previous fix attempt into attempt-N dir
+                    attempt_log_dir = log_dir / f"attempt-{attempt_num}"
+                    attempt_log_dir.mkdir(parents=True, exist_ok=True)
+                    for log_file in state.local_clone.glob("*.log*"):
+                        if log_file.suffix in (".log", ".gz"):
+                            log_file.rename(attempt_log_dir / log_file.name)
+
+                    attempts_log = log_dir / "fix-attempts.md"
+
+                    if not attempts_log.exists():
+                        attempts_log.write_text(
+                            f"# Fix Attempts Log\n\n"
+                            f"## Initial build failure\n\n```\n{state.build_error}\n```\n\n"
+                            f"## Attempt {attempt_num}\n\n"
+                            f"**Build error to fix:**\n```\n{state.build_error}\n```\n\n"
+                        )
+                    else:
+                        with attempts_log.open("a") as f:
+                            f.write(
+                                f"\n## Attempt {attempt_num}\n\n"
+                                f"**Build error to fix:**\n```\n{state.build_error}\n```\n\n"
+                            )
+
                     # Create a fresh backport agent with build tools enabled for iterative testing
                     fix_agent = await create_backport_agent(
                         gateway_tools,

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -639,8 +639,7 @@ BACKPORT_FIX_BUILD_ERROR_PROMPT = """
          - `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep`
          - `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} srpm`
          - Call `build_package` with the SRPM path, dist_git_branch, and jira_issue
-         - If build fails: use `download_artifacts` to get logs, identify the new error,
-           and save the log files to {{local_clone}}-upstream/build-logs/
+         - If build fails: use `download_artifacts` to get logs and identify the new error
 
       6. Append a summary to {{local_clone}}-upstream/build-logs/fix-attempts.md documenting:
          - What you identified as the root cause
@@ -1024,7 +1023,11 @@ async def main() -> None:
                     log_dir.mkdir(parents=True, exist_ok=True)
                     attempt_num = state.incremental_fix_attempts + 1
 
-                    _move_build_logs(state.local_clone, log_dir / f"attempt-{attempt_num}")
+                    if state.incremental_fix_attempts > 0:
+                        _move_build_logs(
+                            state.local_clone,
+                            log_dir / f"attempt-{state.incremental_fix_attempts}",
+                        )
                     _update_fix_attempts_log(log_dir, attempt_num, state.build_error)
 
                     # Create a fresh backport agent with build tools enabled for iterative testing

--- a/ymir/agents/build_agent.py
+++ b/ymir/agents/build_agent.py
@@ -33,7 +33,7 @@ def get_instructions() -> str:
       just return the error message. Otherwise, start with `builder-live.log` and try to identify
       the build failure. If not found, try the same with `root.log`. Summarize the findings
       and return them as `error`. If the build failed due to a build timeout, set `is_timeout` to `true`
-      in your output. Remove the downloaded *.log.gz files, if any.
+      in your output.
 
       General instructions:
 

--- a/ymir/agents/tests/unit/test_backport_helpers.py
+++ b/ymir/agents/tests/unit/test_backport_helpers.py
@@ -1,0 +1,104 @@
+from ymir.agents.backport_agent import _move_build_logs, _update_fix_attempts_log
+
+
+class TestMoveBuildLogs:
+    def test_moves_log_files(self, tmp_path):
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "build.log").write_text("log content")
+        (source / "root.log").write_text("root content")
+
+        target = tmp_path / "target"
+        _move_build_logs(source, target)
+
+        assert (target / "build.log").exists()
+        assert (target / "root.log").exists()
+        assert not (source / "build.log").exists()
+        assert not (source / "root.log").exists()
+
+    def test_moves_gz_files(self, tmp_path):
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "build.log.gz").write_bytes(b"\x1f\x8b fake gz")
+
+        target = tmp_path / "target"
+        _move_build_logs(source, target)
+
+        assert (target / "build.log.gz").exists()
+        assert not (source / "build.log.gz").exists()
+
+    def test_ignores_non_log_files(self, tmp_path):
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "package.spec").write_text("spec content")
+        (source / "README.md").write_text("readme")
+        (source / "build.log").write_text("log")
+
+        target = tmp_path / "target"
+        _move_build_logs(source, target)
+
+        assert (target / "build.log").exists()
+        assert not (target / "package.spec").exists()
+        assert not (target / "README.md").exists()
+        assert (source / "package.spec").exists()
+        assert (source / "README.md").exists()
+
+    def test_creates_target_directory(self, tmp_path):
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "build.log").write_text("log")
+
+        target = tmp_path / "nested" / "deep" / "target"
+        _move_build_logs(source, target)
+
+        assert target.exists()
+        assert (target / "build.log").exists()
+
+    def test_noop_when_no_logs(self, tmp_path):
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "README.md").write_text("no logs here")
+
+        target = tmp_path / "target"
+        _move_build_logs(source, target)
+
+        assert target.exists()
+        assert list(target.iterdir()) == []
+
+
+class TestUpdateFixAttemptsLog:
+    def test_creates_log_on_first_attempt(self, tmp_path):
+        _update_fix_attempts_log(tmp_path, 1, "undefined reference to 'foo'")
+
+        log = tmp_path / "fix-attempts.md"
+        assert log.exists()
+        content = log.read_text()
+        assert "# Fix Attempts Log" in content
+        assert "## Initial build failure" in content
+        assert "## Attempt 1" in content
+        assert "undefined reference to 'foo'" in content
+
+    def test_appends_on_subsequent_attempt(self, tmp_path):
+        _update_fix_attempts_log(tmp_path, 1, "first error")
+        _update_fix_attempts_log(tmp_path, 2, "second error")
+
+        content = (tmp_path / "fix-attempts.md").read_text()
+        assert "## Attempt 1" in content
+        assert "## Attempt 2" in content
+        assert "first error" in content
+        assert "second error" in content
+
+    def test_preserves_existing_content_on_append(self, tmp_path):
+        _update_fix_attempts_log(tmp_path, 1, "original error")
+        original_content = (tmp_path / "fix-attempts.md").read_text()
+
+        _update_fix_attempts_log(tmp_path, 2, "new error")
+        new_content = (tmp_path / "fix-attempts.md").read_text()
+
+        assert new_content.startswith(original_content.rstrip())
+
+    def test_error_wrapped_in_code_block(self, tmp_path):
+        _update_fix_attempts_log(tmp_path, 1, "make[2]: *** [Makefile:42] Error 1")
+
+        content = (tmp_path / "fix-attempts.md").read_text()
+        assert "```\nmake[2]: *** [Makefile:42] Error 1\n```" in content


### PR DESCRIPTION
## Summary

This PR improves the `fix_build_error` iterative workflow for the backport agent by adding persistent memory across fix iterations and slimming down the prompts.

### Changes

**Persistent memory for fix iterations:**
- Build logs (`builder-live.log`, `root.log`) are now preserved in `<upstream-repo>/build-logs/attempt-N/` directories across fix attempts, instead of being deleted after analysis.
- A `fix-attempts.md` file is seeded and appended on each iteration with the build error, giving each fresh fix agent context on what was already tried.

**Prompt optimization:**
- Replaced two verbose, nearly identical prompts (~290 lines total) with a single concise version (~55 lines) that instructs the agent to read `fix-attempts.md` before starting and not repeat failed strategies.

**Misc:**
- Fixed `restart: no` YAML parsing bug in `compose.yaml` (interpreted as boolean `False`).

### Commits

| Commit | Description |
|--------|-------------|
| `build_agent: stop deleting build logs after analysis` | Logs persist for the fix workflow |
| `backport_agent: guard against missing upstream repo in fix_build_error` | Graceful fallback instead of crash |
| `backport_agent: preserve build logs for fix iterations` | Move logs to `build-logs/attempt-0/` on initial failure |
| `backport_agent: seed fix-attempts.md as persistent memory across iterations` | Create/append fix history + per-attempt log dirs |
| `backport_agent: slim fix_build_error prompts` | Replace verbose prompts with concise version |
| `fix restart error of supervisor container` | Fix YAML `restart: no` → `restart: "no"` |