### PR TITLE
Pass changelog unmodified, let LogAgent swap the JIRA references

### DIFF
--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -781,8 +781,9 @@ async def extract_source_changelog(
     """Extract changelog messages from source dist-git commits.
 
     Iterates all upstream patch URLs, extracts the newest changelog entry
-    from each commit's spec file, strips Resolves/Related lines, and
-    combines the descriptive lines (deduplicating across commits).
+    from each commit's spec file, and combines the lines (deduplicating
+    across commits). The content is passed through as-is; the LogAgent
+    handles replacing Jira references.
     """
     upstream_clone = Path(f"{local_clone}-upstream")
     if not upstream_clone.exists():
@@ -815,8 +816,6 @@ async def extract_source_changelog(
             continue
 
         for line in entry.content:
-            if re.match(r"^\s*[-\*]?\s*(resolves|related):", line, re.IGNORECASE):
-                continue
             if line not in seen:
                 seen.add(line)
                 collected_lines.append(line)

--- a/ymir/agents/log_agent.py
+++ b/ymir/agents/log_agent.py
@@ -43,8 +43,8 @@ def get_instructions() -> str:
 
          If a source changelog message is provided in the prompt, use those lines as the
          exact changelog message content. Keep the descriptive lines exactly as-is — do not
-         rephrase, summarize, or add to them. Add the Resolves/Related line
-         for <JIRA_ISSUES>, matching the style of existing changelog entries.
+         rephrase, summarize, or add to them. In any Resolves/Related lines, replace all
+         original Jira issue references with <JIRA_ISSUES>, ensuring no duplicates remain.
 
          If no source changelog message is provided, write a new entry. In general,
          the entry should contain a short summary of the changes, ideally fitting on a single line,


### PR DESCRIPTION
Now the source changelog is passed through unmodified, and the LogAgent is told to only swap the JIRA issue references in Resolves/Related lines. This provides better changelog consistency based on our trials and also simplifies the logic making it less error prone. The downside is that the model can make a mistake when swapping JIRA references (if they are present) but that remains to be seen as so far it has behaved correctly on multiple trials.
