### PR TITLE
triage: use whole PR as patch if possible; CVE version range applicability

### DIFF
--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -14,7 +14,7 @@ arguments:
     description: "If true, skip all Jira updates (comments, labels, status changes). Default: false"
     required: false
   - name: auto_chain
-    description: "If true, include follow-up workflow note in Jira comment. Default: true"
+    description: "If true, the automated follow-up workflow will handle next steps, so no follow-up note is appended to the Jira comment. If false, a note is appended indicating that automated follow-up is planned. Default: true"
     required: false
 ---
 
@@ -290,11 +290,10 @@ You must analyze the Jira issue and decide between one of the following resoluti
         the patch URL is `https://gitlab.com/org/repo/-/merge_requests/N.patch`.
      2. Fetch and validate the PR `.patch` URL via `get_patch_from_url` — it returns
         a combined diff of all commits in the PR. Verify it contains the expected changes.
-     3. If the PR `.patch` URL is valid, use the non-.patch form of the URL
-        (e.g. `https://github.com/org/repo/pull/N`) as the single entry in `patch_urls`.
-     4. If the PR `.patch` URL cannot be fetched or is invalid, fall back to individual
+     3. If the PR `.patch` URL cannot be fetched or is invalid, fall back to individual
         commit URLs.
      Only use individual commit URLs when:
+     - Maintainer explicitly stated their preference in the rules.
      - The commits come from different PRs/MRs or were committed directly to the default
        branch without a PR/MR, OR
      - The PR `.patch` URL fetch fails.
@@ -613,7 +612,8 @@ Format the triage result and post it as a Jira comment.
    ```
    *Resolution*: postponed
    *Summary*: <summary>
-   *Waiting for*:
+   *Waiting for*:          (if single pending issue)
+   *Waiting for at least one of*:   (if multiple pending issues)
    * <pending_issue_1>
    * <pending_issue_2>
    ```
