### PR TITLE
openshift: reduce backport agent memory limits to 4Gi; distgit sync logging; xmlto dep

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -53,6 +53,7 @@ RUN dnf -y install --allowerasing \
       javapackages-tools \
       javapackages-local \
       xmvn-tools \
+      xmlto \
       ${EXTRA_PACKAGES} \
     && dnf clean all
 

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -52,6 +52,7 @@ RUN dnf -y install --allowerasing \
       javapackages-tools \
       javapackages-local \
       xmvn-tools \
+      xmlto \
       ${EXTRA_PACKAGES} \
     && dnf clean all
 

--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -43,7 +43,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            memory: 5Gi
+            memory: 4Gi
           requests:
             memory: 2Gi
         terminationMessagePath: /dev/termination-log

--- a/openshift/deployment-backport-agent-c9s.yml
+++ b/openshift/deployment-backport-agent-c9s.yml
@@ -43,7 +43,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            memory: 5Gi
+            memory: 4Gi
           requests:
             memory: 2Gi
         terminationMessagePath: /dev/termination-log

--- a/ymir/tools/privileged/distgit.py
+++ b/ymir/tools/privileged/distgit.py
@@ -116,6 +116,13 @@ class CreateZstreamBranchTool(Tool[CreateZstreamBranchToolInput, ToolRunOptions,
                 while time.monotonic() - start_time < SYNC_TIMEOUT:
                     if await asyncio.to_thread(repo.git.ls_remote, gitlab_repo_url, branch, branches=True):
                         return StringToolOutput(result=f"Successfully created Z-Stream branch {branch}")
+                    elapsed = int(time.monotonic() - start_time)
+                    logger.info(
+                        "Waiting for GitLab mirror sync of %s branch %s (%ds elapsed)",
+                        package,
+                        branch,
+                        elapsed,
+                    )
                     await asyncio.sleep(30)
                 raise RuntimeError(
                     f"The {branch} branch wasn't synced to GitLab after {SYNC_TIMEOUT} seconds"


### PR DESCRIPTION
## Summary

- **OpenShift**: reduce backport agent memory limits from 5Gi → 4Gi to fit within the namespace quota (`limits.memory=16Gi`)
- **distgit**: add logging while waiting for GitLab mirror sync
- **Containerfiles**: install `xmlto` in c9s and c10s images (needed by backport agent)

## Test plan

- [ ] Both backport agent pods (`c9s`, `c10s`) start successfully after redeployment
- [ ] Namespace `limits.memory` quota not exceeded with both agents running
- [ ] `xmlto` available inside agent containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)