### PR TITLE
Use patch URL instead of API URL for auth headers check

### DIFF
--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -41,7 +41,7 @@ DEVELOPER_ACCESS_LEVEL = 30
 
 _GITLAB_COMMIT_RE = re.compile(r"^/(.+?)/-/commit/([0-9a-f]+)\.(?:patch|diff)$", re.IGNORECASE)
 _REDHAT_WEB_PREFIX = "/redhat/"
-_REDHAT_API_PREFIX = "/api/v4/projects/redhat"
+_REDHAT_API_PREFIX = "/api/v4/projects/redhat%2F"
 
 
 def _is_private_gitlab(url: str) -> bool:

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -40,7 +40,8 @@ DEVELOPER_ACCESS_LEVEL = 30
 
 
 _GITLAB_COMMIT_RE = re.compile(r"^/(.+?)/-/commit/([0-9a-f]+)\.(?:patch|diff)$", re.IGNORECASE)
-_REDHAT_PATH_PREFIX = "/redhat/"
+_REDHAT_WEB_PREFIX = "/redhat/"
+_REDHAT_API_PREFIX = "/api/v4/projects/redhat"
 
 
 def _is_private_gitlab(url: str) -> bool:
@@ -49,7 +50,9 @@ def _is_private_gitlab(url: str) -> bool:
     hostname = parsed.hostname or ""
     if hostname == "gitlab.cee.redhat.com":
         return True
-    return hostname == "gitlab.com" and parsed.path.startswith(_REDHAT_PATH_PREFIX)
+    if hostname != "gitlab.com":
+        return False
+    return parsed.path.startswith(_REDHAT_WEB_PREFIX) or parsed.path.startswith(_REDHAT_API_PREFIX)
 
 
 def _get_api_diff_url(url: str) -> str:


### PR DESCRIPTION
This fixes a bug introduced in 9277699 ("Fix GetPatchFromUrlTool when retrieving patches out of Redhat namespace") which breaks get_patch_from_url tool for Red Hat GitLab. The request URL never starts with "redhat", it is in API form like "https://gitlab.com/api/v4/projects/..." so instead of using that the logic should be using the original patch URL instead to make the correct determination.