@@ -631,18 +631,30 @@ Format the triage result and post it as a Jira comment.
    *Details*: <details>
    ```
 
-2. If the applicability check was skipped, append:
+2. For **backport**, **rebase**, and **rebuild** resolutions: if `auto_chain` is false,
+   append the following note after the formatted text:
+   `_Automated individual follow-up workflow for this resolution type is planned for Q2 2026. Stay tuned._`
+   (When `auto_chain` is true, omit this note — the automated workflow handles follow-up.)
+
+3. For **open-ended-analysis** resolution, append:
+   `_Note: Automated resolution for this resolution type is not yet supported by Ymir. Manual action is required._`
+
+4. Append the following disclaimer to ALL resolution types:
+   `_By following Ymir suggestions, you agree to comply with the [Guidelines on Use of AI Generated Content|https://source.redhat.com/departments/legal/legal_compliance_ethics/compliance_folder/appendix_1_to_policy_on_the_use_of_ai_technologypdf] and [Guidelines for Responsible Use of AI Code Assistants|https://source.redhat.com/projects_and_programs/ai/wiki/code_assistants_guidelines_for_responsible_use_of_ai_code_assistants]._`
+
+5. If the applicability check was skipped, append:
    `_Note: CVE applicability check could not be performed (source preparation failed)._`
 
-3. If `dry_run` is true, end the workflow without posting.
+6. If `dry_run` is true, end the workflow without posting.
 
-4. Check whether to update Jira:
+7. Check whether to update Jira:
    - If `silent_run` is false → post the comment.
    - If `silent_run` is true → only post for `not-affected` and `postponed` resolutions;
      skip for all others.
 
-5. Post the comment using `add_jira_comment` with `issue_key` = `{{jira_issue}}`,
-   `agent_type` = `"Triage"`, and the formatted comment text.
+8. Post the comment using `add_jira_comment` with `issue_key` = `{{jira_issue}}`,
+   `agent_type` = `"Triage"`, and the formatted comment text. The comment is wrapped
+   in the template: `Output from Ymir Triage Agent: \n\n<comment>\n\n<agent warning>`
 
 ---
 

--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -224,33 +224,127 @@ You must analyze the Jira issue and decide between one of the following resoluti
 
    2.3. Validate the Fix and URL
    * First, make sure the URL is an actual patch/commit link, not an issue or bug tracker reference
+     (e.g. reject URLs containing `/issues/`, `/bug/`, `bugzilla`, `jira`, `/tickets/`)
    * Use `get_patch_from_url` to fetch content from any patch/commit URL you intend to use
-   * Validate two things:
-     1. **Is it a patch/diff?** Look for diff indicators (`diff --git`, `--- a/file +++ b/file`,
-        `@@...@@` hunk headers)
-     2. **Does it fix the issue?** Examine actual code changes to verify the fix addresses
-        the root cause. For CVE issues, verify the patch modifies the exact expressions/variables
-        involved in the vulnerability.
-   * For CVE issues, verify CVE ID match: check if the patch mentions the exact CVE ID.
-     If not, verify the vulnerability description matches what the patch fixes.
+   * Once you have the content, you must validate two things:
+     1. **Is it a patch/diff?** Look for diff indicators like:
+        - `diff --git` headers
+        - `--- a/file +++ b/file` unified diff headers
+        - `@@...@@` hunk headers
+        - `+` and `-` lines showing changes
+     2. **Does it fix the issue?** Examine the actual code changes to verify:
+        - The fix directly addresses the root cause identified in your analysis
+        - The code changes align with the symptoms described in the Jira issue
+        - The modified functions/files match those mentioned in the issue
+        - If the CVE description quotes specific code expressions or variable names
+          involved in the vulnerability, verify that the patch modifies those exact
+          expressions — not just the same file or neighboring functions
+     3. **For CVE issues - Verify CVE ID match**: If the issue is a CVE (contains CVE-YYYY-NNNNN):
+        - Check if the patch content or commit message mentions the EXACT CVE ID
+        - If the CVE ID is NOT mentioned in the patch, verify that:
+          * The vulnerability description in the CVE matches what the patch fixes
+          * The code changes address the specific vulnerability type (buffer overflow,
+            integer overflow, etc.)
+          * The affected functions/files align with the CVE details
+        - **WARNING**: Patches from bundled CVE updates (e.g., Oracle CPU, bundled library updates)
+          may fix MULTIPLE CVEs - verify you have the correct patch for THIS specific CVE
+        - If you cannot confirm the patch matches the CVE, search for alternative patches or
+          request clarification
    * Only proceed with URLs that contain valid patch content AND address the specific issue
-   * **Only use merged/accepted fixes** from upstream or Fedora. Do NOT use patches from
-     unmerged PRs, bug tracker attachments, mailing list proposals, or forks.
-   * **Check for follow-up commits**: After identifying a valid fix, check for follow-up
-     commits that complement or complete the fix. Include ALL relevant patches in your
-     patch_urls list, ordered chronologically.
+   * If the content is not a proper patch or doesn't fix the issue, continue searching for other fixes
+   * **Only use merged/accepted fixes**: Patches must come from commits that have been merged
+     into the upstream repository (or Fedora). Do NOT use patches from:
+     - Unmerged pull requests or merge requests
+     - Bug tracker attachments or discussion threads (e.g. SourceForge, Bugzilla attachments)
+     - Mailing list proposals that have not been accepted upstream
+     - Forks or personal branches that are not part of the official repository
+     If you find a relevant but unmerged patch during your investigation, mention it in the
+     clarification-needed note so a human can evaluate it, but do not use it as the basis
+     for a backport decision.
+   * **Check for follow-up commits**: After identifying a valid fix, you MUST check whether
+     there are follow-up commits that complement or complete the fix. Common patterns include:
+     - A second commit that fixes a bug or regression introduced by the first fix
+     - An incremental commit that addresses the same CVE/issue from a different angle
+       (e.g. fixing a separate code path or variant of the same vulnerability)
+     - A commit by the same or related author modifying the same files/functions
+       shortly after the primary fix
+     - A commit whose message explicitly references the first fix (e.g. "follow-up to ...",
+       "fix for ...", same CVE ID, or same bug tracker reference)
+     Search the git log around the date of the primary fix for related commits
+     (e.g. `git log <primary-fix>..HEAD -- <affected-files>`).
+     If you find follow-up commits, validate them the same way (fetch via `get_patch_from_url`
+     and verify they are real patches) and include ALL of them in your `patch_urls` list,
+     ordered chronologically (earliest first).
+     **Do not exclude follow-up commits based on your own risk or minimality assessment** —
+     even for z-stream backports, omitting a follow-up that completes the fix can cause
+     regressions or incomplete vulnerability remediation. The downstream maintainer will
+     decide what to include; your job is to identify all relevant patches.
+   * **Prefer PR/MR URL when commits originate from a single PR/MR**:
+     When all the commits fixing the issue are part of a single upstream pull request or
+     merge request (GitHub PR, GitLab MR), you MUST output the PR/MR URL as the sole entry
+     in `patch_urls` instead of listing individual commit URLs. Procedure:
+     1. Construct the PR `.patch` URL: for a GitHub PR at
+        `https://github.com/org/repo/pull/N`, the patch URL is
+        `https://github.com/org/repo/pull/N.patch`.
+        For a GitLab MR at `https://gitlab.com/org/repo/-/merge_requests/N`,
+        the patch URL is `https://gitlab.com/org/repo/-/merge_requests/N.patch`.
+     2. Fetch and validate the PR `.patch` URL via `get_patch_from_url` — it returns
+        a combined diff of all commits in the PR. Verify it contains the expected changes.
+     3. If the PR `.patch` URL is valid, use the non-.patch form of the URL
+        (e.g. `https://github.com/org/repo/pull/N`) as the single entry in `patch_urls`.
+     4. If the PR `.patch` URL cannot be fetched or is invalid, fall back to individual
+        commit URLs.
+     Only use individual commit URLs when:
+     - The commits come from different PRs/MRs or were committed directly to the default
+       branch without a PR/MR, OR
+     - The PR `.patch` URL fetch fails.
 
    2.4. Decide the Outcome
    * For non-older-z-stream issues:
-     - **Check if the fix belongs to the package or a dependency**: Before deciding on backport,
-       verify the patch modifies the package's OWN source code, not a dependency. Check the spec
-       file for `Provides: bundled(...)` entries, vendor tarballs, etc.
-       **If the fix is in a dependency**, use "rebuild" resolution instead.
-     - If the patch IS for the package's own code and passes all validations, decide backport.
+     - **CRITICAL — CVE version range check (CVE issues only):**
+       Before deciding on backport for a CVE, verify that the downstream package version
+       is within the CVE's affected upstream version range:
+       1. Extract the affected upstream version range from the CVE description or advisory
+          text (e.g. "affects versions 10.0 through 10.6"). The CVE description, Jira issue
+          summary, or linked NVD/advisory page typically states which upstream versions are
+          vulnerable.
+       2. Determine the downstream package version by reading the `Version:` field from the
+          package spec file in the CentOS Stream / RHEL dist-git repository (you already
+          checked this repo exists in step 2 of the initial analysis).
+       3. If the downstream package version is clearly **outside** the affected range (e.g.
+          the downstream ships version 7.5.1 but the CVE only affects 10.0+), the vulnerable
+          code was never present in the shipped version. In this case, use the "not-affected"
+          resolution with justification category "Vulnerable Code not Present" and explain
+          that the downstream version is outside the affected upstream version range.
+       4. If the CVE description does not specify an affected version range, or if the
+          downstream version is ambiguously close to the boundary, proceed with the backport
+          decision and let the post-triage applicability check handle it.
+       This check prevents wasted effort on backports that will produce empty cherry-picks
+       because the vulnerable code path does not exist in the downstream version.
+     - **CRITICAL — Check if the fix belongs to the package or a dependency:**
+       Before deciding on backport, verify that the patch you found modifies the package's
+       OWN source code, not the source code of a dependency. Watch for these signs that the
+       fix is in a DEPENDENCY:
+       * The patch comes from a different upstream repository than the package (e.g., a Go
+         standard library or Go module patch for a Go application, a C library patch for an
+         application that links to it, etc.)
+       * The package bundles or vendors dependencies. Check the spec file for indicators like:
+         - `Provides: bundled(golang(...))` or `Provides: bundled(...)` entries
+         - Vendor tarballs like `Source1: *-vendor.tar.gz` or `Source1: *-vendor-*.tar.*`
+       * The CVE describes a vulnerability in a library, runtime, or language (e.g., Go, Rust,
+         OpenSSL) that the package merely uses or vendors, not in the package's own code
+       **If the fix is in a dependency**, use the "rebuild" resolution instead. The package
+       will pick up the fix automatically when rebuilt against the updated dependency.
+     - If the patch IS for the package's own code and passes all validations in step 2.3,
+       your decision is **backport**. You must justify why the patch is correct and how it
+       addresses the issue.
    * For older z-stream issues:
-     - If your investigation identifies a valid fix that passes all validations, decide backport.
+     - If your investigation identifies a valid fix that passes all validations in step 2.3,
+       your decision is **backport**.
+     - You must be able to justify why the patch is correct and how it addresses the issue.
    * If investigation confirms a valid bug/CVE but fails to locate a specific fix, decide
-     clarification-needed.
+     **clarification-needed**. This is the correct choice when you are sure a problem exists
+     but cannot find the solution yourself.
    * Set the Jira fields as per the Final Step instructions below.
 
 **3. Rebuild**
@@ -373,19 +467,44 @@ This step checks whether a CVE actually affects the package by analyzing its sou
 
 6. Perform the CVE applicability analysis:
 
-   Analyze the unpacked source code to determine whether the CVE actually affects this package.
-   Consider:
-   - Is the vulnerable code present in this version of the package?
-   - For rebuild/dependency CVEs: does the package actually use the affected functionality
-     of the dependency?
-   - Does the package build against or link to the vulnerable component?
+   - Use `get_maintainer_rules` with the package name to check for maintainer-specific
+     guidelines. If rules are found, treat them as additional context — e.g. if they indicate
+     rebuilds are always relevant, classify as "Inconclusive" rather than "Not Affected".
+   - Use `get_jira_details` on `{{jira_issue}}` to understand the CVE context and what is
+     affected. Check the Jira comments — maintainers may have left notes about whether this
+     CVE is relevant. If the Jira issue does not provide sufficient context, search for more
+     information about the CVE online.
+   - If upstream fix patches are available, read them to identify the specific files and
+     functions modified by the fix.
+   - Search for those files/functions in the package source.
+   - If the vulnerable code is not present, determine why — older version that predates
+     the vulnerability? Patched downstream?
+   - For dependency rebuilds: verify whether the package uses the specific affected API/module
+     of the dependency. Check direct imports, linked libraries, and build dependencies.
+     Remember: transitive dependencies and build-time usage also count — a package that vendors
+     or bundles the dependency is affected even without a direct import.
 
    Use Red Hat justification categories when determining the package is not affected:
-   - "Vulnerable Code not Present" — the vulnerable code path does not exist
-   - "Vulnerable Code not Reachable" — the code exists but cannot be triggered
-   - "Vulnerable Code Cannot be Controlled by an Adversary" — the code is reachable but
-     cannot be exploited
-   - "Inline Mitigations Already Exist" — existing safeguards prevent exploitation
+   - "Component not Present" — the affected component/subcomponent is not included in
+     this package build
+   - "Vulnerable Code not Present" — the package includes the component but the specific
+     vulnerable code was introduced in a later version or is patched/removed downstream
+   - "Vulnerable Code not in Execute Path" — the vulnerable code exists but is not reachable
+     in normal execution (unused import, dead code, dependency API not called by this package)
+   - "Vulnerable Code cannot be Controlled by Adversary" — the vulnerable code is present
+     and reachable, but the input that triggers the vulnerability cannot be supplied by an attacker
+   - "Inline Mitigations already Exist" — additional hardening or security measures exist
+     that prevent exploitation
+
+   If affected or cannot determine with confidence, classify as "Inconclusive". Be conservative:
+   default to "Inconclusive" when unsure.
+
+   **REBUILD CAUTION**: The bar for declaring a rebuild "not affected" is very high. A false
+   negative means skipping a security rebuild entirely. Only classify as not affected if you
+   have strong, concrete evidence — e.g. the package provably does not import/link/use the
+   affected module at all. If there is any ambiguity — transitive dependencies, conditional
+   imports, build-time usage, or you simply cannot verify the full dependency chain — classify
+   as "Inconclusive".
 
    If source prep failed (using unpatched upstream source only), note this in the analysis.
 

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -390,6 +390,28 @@ TRIAGE_PROMPT = """
            completes the fix can cause regressions or incomplete vulnerability remediation.
            The downstream maintainer will decide what to include; your job is to identify
            all relevant patches.
+         * **Prefer PR/MR URL when commits originate from a single PR/MR**:
+           When all the commits fixing the issue are part of a single upstream
+           pull request or merge request (GitHub PR, GitLab MR), you MUST output
+           the PR/MR URL as the sole entry in `patch_urls` instead of listing
+           individual commit URLs. Procedure:
+           1. Construct the PR `.patch` URL: for a GitHub PR at
+              `https://github.com/org/repo/pull/N`, the patch URL is
+              `https://github.com/org/repo/pull/N.patch`.
+              For a GitLab MR at
+              `https://gitlab.com/org/repo/-/merge_requests/N`,
+              the patch URL is
+              `https://gitlab.com/org/repo/-/merge_requests/N.patch`.
+           2. Fetch and validate the PR `.patch` URL via `get_patch_from_url` —
+              it returns a combined diff of all commits in the PR. Verify it
+              contains the expected changes.
+           3. If the PR `.patch` URL cannot be fetched or is invalid, fall back
+              to individual commit URLs.
+           Only use individual commit URLs when:
+           - Maintainer explicitly stated their preference in the rules.
+           - The commits come from different PRs/MRs or were committed directly
+             to the default branch without a PR/MR, OR
+           - The PR `.patch` URL fetch fails.
 
          2.4. Decide the Outcome
          {{^is_older_zstream}}
@@ -741,7 +763,7 @@ async def run_workflow(
                         "resolution": "backport",
                         "data": {{
                         "package": "some-package",
-                        "patch_url": "https://example.com/some.patch",
+                        "patch_urls": ["https://github.com/example-org/example-repo/pull/42.patch"],
                         "justification": "This patch fixes the bug by doing X, Y, and Z.",
                         "jira_issue": "RHEL-12345",
                         "cve_id": "CVE-1234-98765",

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -393,6 +393,31 @@ TRIAGE_PROMPT = """
 
          2.4. Decide the Outcome
          {{^is_older_zstream}}
+         * **CRITICAL — CVE version range check (CVE issues only):**
+           Before deciding on backport for a CVE, verify that the downstream
+           package version is within the CVE's affected upstream version range:
+           1. Extract the affected upstream version range from the CVE description
+              or advisory text (e.g. "affects versions 10.0 through 10.6").
+              The CVE description, Jira issue summary, or linked NVD/advisory
+              page typically states which upstream versions are vulnerable.
+           2. Determine the downstream package version by reading the `Version:`
+              field from the package spec file in the CentOS Stream / RHEL
+              dist-git repository (you already checked this repo exists in
+              step 2 of the initial analysis).
+           3. If the downstream package version is clearly **outside** the
+              affected range (e.g. the downstream ships version 7.5.1 but
+              the CVE only affects 10.0+), the vulnerable code was never
+              present in the shipped version. In this case, use the
+              "not-affected" resolution with justification category
+              "Vulnerable Code not Present" and explain that the downstream
+              version is outside the affected upstream version range.
+           4. If the CVE description does not specify an affected version
+              range, or if the downstream version is ambiguously close to
+              the boundary, proceed with the backport decision and let the
+              post-triage applicability check handle it.
+           This check prevents wasted effort on backports that will produce
+           empty cherry-picks because the vulnerable code path does not exist
+           in the downstream version.
          * **CRITICAL — Check if the fix belongs to the package or a dependency:**
            Before deciding on backport, verify that the patch you found modifies the package's OWN source
            code, not the source code of a dependency. Watch for these signs that the fix is in a DEPENDENCY:

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -188,8 +188,11 @@ class BackportData(BaseModel):
 
     package: str = Field(description="Package name")
     patch_urls: list[str] = Field(
-        description="A list of URLs to the sources of the fixes "
-        "that were validated using the get_patch_from_url tool"
+        description="A list of URLs to the sources of the fixes, each validated "
+        "using the get_patch_from_url tool. Prefer a single GitHub PR / GitLab MR "
+        "URL when all commits originate from one PR/MR (e.g. "
+        "'https://github.com/org/repo/pull/42.patch'). Use individual commit URLs only "
+        "when commits come from different PRs or are committed directly."
     )
     justification: str = Field(
         description=(


### PR DESCRIPTION
- **triage: check for CVE version range**
- **triage: prefer PR/MR .patch URL over individual commit URLs for multi-commit fixes**
