### PR TITLE
pin phoenix to version 15

### DIFF
--- a/Containerfile.phoenix
+++ b/Containerfile.phoenix
@@ -2,7 +2,7 @@
 FROM fedora:44
 RUN dnf install -y python3-pip python3-numpy python3-scipy \
     && dnf clean all \
-    && pip3 install --no-cache-dir arize-phoenix \
+    && pip3 install --no-cache-dir 'arize-phoenix<16' \
     && useradd -u 1001 -g 0 -m -s /sbin/nologin phoenix
 USER 1001
 EXPOSE 6006 4317


### PR DESCRIPTION
16 has a bug that auto-downloads wasm binary on startup:

```
WASM sandbox binary pre-fetch failed: Failed to download WASM binary: <urlopen error [Errno 110] Connection timed out>
```

Signed-off-by: Tomas Tomecek <ttomecek@redhat.com>
