### PR TITLE
Make fork namespace configurable via FORK_NAMESPACE env var

### DIFF
--- a/openshift/deployment-mcp-gateway.yml
+++ b/openshift/deployment-mcp-gateway.yml
@@ -33,6 +33,8 @@ spec:
           value: "true"
         - name: SSE_PORT
           value: "8000"
+        - name: FORK_NAMESPACE
+          value: redhat/rhel/bot-branches
         - name: REQUESTS_CA_BUNDLE
           value: /etc/pki/tls/certs/ca-bundle.crt
         envFrom:

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -38,7 +38,6 @@ logger = logging.getLogger(__name__)
 # Maintainer (40), Owner (50)
 DEVELOPER_ACCESS_LEVEL = 30
 
-FORK_GROUP_NAMESPACE = "redhat/rhel/bot-branches"
 
 _GITLAB_COMMIT_RE = re.compile(r"^/(.+?)/-/commit/([0-9a-f]+)\.(?:patch|diff)$", re.IGNORECASE)
 _REDHAT_PATH_PREFIX = "/redhat/"
@@ -214,9 +213,12 @@ class ForkRepositoryTool(Tool[ForkRepositoryToolInput, ToolRunOptions, StringToo
         if not namespace or namespace[0] != "redhat":
             raise ToolError("Unexpected GitLab project, expected gitlab.com/redhat")
 
+        fork_namespace = os.getenv("FORK_NAMESPACE")
+
         def get_fork():
+            target = fork_namespace or project.service.user.get_username()
             for fork in project.get_forks():
-                if fork.gitlab_repo.namespace["full_path"] == FORK_GROUP_NAMESPACE:
+                if fork.gitlab_repo.namespace["full_path"] == target:
                     return fork
             return None
 
@@ -226,10 +228,14 @@ class ForkRepositoryTool(Tool[ForkRepositoryToolInput, ToolRunOptions, StringToo
         def create_fork():
             prefix = "_".join(ns.replace("centos-stream", "centos") for ns in namespace[1:])
             fork_name = (f"{prefix}_" if prefix else "") + project.gitlab_repo.name
-            data = {"name": fork_name, "path": fork_name, "namespace": FORK_GROUP_NAMESPACE}
+            data = {"name": fork_name, "path": fork_name}
+            if fork_namespace:
+                data["namespace"] = fork_namespace
             try:
                 fork = project.gitlab_repo.forks.create(data=data)
             except GitlabAPIException:
+                if not fork_namespace:
+                    raise
                 logger.info("Fork creation failed, checking if it was created by another deployment")
                 fork = get_fork()
                 if not fork:

--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from pathlib import Path
 
 import gitlab
@@ -35,14 +36,25 @@ from ymir.tools.privileged.gitlab import (
     "fork_exists",
     [False, True],
 )
+@pytest.mark.parametrize(
+    "fork_namespace",
+    [None, "redhat/rhel/bot-branches"],
+)
 @pytest.mark.asyncio
-async def test_fork_repository(repository, fork_exists):
+async def test_fork_repository(repository, fork_exists, fork_namespace):
     package = "bash"
-    fork_namespace = "redhat/rhel/bot-branches"
+    bot_username = "test-bot"
+    os.environ.pop("FORK_NAMESPACE", None)
+    if fork_namespace:
+        os.environ["FORK_NAMESPACE"] = fork_namespace
+    target_namespace = fork_namespace or bot_username
     fork_name = f"{'rhel' if '/rhel/' in repository else 'centos'}_rpms_{package}"
-    clone_url = f"https://gitlab.com/{fork_namespace}/{fork_name}.git"
+    clone_url = f"https://gitlab.com/{target_namespace}/{fork_name}.git"
+    expected_data = {"name": fork_name, "path": fork_name}
+    if fork_namespace:
+        expected_data["namespace"] = fork_namespace
     fork = flexmock(
-        gitlab_repo=flexmock(namespace={"full_path": fork_namespace}, path=fork_name),
+        gitlab_repo=flexmock(namespace={"full_path": target_namespace}, path=fork_name),
         get_git_urls=lambda: {"git": clone_url},
     )
     flexmock(GitlabProject).new_instances(fork)
@@ -52,7 +64,7 @@ async def test_fork_repository(repository, fork_exists):
             gitlab_repo=flexmock(
                 forks=flexmock()
                 .should_receive("create")
-                .with_args(data={"name": fork_name, "path": fork_name, "namespace": fork_namespace})
+                .with_args(data=expected_data)
                 .and_return(fork.gitlab_repo)
                 .mock(),
                 name=package,
@@ -63,6 +75,7 @@ async def test_fork_repository(repository, fork_exists):
             ),
             service=flexmock(
                 instance_url="https://gitlab.com",
+                user=flexmock(get_username=lambda: bot_username),
             ),
         )
     )


### PR DESCRIPTION
Default to the bot's personal namespace (original behavior) when FORK_NAMESPACE is unset, so **local development doesn't require group access**. Production sets FORK_NAMESPACE=redhat/rhel/bot-branches in the MCP gateway deployment.

Assisted-by: Claude Opus 4.6


