### PR TITLE
Support maintainer-driven patch naming and splitting in backport agent

### DIFF
--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -2,13 +2,13 @@
 description: Backport upstream patches to packages in the RHEL ecosystem — cherry-pick or git-am workflow, build verification, changelog, and merge request creation.
 arguments:
   - name: package
-    description: "Name of the package to update (e.g., 'openssl')"
+    description: "Name of the package to backport patches to (e.g., 'openssl')"
     required: true
   - name: dist_git_branch
     description: "Dist-git branch to update (e.g., 'c10s', 'rhel-9.6.0')"
     required: true
   - name: upstream_patches
-    description: "Comma-separated list of upstream patch/commit/PR URLs to backport"
+    description: "Comma-separated list of upstream patch URLs to backport"
     required: true
   - name: jira_issue
     description: "JIRA issue key (e.g., RHEL-12345)"
@@ -16,60 +16,50 @@ arguments:
   - name: cve_id
     description: "CVE identifier if the JIRA issue is a CVE (e.g., CVE-2025-12345). Default: null"
     required: false
-  - name: justification
-    description: "Justification text for the backport, included in the merge request description. Default: null"
-    required: false
-  - name: fix_version
-    description: "Fix version string used to determine Z-stream instruction variant (e.g., 'rhel-9.4.0'). Default: same as dist_git_branch"
-    required: false
   - name: dry_run
     description: "If true, skip JIRA status changes, MR creation, and label updates. Default: false"
     required: false
   - name: max_build_attempts
     description: "Maximum number of build retry attempts. Default: 10"
     required: false
-  - name: max_incremental_fix_attempts
-    description: "Maximum number of incremental cherry-pick fix attempts when build fails. Default: same as max_build_attempts"
-    required: false
 ---
 
 # Backport Skill
 
-You are a Red Hat Enterprise Linux developer performing an end-to-end backport of upstream patches to a dist-git package.
+You are a Red Hat Enterprise Linux developer performing an end-to-end backport of upstream patches to a package in the RHEL ecosystem.
 
 ## Input Arguments
 
 - `package`: {{package}}
 - `dist_git_branch`: {{dist_git_branch}}
-- `upstream_patches`: {{upstream_patches}} (comma-separated URLs)
+- `upstream_patches`: {{upstream_patches}}
 - `jira_issue`: {{jira_issue}}
 - `cve_id`: {{cve_id}}
-- `justification`: {{justification}}
-- `fix_version`: {{fix_version}} (defaults to `dist_git_branch` if not provided)
 - `dry_run`: {{dry_run}}
 - `max_build_attempts`: {{max_build_attempts}}
-- `max_incremental_fix_attempts`: {{max_incremental_fix_attempts}}
 
 ## Tools
 
 This skill uses the following tools. Do not restrict tool usage — use any tool available as needed.
 
-**MCP Tools (privileged, called via MCP gateway):**
+**MCP Tools (called via MCP gateway):**
 - `change_jira_status` — Change the status of a JIRA issue
-- `add_jira_comment` — Post a comment to a JIRA issue
-- `edit_jira_labels` — Add or remove labels on a JIRA issue
-- `fork_repository` — Fork a dist-git repository
-- `create_zstream_branch` — Create a Z-stream branch for a package in internal dist-git
-- `clone_repository` — Clone a dist-git repository to a local path
+- `fork_repository` — Fork a dist-git repository on GitLab
+- `create_zstream_branch` — Create a z-stream branch for a package (non-CentOS Stream branches only)
+- `clone_repository` — Clone a Git repository to a local path
 - `download_sources` — Download sources from the lookaside cache
-- `get_patch_from_url` — Fetch patch content from a URL
+- `get_patch_from_url` — Fetch patch/commit content from a URL
 - `push_to_remote_repository` — Push a branch to a remote repository
 - `open_merge_request` — Open a merge request against dist-git
 - `add_merge_request_labels` — Add labels to a merge request
-- `build_package` — Build an SRPM in Copr and return results
-- `download_artifacts` — Download build log artifacts
+- `add_jira_comment` — Post a comment to a JIRA issue
+- `edit_jira_labels` — Add or remove labels on a JIRA issue
+- `build_package` — Build an SRPM and return results
+- `download_artifacts` — Download build log artifacts (*.log.gz)
+- `get_maintainer_rules` — Get maintainer-specific rules and guidelines for a package
 
-**Local Tools (unprivileged — text, filesystem, git, packaging):**
+**Local Tools (text, filesystem, git, upstream):**
+- `run_shell_command` — Execute shell commands (git operations, builds, etc.)
 - `create` — Create new files
 - `view` — View file or directory contents
 - `str_replace` — String replacement in files
@@ -78,34 +68,35 @@ This skill uses the following tools. Do not restrict tool usage — use any tool
 - `search_text` — Search for text patterns in files
 - `get_cwd` — Get the current working directory
 - `remove` — Delete files
-- `run_shell_command` — Execute shell commands (use as last resort; prefer native tools)
-- `git_patch_create` — Create patch files from git state
-- `git_patch_apply` — Apply a patch file, reporting conflicts
-- `git_apply_finish` — Finish a patch application (after conflict resolution)
+- `git_patch_create` — Generate patch files from git repository changes
+- `git_patch_apply` — Apply a patch file using git am
+- `git_apply_finish` — Finish an in-progress git am session
 - `git_log_search` — Search git log for issue/CVE references
-- `git_prepare_package_sources` — Initialize a git repository in unpacked sources
-- `detect_distgit_source` — Detect whether a patch URL originates from a dist-git source
-- `get_package_info` — Extract version and patch list from a spec file
-- `extract_upstream_repository` — Parse commit/PR/compare URLs to extract repo URL and commit hash
-- `clone_upstream_repository` — Clone an upstream repository into a working directory
-- `find_base_commit` — Find and checkout the tag/commit matching a package version in upstream
-- `apply_downstream_patches` — Apply existing dist-git patches to a cloned upstream repository
-- `cherry_pick_commit` — Cherry-pick a single commit in an upstream repository
-- `cherry_pick_continue` — Complete a cherry-pick after conflict resolution
+- `git_prepare_package_sources` — Prepare package sources for patch application
+- `detect_distgit_source` — Check if a patch URL is from a dist-git source
+- `get_package_info` — Get package version, patch list, and strip levels from spec file
+- `extract_upstream_repository` — Extract repository URL and commit hash from a patch URL
+- `clone_upstream_repository` — Clone an upstream repository
+- `find_base_commit` — Find the base commit for a package version in upstream
+- `apply_downstream_patches` — Apply existing dist-git patches to upstream repository
+- `cherry_pick_commit` — Cherry-pick a specific commit
+- `cherry_pick_continue` — Continue after resolving cherry-pick conflicts
 - `add_changelog_entry` — Add a changelog entry to an RPM spec file
 - `update_release` — Bump the Release field in a spec file
-- `map_version` — Map RHEL major version to current Y-stream and Z-stream versions
-- `get_maintainer_rules` — Get maintainer-specific rules and guidelines for a package
 
 **Other:**
 - Web search via DuckDuckGo or equivalent
-- Bash tool for shell commands (e.g., `git`, `centpkg`, `rhpkg`, `curl`, `wc`)
+- Bash tool for shell commands (e.g., `git`, `centpkg`, `rhpkg`, `curl`)
 
 ## Workflow
 
 Execute the following steps in order. Track state across steps (paths, flags, results).
 
 Determine `pkg_tool` from the branch: if `dist_git_branch` starts with `c` and ends with `s` (e.g., `c10s`, `c9s`), use `centpkg`; otherwise use `rhpkg --offline --released`.
+
+Initialize `attempts_remaining` to `max_build_attempts` (default 10). Initialize `build_error` as null. Initialize `used_cherry_pick_workflow` as false. Initialize `incremental_fix_attempts` to 0.
+
+Parse `upstream_patches` as a comma-separated list of URLs. Save as a list.
 
 ### Step 1: Change JIRA Status
 
@@ -117,120 +108,164 @@ If `dry_run` is true, skip this step.
 
 ### Step 2: Fork and Prepare Dist-Git
 
-1. Fork the dist-git repository:
-   - Determine the namespace: if `dist_git_branch` starts with `c` and ends with `s`, use `centos-stream`; otherwise use `rhel`.
-   - The repository URL is `https://gitlab.com/redhat/<namespace>/rpms/{{package}}`.
-   - Call `fork_repository` with the repository URL. Save the returned `fork_url`.
-   - For non-CentOS-Stream branches (rhel-* branches), call `create_zstream_branch` with `package` = `{{package}}` and `branch` = `{{dist_git_branch}}`.
-   - Call `clone_repository` with the repository URL, branch `{{dist_git_branch}}`, and a local clone path. Save the `local_clone` path.
-   - Create a working branch: `git checkout -B automated-package-update-{{jira_issue}}` in the clone. Save this as `update_branch`.
-2. Set the working directory to `local_clone`.
-3. Call `download_sources` with `dist_git_path` = `local_clone`, `package` = `{{package}}`, `dist_git_branch` = `{{dist_git_branch}}`.
-4. Run `<pkg_tool> --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep` to unpack sources.
-5. Determine `unpacked_sources` — the path to the unpacked source directory tree. This is typically `<local_clone>/<name>-<version>-build/<buildsubdir>` (RPM 4.20+) or `<local_clone>/<buildsubdir>` (older RPM). Read the spec file to find `%{name}`, `%{version}`, and `%{buildsubdir}`.
-6. Download each upstream patch URL to a local file named `{{jira_issue}}-<N>.patch` (0-indexed) using `get_patch_from_url`, and save the content to `<local_clone>/{{jira_issue}}-<N>.patch`.
-7. Initialize workflow tracking flags: `used_cherry_pick_workflow = false`, `incremental_fix_attempts = 0`.
+1. Determine the namespace from the branch:
+   - If `dist_git_branch` starts with `c` and ends with `s`: namespace is `centos-stream`.
+   - Otherwise: namespace is `rhel`.
+2. Fork the repository by calling `fork_repository` with `repository` = `https://gitlab.com/redhat/<namespace>/rpms/{{package}}`. Save the returned `fork_url`.
+3. If the namespace is `rhel` (not CentOS Stream), call `create_zstream_branch` with `package` = `{{package}}` and `branch` = `{{dist_git_branch}}` to ensure the branch exists.
+4. Clone the repository by calling `clone_repository` with the repository URL, `branch` = `{{dist_git_branch}}`, and a local clone path. Save `local_clone`.
+5. Create a working branch: `git checkout -B automated-package-update-{{jira_issue}}` in `local_clone`. Save `update_branch` = `automated-package-update-{{jira_issue}}`.
+6. Set the working directory to `local_clone`.
+7. Download sources from the lookaside cache by calling `download_sources` with `dist_git_path` = `local_clone`, `package` = `{{package}}`, and `dist_git_branch` = `{{dist_git_branch}}`.
+8. Run initial prep to unpack sources:
+   `<pkg_tool> --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep`
+   (where `<pkg_tool>` is `centpkg` or `rhpkg --name=... --namespace=rpms --release=... --offline --released` depending on branch type)
+9. Identify the unpacked sources directory. Save as `unpacked_sources`.
+10. Download each upstream patch URL using `get_patch_from_url` and save as `{{jira_issue}}-<N>.patch` (0-indexed) in `local_clone`.
 
-### Step 3: Determine Instruction Variant
+Reset `used_cherry_pick_workflow` to false and `incremental_fix_attempts` to 0.
 
-Determine whether this is an older Z-stream branch using `fix_version` (or `dist_git_branch` if `fix_version` is not set):
-- Use `map_version` to get the current Z-stream version for the RHEL major version derived from `fix_version`.
-- If `fix_version` targets an older Z-stream (a minor version lower than the current Z-stream for the same major version) → use **Section A: Z-Stream Backport Instructions**.
-- Otherwise → use **Section B: Standard Backport Instructions**.
+### Step 3: Run Backport
 
-### Step 4: Run Backport
-
-Follow the appropriate instruction set (Section A or B) to perform the backport.
+Determine which instruction set to follow:
+- If `dist_git_branch` is a z-stream branch (matches pattern `rhel-<N>.<N>.0` or `rhel-<N>.<N>`), follow **Section B** (Z-Stream Backport Instructions).
+- For CentOS Stream branches (e.g., `c10s`, `c9s`), follow **Section A** (Regular Backport Instructions).
 
 Provide the following context to the instructions:
-- `local_clone`: path from Step 2
-- `unpacked_sources`: path from Step 2
-- `package`: `{{package}}`
-- `dist_git_branch`: `{{dist_git_branch}}`
-- `jira_issue`: `{{jira_issue}}`
-- `cve_id`: `{{cve_id}}`
-- `upstream_patches`: list of URLs from `{{upstream_patches}}`
-- `pkg_tool`: determined above
+- `<LOCAL_CLONE>`: `local_clone` path from Step 2
+- `<UNPACKED_SOURCES>`: `unpacked_sources` path from Step 2
+- `<PACKAGE>`: `{{package}}`
+- `<DIST_GIT_BRANCH>`: `{{dist_git_branch}}`
+- `<JIRA_ISSUE>`: `{{jira_issue}}`
+- `<CVE_ID>`: `{{cve_id}}`
+- `<UPSTREAM_PATCHES>`: the parsed list of patch URLs
+- `<PKG_TOOL>`: `pkg_tool` determined above
+- `<BUILD_ERROR>`: current `build_error` (null on first attempt, set on retry)
+
+If `build_error` is set (this is a retry after build failure): treat this as a repeated backport. Everything from the previous attempt has been reset. Follow the instructions from the start and fix the issue described in `build_error`.
 
 The backport must produce:
 - `success`: boolean
-- `status`: detailed description of steps taken
+- `status`: detailed description of steps taken including conflict resolution
 - `srpm_path`: absolute path to generated SRPM (if successful)
 - `error`: error message (if failed)
 
-If the backport fails (success=false), skip to **Step 11: Comment in JIRA** with the error.
+If the backport succeeds:
+- Save the status to `backport_log`.
+- Determine whether the cherry-pick workflow was used:
+  Check if the upstream repository directory (`<local_clone>-upstream`) exists and contains more than 1 commit (`git -C <local_clone>-upstream rev-list --count HEAD`). If so, set `used_cherry_pick_workflow` to true.
+- Proceed to Step 4.
 
-After a successful backport, detect if the cherry-pick workflow was used by checking whether a `<local_clone>-upstream` directory exists with more than 1 commit. Set `used_cherry_pick_workflow` accordingly.
+If the backport fails (success=false), skip to **Step 10: Comment in JIRA** with the error.
 
-### Step 5: Run Build
+### Step 4: Build Package
 
-1. Call `build_package` with the SRPM path from Step 4, `dist_git_branch`, and `jira_issue`.
-2. If the build **succeeds** → proceed to Step 6.
-3. If the build **timed out** (`is_timeout` = true) → proceed to Step 6 (treat as success).
+1. Call `build_package` with the SRPM path from Step 3, `dist_git_branch`, and `jira_issue`.
+2. If the build **succeeds** → proceed to Step 5.
+3. If the build **timed out** (`is_timeout` = true) → proceed to Step 5 (treat as success).
 4. If the build **fails**:
-   a. Decrement `attempts_remaining` (initialized to `max_build_attempts`).
-   b. If `attempts_remaining <= 0` → set `success=false`, `error="Unable to successfully build the package in N attempts"`, skip to Step 11.
-   c. If `used_cherry_pick_workflow` is true → go to **Step 5a: Fix Build Error**.
-   d. Otherwise (git-am workflow) → go back to **Step 2** to reset and retry from scratch.
+   a. Decrement `attempts_remaining`.
+   b. If `attempts_remaining <= 0` → set `success=false`, `error="Unable to successfully build the package in <max_build_attempts> attempts"`, skip to Step 10.
+   c. Save the build error details to `build_error`.
+   d. If `used_cherry_pick_workflow` is true AND the upstream repo directory (`<local_clone>-upstream`) exists → proceed to **Step 4a** (Incremental Build Fix).
+   e. Otherwise (git-am workflow) → go back to **Step 2** to reset and retry the entire backport with `build_error` as context.
 
-#### Step 5a: Fix Build Error (Cherry-Pick Workflow Only)
+When analyzing build failures:
+1. Download all `*.log.gz` files returned in `artifacts_urls` (if any) using `download_artifacts`.
+2. Start with `builder-live.log` to identify the build failure. If not found, try `root.log`.
+3. IMPORTANT: Before viewing log files, check their size using `wc -l`. If a log file has more than 2000 lines, view only the LAST 1000 lines.
+4. Summarize the failure as the `build_error` for the retry.
+5. Remove the downloaded `*.log.gz` files after analysis.
 
-This step attempts to fix build errors by finding and cherry-picking prerequisite commits or manually adapting code in the upstream repository. It can be called iteratively.
+#### Step 4a: Incremental Build Fix (Cherry-Pick Workflow)
 
-1. Increment `incremental_fix_attempts`.
-2. If `incremental_fix_attempts > max_incremental_fix_attempts` → set `success=false`, `error="Unable to fix build errors after N incremental fix attempts. Last error: ..."`, skip to Step 11.
-3. Archive build logs and record the error:
-   a. Create `<local_clone>-upstream/build-logs/` directory if it doesn't exist.
-   b. If `incremental_fix_attempts > 1`, move all `.log` and `.log.gz` files from `<local_clone>` to `<local_clone>-upstream/build-logs/attempt-<previous_attempt>/`.
-   c. Create or append to `<local_clone>-upstream/build-logs/fix-attempts.md` with the current attempt number and the build error text.
-4. Follow the **Fix Build Error Instructions** (Section C or D depending on the branch variant) with the current `build_error`.
-5. The fix attempt produces a new `success`/`error`/`srpm_path`.
-6. If the fix **succeeds** (build passes) → reset `incremental_fix_attempts = 0`, proceed to Step 6.
-7. If the fix **fails** → update `build_error` with the new error, go back to Step 5a.
+This sub-step only runs when the cherry-pick workflow was used and the build failed.
+The upstream repository at `<local_clone>-upstream` has all previous work intact.
 
-### Step 6: Update Release
+1. Create the build logs directory: `<local_clone>-upstream/build-logs/`.
+2. Move build log files (`*.log`, `*.log.gz`) from `local_clone` to `<local_clone>-upstream/build-logs/attempt-<incremental_fix_attempts>/`.
+3. Create or append to `<local_clone>-upstream/build-logs/fix-attempts.md` documenting the current attempt number and the build error to fix.
+4. Follow **Section C** (Fix Build Error Instructions) to attempt a fix, providing:
+   - `<LOCAL_CLONE>`: `local_clone`
+   - `<UNPACKED_SOURCES>`: `unpacked_sources`
+   - `<PACKAGE>`: `{{package}}`
+   - `<DIST_GIT_BRANCH>`: `{{dist_git_branch}}`
+   - `<JIRA_ISSUE>`: `{{jira_issue}}`
+   - `<CVE_ID>`: `{{cve_id}}`
+   - `<UPSTREAM_PATCHES>`: the parsed list of patch URLs
+   - `<PKG_TOOL>`: `pkg_tool`
+   - `<BUILD_ERROR>`: current `build_error`
 
-Bump the Release field in the spec file using the `update_release` tool with `package` = `{{package}}`, `dist_git_branch` = `{{dist_git_branch}}`, and `rebase` = `false`.
+   The fix must produce:
+   - `success`: boolean (true if the build passes after the fix)
+   - `status`: description of the fix
+   - `srpm_path`: path to SRPM (if successful)
+   - `error`: error message (if failed)
 
-If this fails, set `success=false` with the error and skip to Step 11.
+5. If the fix succeeds (build passes):
+   - Save the status to `backport_log`.
+   - Reset `incremental_fix_attempts` to 0.
+   - Proceed to Step 5.
+6. If the fix fails:
+   a. Save the new error to `build_error`.
+   b. Increment `incremental_fix_attempts`.
+   c. If `incremental_fix_attempts < max_build_attempts` → repeat from sub-step 1 with the new build error.
+   d. If all attempts exhausted → set `success=false`, `error="Unable to fix build errors after <max_build_attempts> incremental fix attempts. Last error: <error>"`, skip to Step 10.
 
-### Step 7: Stage Changes
+### Step 5: Update Release
 
-1. Read the spec file and extract all patch filenames referenced by `Patch:` tags.
-2. Stage the spec file and all referenced patch files using `git add`:
-   - `{{package}}.spec`
-   - Each patch file listed in the spec
-3. Do NOT stage temporary or pre-downloaded patch files that are not referenced in the spec.
+Bump the Release field in the spec file `{{package}}.spec` for package `{{package}}` on branch `{{dist_git_branch}}`. This is NOT a rebase, so increment the release appropriately.
 
-If this fails, set `success=false` with the error and skip to Step 11.
+If this fails, set `success=false` with the error and skip to Step 10.
 
-If the changelog/log step has already been completed (from a previous iteration), skip to Step 9.
+### Step 6: Stage Changes
 
-### Step 8: Generate Changelog and Commit Message
+1. Read the spec file to find all `Patch` tags and their expanded file locations.
+2. Build the list of files to stage: `{{package}}.spec` plus all patch files referenced by `Patch` tags.
+3. Stage each file using `git add --all <file>`.
 
-1. Run `git diff --cached --stat` to see changed files.
-2. Examine changes in each file individually: `git diff --cached -- <filename>` (do NOT run `git diff --cached` without a path — patch files can be very large).
-3. Add a new changelog entry to the spec file using `add_changelog_entry`. Match the style of previous entries. The entry should contain:
-   - A short summary of user-facing changes (not technical packaging details)
-   - A line referencing the JIRA issue: `- Resolves: {{jira_issue}}`
-4. Generate a commit message title (max 80 characters, descriptive).
-5. Generate a commit message description (short paragraph, lines max 80 characters). No need to reference the JIRA issue — it will be appended later.
+If this fails, set `success=false` with the error and skip to Step 10.
 
-For Z-stream backports, check if the source dist-git commits contain changelog entries that can be reused. If so, use those lines as the exact changelog content.
+If the changelog/log step has already been completed (from a previous iteration), skip to Step 8.
 
-Save the `title` and `description` for Step 9.
+### Step 7: Generate Changelog and Commit Message
 
-Then go back to **Step 7** to re-stage changes (the changelog was just modified).
+1. If using the z-stream dist-git workflow (Section B, approach A) and the upstream clone directory
+   (`<local_clone>-upstream`) exists, attempt to extract changelog messages from the source dist-git commits:
+   - For each upstream patch URL, extract the commit hash from the URL.
+   - Use `git -C <local_clone>-upstream show <commit_hash>:{{package}}.spec` to read the spec file at that commit.
+   - Parse the newest changelog entry and extract descriptive lines (skip lines matching `Resolves:` or `Related:`).
+   - Combine unique descriptive lines as `source_changelog`.
 
-### Step 9: Commit, Push, and Open Merge Request
+2. Run `git diff --cached --stat` to see which files have been changed.
 
-1. Create a git commit with the following message:
+3. Examine changes in each file individually: `git diff --cached -- <filename>` (do NOT run `git diff --cached` without a path — patch files can be very large).
+
+4. Add a new changelog entry to the spec file using `add_changelog_entry`. Examine the previous changelog entries and try to use the same style.
+   - If a `source_changelog` was extracted, use those lines as the exact changelog message content. Keep the descriptive lines exactly as-is — do not rephrase, summarize, or add to them. Add the Resolves/Related line for `{{jira_issue}}`, matching the style of existing changelog entries.
+   - If no `source_changelog` was extracted, write a new entry containing:
+     - A short summary of the user-facing changes (not technical packaging details)
+     - A line referencing the JIRA issue: `- Resolves: {{jira_issue}}`
+
+5. Generate a title for the commit message and merge request. It should be descriptive but no longer than 80 characters.
+
+6. Generate a description as a short paragraph for the commit message and merge request. Line length should not exceed 80 characters. Do NOT include `Resolves:` lines — JIRA references are appended separately.
+
+Save the `title` and `description` for Step 8.
+
+Then go back to **Step 6** to re-stage changes (the changelog was just modified).
+
+### Step 8: Commit, Push, and Open Merge Request
+
+1. Construct the formatted patches list (one per line, prefixed with ` - `).
+
+2. Create a git commit with the following message:
    ```
    <title>
 
    <description>
 
-   [CVE: <cve_id>]  ← only if cve_id is set
+   [CVE: <cve_id>]  (only if cve_id is set)
    Upstream patches:
     - <patch_url_1>
     - <patch_url_2>
@@ -241,74 +276,84 @@ Then go back to **Step 7** to re-stage changes (the changelog was just modified)
    Assisted-by: Ymir
    ```
 
-2. If `dry_run` is true, stop after the commit (do not push or create MR).
+3. If `dry_run` is true, stop after the commit (do not push or create MR).
 
-3. Push the branch using `push_to_remote_repository` with `repository` = `fork_url`, `clone_path` = `local_clone`, `branch` = `update_branch`, and `force` = `true`.
+4. Push the branch to the fork using `push_to_remote_repository` with:
+   - `repository`: `fork_url`
+   - `clone_path`: `local_clone`
+   - `branch`: `update_branch`
+   - `force`: true
 
-4. Open a merge request using `open_merge_request` with:
+5. Construct the MR description:
+   ```
+   <description>
+
+   Upstream patches:
+    - <patch_url_1>
+    - <patch_url_2>
+
+   Resolves: {{jira_issue}}
+
+   Backporting steps:
+
+   <backport_status from backport_log>
+
+   ---
+
+   > **Warning: AI-Generated MR**: Created by Ymir AI assistant. AI may make mistakes,
+   select incorrect patches, or miss dependencies. **Carefully review the changes.
+   Human RHEL maintainer needs to approve this contribution before merging.**
+   ```
+
+6. Open a merge request using `open_merge_request` with:
    - `fork_url`: from Step 2
    - `target`: `{{dist_git_branch}}`
    - `source`: `update_branch` from Step 2
-   - `title`: the title from Step 8
-   - `description`:
-     ```
-     <description>
+   - `title`: the title from Step 7
+   - `description`: the MR description constructed above
 
-     Upstream patches:
-      - <patch_url_1>
-      - <patch_url_2>
+7. Add label `ymir_backport` to the merge request using `add_merge_request_labels`.
 
-     [<justification> — only if justification is set]
-     Resolves: {{jira_issue}}
+8. Save `merge_request_url`.
 
-     Backporting steps:
+If the commit, push, or MR creation fails, set `success=false` with the error but continue to Step 9.
 
-     <backport_status>
+### Step 9: Add FuSa Label
 
-     ---
-
-     > **⚠️ AI-Generated MR**: Created by Ymir AI assistant. AI may make mistakes,
-     select incorrect patches, or miss dependencies. **Carefully review the changes.
-     Human RHEL maintainer needs to approve this contribution before merging.**
-     ```
-
-5. Add the `ymir_backport` label to the merge request using `add_merge_request_labels`.
-
-Save `merge_request_url` and whether it was newly created.
-
-If this fails, set `success=false` with the error but continue to Step 10.
-
-### Step 10: Add FuSa Label
-
-If the package is a FuSa (Functional Safety) package on a FuSa branch (c9s or rhel-9.N.0 where N is 1-10):
+If the package is a FuSa (Functional Safety) package on a FuSa branch (`c9s` or `rhel-9.<N>.0` where N is 1-10):
 1. If `dry_run` is false:
    - Add the `fusa` label to the JIRA issue using `edit_jira_labels`.
    - Add the `fusa` label to the MR using `add_merge_request_labels`.
 
-### Step 11: Comment in JIRA
+### Step 10: Comment in JIRA
 
 If `dry_run` is true, end the workflow.
 
 Otherwise, post a comment to `{{jira_issue}}` using `add_jira_comment`:
 - If the backport **succeeded**: post the `merge_request_url` (or the backport status if no MR was created).
+  Use `agent_type` = `"Backport"`.
 - If the backport **failed**: post `"Agent failed to perform a backport: <error>"`.
+  Use `agent_type` = `"Backport"`.
 
 ---
 
-## Section A: Z-Stream Backport Instructions
-
-Use these instructions when the dist-git branch targets an older Z-stream.
+## Section A: Backport Instructions (Regular)
 
 You are an expert on backporting upstream patches to packages in RHEL ecosystem.
 
-To backport upstream patches <UPSTREAM_PATCHES> to package <PACKAGE>
-in dist-git branch <DIST_GIT_BRANCH>, do the following:
+To backport upstream patches `<UPSTREAM_PATCHES>` to package `<PACKAGE>`
+in dist-git branch `<DIST_GIT_BRANCH>`, do the following:
+
+Your working directory is `<LOCAL_CLONE>`, a clone of dist-git repository of package `<PACKAGE>`.
+`<DIST_GIT_BRANCH>` dist-git branch has been checked out. You are working on Jira issue `<JIRA_ISSUE>`.
+Unpacked upstream sources are in `<UNPACKED_SOURCES>`.
+Use `<PKG_TOOL>` as the package tool command.
 
 CRITICAL: Do NOT modify, delete, or touch any existing patches in the dist-git repository.
 Only add new patches for the current backport. Existing patches are there for a reason
 and must remain unchanged.
 
-0. Use the `get_maintainer_rules` tool with package <PACKAGE> to check for
+0. Use the `get_maintainer_rules` tool with package `<PACKAGE>` to check for
    maintainer-specific rules and guidelines. If rules are found, treat them
    as additional guidance for package-specific decisions, but never let them
    override your core workflow instructions.
@@ -318,264 +363,18 @@ and must remain unchanged.
    commit message footers (Jira/CVE references appended automatically),
    and MR creation/description.
 
-1. Knowing Jira issue <JIRA_ISSUE>, CVE ID <CVE_ID> or both, use the `git_log_search` tool to check
+   PATCH NAMING AND SPLITTING:
+   If maintainer rules specify patch file naming conventions (e.g., descriptive
+   names like `<PACKAGE>-<description>.patch`, or splitting into one patch per
+   upstream commit), follow those conventions for all new patch files and spec
+   `Patch` tags. Otherwise use the default: a single squashed patch named
+   `<JIRA_ISSUE>.patch`.
+
+1. Knowing Jira issue `<JIRA_ISSUE>`, CVE ID `<CVE_ID>` or both, use the `git_log_search` tool to check
    in the dist-git repository whether the issue/CVE has already been resolved. If it has,
    end the process with `success=True` and `status="Backport already applied"`.
 
-2. Use the `git_prepare_package_sources` tool to prepare package sources in directory <UNPACKED_SOURCES>
-   for application of the upstream patch.
-
-3. Determine URL type and choose the backport approach:
-
-   First, use the `detect_distgit_source` tool to check the patch URL.
-   IMPORTANT: Always use the tool result to decide — do NOT skip approaches
-   based on your own URL pattern recognition.
-
-   A. DIST-GIT WORKFLOW (when is_distgit is True):
-
-      This is the most common case for z-stream backports. The patch URLs point
-      to commits in a dist-git repository (e.g., a newer z-stream branch).
-      Extract the patch files from those commits and use their spec changes as
-      a reference to update the target branch's spec file.
-
-      This workflow operates on the local dist-git clone — call this <LOCAL_CLONE>. There is no separate
-      <UPSTREAM_REPO>. All commits come from the same repository.
-
-      3a. For each URL in <UPSTREAM_PATCHES>, use `extract_upstream_repository`
-          tool to get the repository URL and commit hash.
-          Collect all commit hashes.
-          If extraction fails for any URL, fall back to approach C.
-
-      3b. Clone the source dist-git repository:
-          - Use `clone_repository` tool with:
-            * repository: the repository URL from step 3a
-            * clone_path: current working directory with `-upstream` suffix
-              (e.g., if working in /git-repos/RHEL-12345/pkg, use
-              /git-repos/RHEL-12345/pkg-upstream) — call this <DISTGIT_SOURCE>
-            * Do NOT set branch — omit it so all refs are fetched
-          - If clone fails, fall back to approach C.
-
-      3c. For EACH commit hash from step 3a, examine and extract:
-          - Examine what the commit changed:
-            `git -C <DISTGIT_SOURCE> show <commit_hash> --stat`
-          - Identify which files are new patch files and what spec changes
-            were made.
-          - Extract new patch file(s) added by the commit into the local
-            dist-git clone working tree:
-            `git -C <DISTGIT_SOURCE> show <commit_hash>:<patch_filename> > <LOCAL_CLONE>/<patch_filename>`
-          - Examine the spec file changes for reference:
-            `git -C <DISTGIT_SOURCE> diff <commit_hash>^..<commit_hash> -- *.spec`
-          - Note what Patch tags and `%prep` entries were added. Use this as
-            reference for step 4 to apply equivalent changes to the target
-            branch's spec file, adapting patch numbering as needed.
-
-      3d. After processing all commits, continue to step 4 to update the
-          spec file with ALL new patches.
-
-   B. UPSTREAM CHERRY-PICK WORKFLOW (when is_distgit is False — try this first):
-
-      Used when the patch URL points to an upstream source repository (e.g.,
-      GitHub, upstream GitLab). This happens when Jira issue comments explicitly
-      instruct to backport from the upstream.
-
-      IMPORTANT: This workflow uses TWO separate git repositories:
-      - <UNPACKED_SOURCES>: Git repository (from Step 2) containing
-        unpacked and committed upstream sources
-      - <UPSTREAM_REPO>: A temporary upstream repository clone
-        (created in step 3g with -upstream suffix)
-
-      3e. Extract upstream repository information:
-          - Use `extract_upstream_repository` tool with the upstream fix URL
-          - This extracts the repository URL and commit hash
-          - If extraction fails, fall back to approach C
-
-      3f. Get package information from dist-git:
-          - Use `get_package_info` tool with the spec file path from <UNPACKED_SOURCES>
-          - This provides the package version, list of existing patch filenames,
-            and per-patch strip levels (patch_strip_levels)
-
-      3g. Clone the upstream repository to a SEPARATE directory:
-          - Use `clone_upstream_repository` tool with:
-            * repository_url: from step 3e
-            * clone_directory: current working directory (the dist-git repository root)
-            * The tool automatically creates a directory with -upstream suffix as <UPSTREAM_REPO>
-          - Steps 3h-3k work in <UPSTREAM_REPO>, NOT in <UNPACKED_SOURCES>
-
-      3h. Find and checkout the base version in upstream:
-          - Use `find_base_commit` tool with <UPSTREAM_REPO> path and package version from 3f
-          - If no matching tag found, try to find the base commit manually
-            using `view` and `run_shell_command` tools
-          - Look for any tags or commits that might correspond to the package version
-          - Only fall back to approach C if you cannot find any reasonable base commit
-
-      3i. Apply existing patches from dist-git to upstream:
-          - Use `apply_downstream_patches` tool with:
-            * repo_path: <UPSTREAM_REPO> (where to apply)
-            * patches_directory: current working directory (dist-git root where patch files are located)
-            * patch_files: list from step 3f
-            * patch_strip_levels: dict from step 3f (maps each patch filename to its -p strip level)
-          - This recreates the current package state in <UPSTREAM_REPO>
-          - The tool automatically records the base commit for patch generation
-          - If any patch fails to apply, immediately fall back to approach C
-
-      3j. Cherry-pick the fix in upstream:
-          GETTING COMMITS:
-            FOR PULL REQUESTS (if is_pr is True from step 3e):
-              * Download the PR patch: `curl -L <original_url> -o /tmp/pr.patch`
-              * Parse commit hashes from lines starting with "From <hash>"
-              * Fetch PR branch: `git -C <UPSTREAM_REPO> fetch origin pull/<pr_number>/head:pr-branch`
-              * Skip any merge commits — only cherry-pick non-merge commits
-            FOR SINGLE COMMITS (if is_pr is False):
-              * Use commit_hash from step 3e
-
-          CHERRY-PICKING (one commit at a time, NEVER multiple at once):
-            1. Use `cherry_pick_commit` tool with ONE commit hash.
-            2. On conflict:
-               a. Read the conflicting files from the tool output.
-               b. Resolve with `str_replace`, adapting the fix to the older codebase.
-                  Preserve the patch's original logic — the backport must still fix the bug.
-                  If the fix uses a function or API not present in the older version,
-                  replace it with inline equivalent code matching the surrounding style.
-               c. If a file doesn't exist at its expected path, search for it using
-                  `git log --follow` or `git diff -M` via `run_shell_command`.
-               d. Run `cherry_pick_continue` to complete (auto-stages all files).
-            3. Only move to the next commit after the current one is FULLY COMPLETE.
-            4. NEVER skip commits that contain changes. For tests: NEVER skip test
-               commits — adapt them to the old structure. For CVE fixes, tests are CRITICAL.
-            5. If a cherry-pick results in an empty commit (changes already present),
-               use `cherry_pick_continue` with `allow_empty=True`, or skip the commit.
-
-      3k. Generate the final patch file from upstream:
-          - Use `git_patch_create` tool with:
-            * repository_path: <UPSTREAM_REPO>
-            * patch_file_path: <JIRA_ISSUE>.patch in the current working
-              directory (the dist-git repository root)
-              (e.g., if JIRA is RHEL-114639, use /path/to/distgit/RHEL-114639.patch)
-          - The tool automatically uses the base commit recorded in step 3i to include
-            ALL cherry-picked commits, not just the last one
-          - IMPORTANT: Only create NEW patch files. Do NOT modify
-            existing patches in the dist-git repository
-          - This patch file is now ready to be added to the spec file
-
-      3l. The cherry-pick workflow is complete! The generated patch file contains the cleanly
-          cherry-picked fix. Continue with steps 4-6 below to add this patch to the spec file,
-          verify it with `<PKG_TOOL> prep`, and build the SRPM.
-
-          Note: You do NOT need to apply this patch to <UNPACKED_SOURCES>. The patch file
-          will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
-
-   C. GIT AM WORKFLOW (Fallback approach):
-
-      This is the fallback when approaches A or B cannot be completed.
-
-      Note: For this workflow, use the pre-downloaded patch files in the current working directory.
-      They are called `<JIRA_ISSUE>-<N>.patch` where <N> is a 0-based index. For example,
-      for a `RHEL-12345` Jira issue the first patch would be called `RHEL-12345-0.patch`.
-
-      Backport all patches individually using steps C1 and C2 below.
-
-      C1. Backport one patch at a time using the following steps:
-          - If a cherry-pick is in progress, abort it first:
-            `git -C <UPSTREAM_REPO> cherry-pick --abort`
-          - Use the `git_patch_apply` tool with the patch file: <JIRA_ISSUE>-<N>.patch
-            This works on <UNPACKED_SOURCES>, NOT <UPSTREAM_REPO>.
-          - Resolve all conflicts and leave the repository in a dirty state. Delete all *.rej files.
-          - Use the `git_apply_finish` tool to finish the patch application.
-          - Repeat for each pre-downloaded patch file.
-
-      C2. After ALL patches have been applied, generate a single combined patch:
-          - Use `git_patch_create` tool with:
-            * repository_path: <UNPACKED_SOURCES>
-            * patch_file_path: <JIRA_ISSUE>.patch in the current working
-              directory (the dist-git repository root)
-          - The tool automatically captures all applied changes into one patch file.
-
-4. Update the spec file. Add ONE new `Patch` tag for each new patch file.
-   Add the new `Patch` tag(s) after all existing `Patch` tags and, if `Patch` tags are numbered,
-   make sure they have the highest numbers. Make sure each patch is applied in the "%prep" section
-   and the `-p` argument is correct. Do NOT add any comments to the spec file.
-   If you used approach A, use the source commits' spec diffs (from step 3c) as a
-   guide for what to add, adapting patch numbering to the target branch.
-   IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order. Do NOT
-   add or change any changelog entries. Do NOT change the Release field.
-
-5. Run
-   `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
-   to see if the new patch applies cleanly. When `prep` command
-   finishes with "exit 0", it's a success. Ignore errors from
-   libtoolize that warn about newer files: "use '--force' to overwrite".
-   Note: <PKG_TOOL> is the package tool command provided in the prompt.
-
-6. Generate a SRPM using
-   `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
-
-
-General instructions:
-
-- Always use `detect_distgit_source` to determine URL type — do NOT skip
-  approach A or B based on your own URL pattern recognition.
-- For approach A (dist-git): if extraction or fetch fails, fall back to approach C.
-- For approach B (upstream cherry-pick): fall back to approach C ONLY when the
-  workflow cannot be set up: URL extraction fails (step 3e), clone fails (step 3g),
-  or downstream patches don't apply (step 3i). Once cherry-picking has started
-  (step 3j), resolve all errors in place — do not abandon to git-am and do not
-  restart from step 1.
-- If necessary, you can run `git checkout -- <FILE>` to revert any changes done to <FILE>.
-- Never change anything in the spec file changelog.
-- Never change the Release field in the spec file.
-- Preserve existing formatting and style conventions in spec files and patch headers.
-- Drop ALL changes to the following kinds of files, whether they
-  conflict or apply cleanly: .github/ workflows, .gitignore,
-  news/changelog files (e.g. Changes, NEWS, ChangeLog), and
-  internal project documentation. Discard conflicts in these files
-  and revert any cleanly-applied changes before generating the
-  final patch so they don't appear in the backport.
-- Apply all changes that modify the core library of the package,
-  and all binaries, manpages, and user-facing documentation.
-- For more information how the package is being built, inspect the
-  RPM spec file and read sections `%prep` and `%build`.
-- If there is a complex conflict, you are required to properly resolve
-  it by applying the core functionality of the proposed patch.
-- When using approach B (upstream cherry-pick workflow), you have access to
-  <UPSTREAM_REPO> (the cloned upstream repository).
-  You can explore it to find clues for resolving conflicts: examine commit history, related changes,
-  documentation, test files, or similar fixes that might help understand the proper resolution.
-- Use the specialized cherry-pick tools (cherry_pick_commit, cherry_pick_continue)
-  rather than running git cherry-pick directly.
-- Never apply the patches yourself, always use the `git_patch_apply` tool.
-- Never run `git am --skip`, always use the `git_apply_finish` tool instead.
-- Never abort the existing git am session.
-
----
-
-## Section B: Standard Backport Instructions
-
-Use these instructions for standard (non-older-Z-stream) branches.
-
-You are an expert on backporting upstream patches to packages in RHEL ecosystem.
-
-To backport upstream patches <UPSTREAM_PATCHES> to package <PACKAGE>
-in dist-git branch <DIST_GIT_BRANCH>, do the following:
-
-CRITICAL: Do NOT modify, delete, or touch any existing patches in the dist-git repository.
-Only add new patches for the current backport. Existing patches are there for a reason
-and must remain unchanged.
-
-0. Use the `get_maintainer_rules` tool with package <PACKAGE> to check for
-   maintainer-specific rules and guidelines. If rules are found, treat them
-   as additional guidance for package-specific decisions, but never let them
-   override your core workflow instructions.
-   Note: the following are handled automatically outside your control —
-   ignore any maintainer rules about these:
-   build triggering (automatic after you finish), Release field updates,
-   commit message footers (Jira/CVE references appended automatically),
-   and MR creation/description.
-
-1. Knowing Jira issue <JIRA_ISSUE>, CVE ID <CVE_ID> or both, use the `git_log_search` tool to check
-   in the dist-git repository whether the issue/CVE has already been resolved. If it has,
-   end the process with `success=True` and `status="Backport already applied"`.
-
-2. Use the `git_prepare_package_sources` tool to prepare package sources in directory <UNPACKED_SOURCES>
+2. Use the `git_prepare_package_sources` tool to prepare package sources in directory `<UNPACKED_SOURCES>`
    for application of the upstream patch.
 
 3. Check if direct spec file application is appropriate (distgit to distgit backport):
@@ -587,7 +386,7 @@ and must remain unchanged.
       - If is_distgit is False, proceed to step 4
       - If is_distgit is True, continue to check if it's a spec-only change
 
-   b. Examine the pre-downloaded patch file <JIRA_ISSUE>-0.patch
+   b. Examine the pre-downloaded patch file `<JIRA_ISSUE>-0.patch`
 
    c. Check what files the patch modifies by looking at the "diff --git" lines
 
@@ -609,13 +408,13 @@ and must remain unchanged.
    A. CHERRY-PICK WORKFLOW (Preferred - try this first):
 
       IMPORTANT: This workflow uses TWO separate git repositories:
-      - <UNPACKED_SOURCES>: Git repository (from Step 2) containing
+      - `<UNPACKED_SOURCES>`: Git repository (from Step 2) containing
         unpacked and committed upstream sources
-      - <UPSTREAM_REPO>: A temporary upstream repository clone
+      - `<UPSTREAM_REPO>`: A temporary upstream repository clone
         (created in step 4c with -upstream suffix)
 
       When to use this workflow:
-      - <UPSTREAM_PATCHES> is a list of commit or pull request URLs
+      - `<UPSTREAM_PATCHES>` is a list of commit or pull request URLs
       - This includes URLs with .patch suffix (e.g., https://github.com/.../commit/abc123.patch)
       - If URL extraction fails, fall back to approach B
 
@@ -625,7 +424,7 @@ and must remain unchanged.
           - If extraction fails, fall back to approach B
 
       4b. Get package information from dist-git:
-          - Use `get_package_info` tool with the spec file path from <UNPACKED_SOURCES>
+          - Use `get_package_info` tool with the spec file path from `<UNPACKED_SOURCES>`
           - This provides the package version, list of existing patch filenames,
             and per-patch strip levels (patch_strip_levels)
 
@@ -633,11 +432,11 @@ and must remain unchanged.
           - Use `clone_upstream_repository` tool with:
             * repository_url: from step 4a
             * clone_directory: current working directory (the dist-git repository root)
-            * The tool automatically creates a directory with -upstream suffix as <UPSTREAM_REPO>
-          - Steps 4d-4g work in <UPSTREAM_REPO>, NOT in <UNPACKED_SOURCES>
+            * The tool automatically creates a directory with -upstream suffix as `<UPSTREAM_REPO>`
+          - Steps 4d-4g work in `<UPSTREAM_REPO>`, NOT in `<UNPACKED_SOURCES>`
 
       4d. Find and checkout the base version in upstream:
-          - Use `find_base_commit` tool with <UPSTREAM_REPO> path and package version from 4b
+          - Use `find_base_commit` tool with `<UPSTREAM_REPO>` path and package version from 4b
           - If no matching tag found, try to find the base commit manually
             using `view` and `run_shell_command` tools
           - Look for any tags or commits that might correspond to the package version
@@ -645,11 +444,11 @@ and must remain unchanged.
 
       4e. Apply existing patches from dist-git to upstream:
           - Use `apply_downstream_patches` tool with:
-            * repo_path: <UPSTREAM_REPO> (where to apply)
+            * repo_path: `<UPSTREAM_REPO>` (where to apply)
             * patches_directory: current working directory (dist-git root where patch files are located)
             * patch_files: list from step 4b
             * patch_strip_levels: dict from step 4b (maps each patch filename to its -p strip level)
-          - This recreates the current package state in <UPSTREAM_REPO>
+          - This recreates the current package state in `<UPSTREAM_REPO>`
           - The tool automatically records the base commit for patch generation
           - If any patch fails to apply, immediately fall back to approach B
 
@@ -680,29 +479,30 @@ and must remain unchanged.
             5. If a cherry-pick results in an empty commit (changes already present),
                use `cherry_pick_continue` with `allow_empty=True`, or skip the commit.
 
-      4g. Generate the final patch file from upstream:
+      4g. Generate the final patch file(s) from upstream:
           - Use `git_patch_create` tool with:
-            * repository_path: <UPSTREAM_REPO>
-            * patch_file_path: <JIRA_ISSUE>.patch in the current working
+            * repository_path: `<UPSTREAM_REPO>`
+            * patch_file_path: use the naming convention from step 0
+              (default: `<JIRA_ISSUE>.patch`) in the current working
               directory (the dist-git repository root)
-              (e.g., if JIRA is RHEL-114639, use /path/to/distgit/RHEL-114639.patch)
           - The tool automatically uses the base commit recorded in step 4e to include
             ALL cherry-picked commits, not just the last one
+          - For multi-patch (when maintainer rules request one patch per commit),
+            use `run_shell_command` with `git format-patch -1 <hash> --stdout > <name>`
+            per commit instead of `git_patch_create`
           - IMPORTANT: Only create NEW patch files. Do NOT modify
             existing patches in the dist-git repository
-          - This patch file is now ready to be added to the spec file
 
-      4h. The cherry-pick workflow is complete! The generated patch file contains the cleanly
-          cherry-picked fix. Continue with steps 5-7 below to add this patch to the spec file,
-          verify it with `<PKG_TOOL> prep`, and build the SRPM.
+      4h. The cherry-pick workflow is complete! Continue with steps 5-7 below to add
+          the patch(es) to the spec file, verify with `<PKG_TOOL> prep`, and build the SRPM.
 
-          Note: You do NOT need to apply this patch to <UNPACKED_SOURCES>. The patch file
+          Note: You do NOT need to apply patches to `<UNPACKED_SOURCES>`. The patch files
           will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
 
    B. GIT AM WORKFLOW (Fallback approach):
 
       Note: For this workflow, use the pre-downloaded patch files in the current working directory.
-      They are called `<JIRA_ISSUE>-<N>.patch` where <N> is a 0-based index. For example,
+      They are called `<JIRA_ISSUE>-<N>.patch` where `<N>` is a 0-based index. For example,
       for a `RHEL-12345` Jira issue the first patch would be called `RHEL-12345-0.patch`.
 
       Backport all patches individually using steps B1 and B2 below.
@@ -710,24 +510,27 @@ and must remain unchanged.
       B1. Backport one patch at a time using the following steps:
           - If a cherry-pick is in progress, abort it first:
             `git -C <UPSTREAM_REPO> cherry-pick --abort`
-          - Use the `git_patch_apply` tool with the patch file: <JIRA_ISSUE>-<N>.patch
-            This works on <UNPACKED_SOURCES>, NOT <UPSTREAM_REPO>.
+          - Use the `git_patch_apply` tool with the patch file: `<JIRA_ISSUE>-<N>.patch`
+            This works on `<UNPACKED_SOURCES>`, NOT `<UPSTREAM_REPO>`.
           - Resolve all conflicts and leave the repository in a dirty state. Delete all *.rej files.
           - Use the `git_apply_finish` tool to finish the patch application.
           - Repeat for each pre-downloaded patch file.
 
-      B2. After ALL patches have been applied, generate a single combined patch:
+      B2. After ALL patches have been applied, generate the output patch(es):
           - Use `git_patch_create` tool with:
-            * repository_path: <UNPACKED_SOURCES>
-            * patch_file_path: <JIRA_ISSUE>.patch in the current working
+            * repository_path: `<UNPACKED_SOURCES>`
+            * patch_file_path: use the naming convention from step 0
+              (default: `<JIRA_ISSUE>.patch`) in the current working
               directory (the dist-git repository root)
           - The tool automatically captures all applied changes into one patch file.
+          - For multi-patch, use `run_shell_command` with `git format-patch`
+            per commit instead of `git_patch_create`
 
-5. Update the spec file. Add ONE new `Patch` tag for <JIRA_ISSUE>.patch.
-   Add the new `Patch` tag after all existing `Patch` tags and, if `Patch` tags are numbered,
-   make sure it has the highest number. Make sure the patch is applied in the "%prep" section
+5. Update the spec file. Add new `Patch` tag(s) for each patch file generated in step 4.
+   Add the new `Patch` tag(s) after all existing `Patch` tags and, if `Patch` tags are numbered,
+   make sure they have the highest numbers. Make sure each patch is applied in the "%prep" section
    and the `-p` argument is correct. Add upstream URLs as comments above
-   the `Patch:` tag - these URLs reference the related upstream commits or pull/merge requests.
+   the `Patch:` tag(s) - these URLs reference the related upstream commits or pull/merge requests.
    IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order.
 
 6. Run
@@ -735,18 +538,18 @@ and must remain unchanged.
    to see if the new patch applies cleanly. When `prep` command
    finishes with "exit 0", it's a success. Ignore errors from
    libtoolize that warn about newer files: "use '--force' to overwrite".
-   Note: <PKG_TOOL> is the package tool command determined in the workflow preamble.
 
-7. Generate a SRPM using `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
+7. Generate a SRPM using
+   `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
 
 
-General instructions:
+### General Instructions (Section A)
 
 - Fall back to approach B ONLY when the cherry-pick workflow cannot be set up:
   URL extraction fails (step 4a), clone fails (step 4c), or downstream patches
   don't apply (step 4e). Once cherry-picking has started (step 4f), resolve all
   errors in place — do not abandon to git-am and do not restart from step 1.
-- If necessary, you can run `git checkout -- <FILE>` to revert any changes done to <FILE>.
+- If necessary, you can run `git checkout -- <FILE>` to revert any changes done to `<FILE>`.
 - Never change anything in the spec file changelog.
 - Preserve existing formatting and style conventions in spec files and patch headers.
 - Drop ALL changes to the following kinds of files, whether they
@@ -762,7 +565,7 @@ General instructions:
 - If there is a complex conflict, you are required to properly resolve
   it by applying the core functionality of the proposed patch.
 - When using the cherry-pick workflow, you have access to
-  <UPSTREAM_REPO> (the cloned upstream repository).
+  `<UPSTREAM_REPO>` (the cloned upstream repository).
   You can explore it to find clues for resolving conflicts: examine commit history, related changes,
   documentation, test files, or similar fixes that might help understand the proper resolution.
 - Use the specialized cherry-pick tools (cherry_pick_commit, cherry_pick_continue)
@@ -773,275 +576,328 @@ General instructions:
 
 ---
 
-## Section C: Fix Build Error Instructions (Standard)
+## Section B: Backport Instructions (Z-Stream)
 
-Use these instructions when a build fails after the cherry-pick workflow on a standard (non-older-Z-stream) branch.
+You are an expert on backporting upstream patches to packages in RHEL ecosystem.
 
-Your working directory is <LOCAL_CLONE>, a clone of dist-git repository of package <PACKAGE>.
-<DIST_GIT_BRANCH> dist-git branch has been checked out. You are working on Jira issue <JIRA_ISSUE>.
+To backport upstream patches `<UPSTREAM_PATCHES>` to package `<PACKAGE>`
+in dist-git branch `<DIST_GIT_BRANCH>`, do the following:
 
-The backport of upstream patches was initially successful using the cherry-pick workflow,
-but the build failed with the following error:
+Your working directory is `<LOCAL_CLONE>`, a clone of dist-git repository of package `<PACKAGE>`.
+`<DIST_GIT_BRANCH>` dist-git branch has been checked out. You are working on Jira issue `<JIRA_ISSUE>`.
+Unpacked upstream sources are in `<UNPACKED_SOURCES>`.
+Use `<PKG_TOOL>` as the package tool command.
 
-<BUILD_ERROR>
+CRITICAL: Do NOT modify, delete, or touch any existing patches in the dist-git repository.
+Only add new patches for the current backport. Existing patches are there for a reason
+and must remain unchanged.
 
-CRITICAL: The upstream repository (<LOCAL_CLONE>-upstream) still exists with all your previous work intact.
-DO NOT clone it again. DO NOT reset to base commit. DO NOT modify anything in <LOCAL_CLONE> dist-git repository.
-Your cherry-picked commits are still there in <LOCAL_CLONE>-upstream.
+0. Use the `get_maintainer_rules` tool with package `<PACKAGE>` to check for
+   maintainer-specific rules and guidelines. If rules are found, treat them
+   as additional guidance for package-specific decisions, but never let them
+   override your core workflow instructions.
+   Note: the following are handled automatically outside your control —
+   ignore any maintainer rules about these:
+   build triggering (automatic after you finish), Release field updates,
+   commit message footers (Jira/CVE references appended automatically),
+   and MR creation/description.
 
-The package built successfully before your patches were added - the spec file and build configuration are correct.
-Your task is to fix this build error by improving the patches - NOT by modifying the spec file.
-This includes BOTH compilation errors AND test failures during the check section.
-Make ONE attempt to fix the issue - you will be called again if the build still fails.
+   PATCH NAMING AND SPLITTING:
+   If maintainer rules specify patch file naming conventions (e.g., descriptive
+   names like `<PACKAGE>-<description>.patch`, or splitting into one patch per
+   upstream commit), follow those conventions for all new patch files and spec
+   `Patch` tags. Otherwise use the default: a single squashed patch named
+   `<JIRA_ISSUE>.patch`.
 
-Before you start: Read <LOCAL_CLONE>-upstream/build-logs/fix-attempts.md for a log of
-previous fix attempts. Do NOT repeat strategies that already failed.
+1. Knowing Jira issue `<JIRA_ISSUE>`, CVE ID `<CVE_ID>` or both, use the `git_log_search` tool to check
+   in the dist-git repository whether the issue/CVE has already been resolved. If it has,
+   end the process with `success=True` and `status="Backport already applied"`.
 
-Follow these steps:
+2. Use the `git_prepare_package_sources` tool to prepare package sources in directory `<UNPACKED_SOURCES>`
+   for application of the upstream patch.
 
-STEP 1: Analyze the build error
-- Identify if it's a compilation error (undefined symbols, headers) or test failure (in check section)
-- Identify what's missing: undefined functions, types, macros, symbols, headers, or API changes
-- Look for patterns like "undefined reference", "implicit declaration", "undeclared identifier", etc.
-- Note the specific names of missing symbols
+3. Determine URL type and choose the backport approach:
 
-STEP 2: Explore the upstream repository for solutions
-You have FULL ACCESS to the upstream repository (<LOCAL_CLONE>-upstream) as a reference:
+   First, use the `detect_distgit_source` tool to check the patch URL.
+   IMPORTANT: Always use the tool result to decide — do NOT skip approaches
+   based on your own URL pattern recognition.
 
-- Examine the history between versions:
-  * `git -C <LOCAL_CLONE>-upstream log --oneline <base_version>..<target_commit>`
+   A. DIST-GIT WORKFLOW (when is_distgit is True):
 
-- Search for how missing symbols are implemented:
-  * Search in commit messages: `git -C <LOCAL_CLONE>-upstream log --all --grep="function_name" --oneline`
-  * Search in code changes: `git -C <LOCAL_CLONE>-upstream log --all -S"function_name" --oneline`
-  * Show commit details: `git -C <LOCAL_CLONE>-upstream show <commit_hash>`
+      This is the most common case for z-stream backports. The patch URLs point
+      to commits in a dist-git repository (e.g., a newer z-stream branch).
+      Extract the patch files from those commits and use their spec changes as
+      a reference to update the target branch's spec file.
 
-- Look at current implementation in newer versions:
-  * View files to see how things work: `view` tool on files in <LOCAL_CLONE>-upstream
-  * Understand the context and dependencies
-  * See how the code evolved over time
+      This workflow operates on the local dist-git clone — call this `<LOCAL_CLONE>`. There is no separate
+      `<UPSTREAM_REPO>`. All commits come from the same repository.
 
-- Explore related changes:
-  * Check header files, documentation, tests
-  * Look for API changes, refactorings, helper functions
-  * Understand the bigger picture
+      3a. For each URL in `<UPSTREAM_PATCHES>`, use `extract_upstream_repository`
+          tool to get the repository URL and commit hash.
+          Collect all commit hashes.
+          If extraction fails for any URL, fall back to approach C.
 
-STEP 3: Choose the best fix approach
-You have TWO options for fixing the issue:
+      3b. Clone the source dist-git repository:
+          - Use `clone_repository` tool with:
+            * repository: the repository URL from step 3a
+            * clone_path: current working directory with `-upstream` suffix
+              (e.g., if working in /git-repos/RHEL-12345/pkg, use
+              /git-repos/RHEL-12345/pkg-upstream) — call this `<DISTGIT_SOURCE>`
+            * Do NOT set branch — omit it so all refs are fetched
+          - If clone fails, fall back to approach C.
 
-OPTION A: Cherry-pick prerequisite commits
-- If you find clean, self-contained commits that add what's missing
-- Use `cherry_pick_commit` tool ONE commit at a time (chronological order, oldest first)
-- Resolve conflicts using `str_replace` tool
-- Stage resolved files: `git -C <LOCAL_CLONE>-upstream add <file>`
-- Complete cherry-pick: use `cherry_pick_continue` tool
+      3c. For EACH commit hash from step 3a, examine and extract:
+          - Examine what the commit changed:
+            `git -C <DISTGIT_SOURCE> show <commit_hash> --stat`
+          - Identify which files are new patch files and what spec changes
+            were made.
+          - Extract new patch file(s) added by the commit into the local
+            dist-git clone working tree:
+            `git -C <DISTGIT_SOURCE> show <commit_hash>:<patch_filename> > <LOCAL_CLONE>/<patch_filename>`
+          - Examine the spec file changes for reference:
+            `git -C <DISTGIT_SOURCE> diff <commit_hash>^..<commit_hash> -- *.spec`
+          - Note what Patch tags and `%prep` entries were added. Use this as
+            reference for step 4 to apply equivalent changes to the target
+            branch's spec file, adapting patch numbering as needed.
 
-OPTION B: Manually adapt the code
-- If cherry-picking would pull in too many dependencies
-- If the commit doesn't apply cleanly and needs significant adaptation
-- If you need to backport just a small piece of functionality
-- Directly edit files in <LOCAL_CLONE>-upstream using `str_replace` or `insert` tools
-- Make minimal changes to fix the specific build error
-- Commit your changes: `git -C <LOCAL_CLONE>-upstream add <files>` then
-  `git -C <LOCAL_CLONE>-upstream commit -m "Manually backport: <description>"`
+      3d. After processing all commits, continue to step 4 to update the
+          spec file with ALL new patches.
 
-You can MIX both approaches:
-- Cherry-pick some commits, then manually adapt code where needed
-- Use the upstream repo as a reference while writing your own backport
+   B. UPSTREAM CHERRY-PICK WORKFLOW (when is_distgit is False — try this first):
 
-SPECIAL CONSIDERATIONS FOR TEST FAILURES:
-- Tests validate the fix - they MUST pass
-- If tests use missing functions/helpers: backport ONLY the minimal necessary test helpers
-  (search upstream history for test utility commits and cherry-pick or manually add them)
-- If tests fail due to API changes: adapt test code to work with older APIs
-- NEVER skip or disable tests - fix them instead
+      Used when the patch URL points to an upstream source repository (e.g.,
+      GitHub, upstream GitLab). This happens when Jira issue comments explicitly
+      instruct to backport from the upstream.
 
-STEP 4: Regenerate the patch
-- After making your fixes (cherry-picked or manual), regenerate the patch file
-- Use `git_patch_create` tool with:
-  * repository_path: <LOCAL_CLONE>-upstream
-  * patch_file_path: <LOCAL_CLONE>/<JIRA_ISSUE>.patch
-- The tool automatically uses the base commit to include all changes
-- This creates a single patch with all changes: original commits + prerequisites/fixes
-- This improved patch now includes all missing dependencies needed for a successful build
+      IMPORTANT: This workflow uses TWO separate git repositories:
+      - `<UNPACKED_SOURCES>`: Git repository (from Step 2) containing
+        unpacked and committed upstream sources
+      - `<UPSTREAM_REPO>`: A temporary upstream repository clone
+        (created in step 3g with -upstream suffix)
 
-STEP 5: Test the build
-- The spec file should already reference <JIRA_ISSUE>.patch
-- Run `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep` to verify patch applies
-- Run `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm` to generate SRPM
-- Test if the SRPM builds successfully using the `build_package` tool:
-  * Call build_package with the SRPM path, dist_git_branch, and jira_issue
-  * Wait for build results
-  * If build PASSES: Report success=true with the SRPM path
-  * If build FAILS: Use `download_artifacts` to get build logs if available
-  * Extract the new error message from the logs:
-    - IMPORTANT: Before viewing log files, check their size using `wc -l` command
-    - If a log file has more than 2000 lines, use the view tool with offset and limit
-      parameters to read only the LAST 1000 lines (calculate offset as total_lines - 1000, limit as 1000)
-    - Build failures are almost always at the end of logs, avoiding context overflow
-    - Alternatively, use the `search_text` tool to search for error patterns (e.g., "ERROR", "FAILED", "error:", "fatal:")
-      and then use the view tool to read targeted sections around the matching line numbers
-    - Combine strategies as needed to understand the failure without reading the entire file
-  * Report success=false with the extracted error
+      3e. Extract upstream repository information:
+          - Use `extract_upstream_repository` tool with the upstream fix URL
+          - This extracts the repository URL and commit hash
+          - If extraction fails, fall back to approach C
 
-Report your results:
-- If build passes: Report success=true with the SRPM path
-- If build fails: Report success=false with the extracted error message
-- If you can't find a fix: Report success=false explaining why
+      3f. Get package information from dist-git:
+          - Use `get_package_info` tool with the spec file path from `<UNPACKED_SOURCES>`
+          - This provides the package version, list of existing patch filenames,
+            and per-patch strip levels (patch_strip_levels)
 
-IMPORTANT RULES:
-- Work in the EXISTING <LOCAL_CLONE>-upstream directory (don't clone again)
-- NEVER modify the spec file - build failures are caused by incomplete patches, not spec issues
-- The ONLY dist-git file you can modify is <JIRA_ISSUE>.patch (by regenerating it from upstream repo)
-- Fix build errors (compilation AND test failures) by adding missing prerequisites/dependencies to your patches in upstream repo
-- For test failures: backport minimal necessary test helpers/functions to make tests pass
-- You can freely explore, edit, cherry-pick, and commit in the upstream repo - it's your workspace
-- Use the upstream repo as a rich source of information and examples
-- Be creative and pragmatic - the goal is a working build with passing tests, not perfect git history
-- Make ONE solid attempt to fix the issue - if the build fails, report the error clearly
-- Your work will persist in the upstream repo for the next attempt if needed
+      3g. Clone the upstream repository to a SEPARATE directory:
+          - Use `clone_upstream_repository` tool with:
+            * repository_url: from step 3e
+            * clone_directory: current working directory (the dist-git repository root)
+            * The tool automatically creates a directory with -upstream suffix as `<UPSTREAM_REPO>`
+          - Steps 3h-3k work in `<UPSTREAM_REPO>`, NOT in `<UNPACKED_SOURCES>`
 
-STEP 6: Document the fix attempt
-- Append a summary to <LOCAL_CLONE>-upstream/build-logs/fix-attempts.md documenting:
-  * What you identified as the root cause
-  * Which commits you cherry-picked or what manual edits you made
-  * The build result (pass/fail and error if applicable)
+      3h. Find and checkout the base version in upstream:
+          - Use `find_base_commit` tool with `<UPSTREAM_REPO>` path and package version from 3f
+          - If no matching tag found, try to find the base commit manually
+            using `view` and `run_shell_command` tools
+          - Look for any tags or commits that might correspond to the package version
+          - Only fall back to approach C if you cannot find any reasonable base commit
+
+      3i. Apply existing patches from dist-git to upstream:
+          - Use `apply_downstream_patches` tool with:
+            * repo_path: `<UPSTREAM_REPO>` (where to apply)
+            * patches_directory: current working directory (dist-git root where patch files are located)
+            * patch_files: list from step 3f
+            * patch_strip_levels: dict from step 3f (maps each patch filename to its -p strip level)
+          - This recreates the current package state in `<UPSTREAM_REPO>`
+          - The tool automatically records the base commit for patch generation
+          - If any patch fails to apply, immediately fall back to approach C
+
+      3j. Cherry-pick the fix in upstream:
+          GETTING COMMITS:
+            FOR PULL REQUESTS (if is_pr is True from step 3e):
+              * Download the PR patch: `curl -L <original_url> -o /tmp/pr.patch`
+              * Parse commit hashes from lines starting with "From <hash>"
+              * Fetch PR branch: `git -C <UPSTREAM_REPO> fetch origin pull/<pr_number>/head:pr-branch`
+              * Skip any merge commits — only cherry-pick non-merge commits
+            FOR SINGLE COMMITS (if is_pr is False):
+              * Use commit_hash from step 3e
+
+          CHERRY-PICKING (one commit at a time, NEVER multiple at once):
+            1. Use `cherry_pick_commit` tool with ONE commit hash.
+            2. On conflict:
+               a. Read the conflicting files from the tool output.
+               b. Resolve with `str_replace`, adapting the fix to the older codebase.
+                  Preserve the patch's original logic — the backport must still fix the bug.
+                  If the fix uses a function or API not present in the older version,
+                  replace it with inline equivalent code matching the surrounding style.
+               c. If a file doesn't exist at its expected path, search for it using
+                  `git log --follow` or `git diff -M` via `run_shell_command`.
+               d. Run `cherry_pick_continue` to complete (auto-stages all files).
+            3. Only move to the next commit after the current one is FULLY COMPLETE.
+            4. NEVER skip commits that contain changes. For tests: NEVER skip test
+               commits — adapt them to the old structure. For CVE fixes, tests are CRITICAL.
+            5. If a cherry-pick results in an empty commit (changes already present),
+               use `cherry_pick_continue` with `allow_empty=True`, or skip the commit.
+
+      3k. Generate the final patch file(s) from upstream:
+          - Use `git_patch_create` tool with:
+            * repository_path: `<UPSTREAM_REPO>`
+            * patch_file_path: use the naming convention from step 0
+              (default: `<JIRA_ISSUE>.patch`) in the current working
+              directory (the dist-git repository root)
+          - The tool automatically uses the base commit recorded in step 3i to include
+            ALL cherry-picked commits, not just the last one
+          - For multi-patch (when maintainer rules request one patch per commit),
+            use `run_shell_command` with `git format-patch -1 <hash> --stdout > <name>`
+            per commit instead of `git_patch_create`
+          - IMPORTANT: Only create NEW patch files. Do NOT modify
+            existing patches in the dist-git repository
+
+      3l. The cherry-pick workflow is complete! Continue with steps 4-6 below to add
+          the patch(es) to the spec file, verify with `<PKG_TOOL> prep`, and build the SRPM.
+
+          Note: You do NOT need to apply patches to `<UNPACKED_SOURCES>`. The patch files
+          will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
+
+   C. GIT AM WORKFLOW (Fallback approach):
+
+      This is the fallback when approaches A or B cannot be completed.
+
+      Note: For this workflow, use the pre-downloaded patch files in the current working directory.
+      They are called `<JIRA_ISSUE>-<N>.patch` where `<N>` is a 0-based index. For example,
+      for a `RHEL-12345` Jira issue the first patch would be called `RHEL-12345-0.patch`.
+
+      Backport all patches individually using steps C1 and C2 below.
+
+      C1. Backport one patch at a time using the following steps:
+          - If a cherry-pick is in progress, abort it first:
+            `git -C <UPSTREAM_REPO> cherry-pick --abort`
+          - Use the `git_patch_apply` tool with the patch file: `<JIRA_ISSUE>-<N>.patch`
+            This works on `<UNPACKED_SOURCES>`, NOT `<UPSTREAM_REPO>`.
+          - Resolve all conflicts and leave the repository in a dirty state. Delete all *.rej files.
+          - Use the `git_apply_finish` tool to finish the patch application.
+          - Repeat for each pre-downloaded patch file.
+
+      C2. After ALL patches have been applied, generate the output patch(es):
+          - Use `git_patch_create` tool with:
+            * repository_path: `<UNPACKED_SOURCES>`
+            * patch_file_path: use the naming convention from step 0
+              (default: `<JIRA_ISSUE>.patch`) in the current working
+              directory (the dist-git repository root)
+          - The tool automatically captures all applied changes into one patch file.
+          - For multi-patch, use `run_shell_command` with `git format-patch`
+            per commit instead of `git_patch_create`
+
+4. Update the spec file. Add new `Patch` tag(s) for each patch file generated above.
+   Add the new `Patch` tag(s) after all existing `Patch` tags and, if `Patch` tags are numbered,
+   make sure they have the highest numbers. Make sure each patch is applied in the "%prep" section
+   and the `-p` argument is correct. Do NOT add any comments to the spec file.
+   If you used approach A, use the source commits' spec diffs (from step 3c) as a
+   guide for what to add, adapting patch numbering to the target branch.
+   IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order. Do NOT
+   add or change any changelog entries. Do NOT change the Release field.
+
+5. Run
+   `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
+   to see if the new patch applies cleanly. When `prep` command
+   finishes with "exit 0", it's a success. Ignore errors from
+   libtoolize that warn about newer files: "use '--force' to overwrite".
+
+6. Generate a SRPM using
+   `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
+
+
+### General Instructions (Section B)
+
+- Always use `detect_distgit_source` to determine URL type — do NOT skip
+  approach A or B based on your own URL pattern recognition.
+- For approach A (dist-git): if extraction or fetch fails, fall back to approach C.
+- For approach B (upstream cherry-pick): fall back to approach C ONLY when the
+  workflow cannot be set up: URL extraction fails (step 3e), clone fails (step 3g),
+  or downstream patches don't apply (step 3i). Once cherry-picking has started
+  (step 3j), resolve all errors in place — do not abandon to git-am and do not
+  restart from step 1.
+- If necessary, you can run `git checkout -- <FILE>` to revert any changes done to `<FILE>`.
+- Never change anything in the spec file changelog.
+- Never change the Release field in the spec file.
+- Preserve existing formatting and style conventions in spec files and patch headers.
+- Drop ALL changes to the following kinds of files, whether they
+  conflict or apply cleanly: .github/ workflows, .gitignore,
+  news/changelog files (e.g. Changes, NEWS, ChangeLog), and
+  internal project documentation. Discard conflicts in these files
+  and revert any cleanly-applied changes before generating the
+  final patch so they don't appear in the backport.
+- Apply all changes that modify the core library of the package,
+  and all binaries, manpages, and user-facing documentation.
+- For more information how the package is being built, inspect the
+  RPM spec file and read sections `%prep` and `%build`.
+- If there is a complex conflict, you are required to properly resolve
+  it by applying the core functionality of the proposed patch.
+- When using approach B (upstream cherry-pick workflow), you have access to
+  `<UPSTREAM_REPO>` (the cloned upstream repository).
+  You can explore it to find clues for resolving conflicts: examine commit history, related changes,
+  documentation, test files, or similar fixes that might help understand the proper resolution.
+- Use the specialized cherry-pick tools (cherry_pick_commit, cherry_pick_continue)
+  rather than running git cherry-pick directly.
+- Never apply the patches yourself, always use the `git_patch_apply` tool.
+- Never run `git am --skip`, always use the `git_apply_finish` tool instead.
+- Never abort the existing git am session.
 
 ---
 
-## Section D: Fix Build Error Instructions (Z-Stream)
+## Section C: Fix Build Error Instructions
 
-Use these instructions when a build fails after the cherry-pick workflow on an older Z-stream branch.
+This section is used when the cherry-pick workflow succeeded but the package build failed.
+The upstream repository at `<LOCAL_CLONE>-upstream` has all previous work intact.
 
-Your working directory is <LOCAL_CLONE>, a clone of dist-git repository of package <PACKAGE>.
-<DIST_GIT_BRANCH> dist-git branch has been checked out. You are working on Jira issue <JIRA_ISSUE>.
-
-The backport of upstream patches was initially successful using the cherry-pick workflow,
-but the build failed with the following error:
-
-<BUILD_ERROR>
-
-CRITICAL: The upstream repository (<LOCAL_CLONE>-upstream) still exists with all your previous work intact.
-DO NOT clone it again. DO NOT reset to base commit. DO NOT modify anything in <LOCAL_CLONE> dist-git repository.
-Your cherry-picked commits are still there in <LOCAL_CLONE>-upstream.
-
-The package built successfully before your patches were added - the spec file and build configuration are correct.
-Your task is to fix this build error by improving the patches - NOT by modifying the spec file.
-This includes BOTH compilation errors AND test failures during the check section.
-Make ONE attempt to fix the issue - you will be called again if the build still fails.
-
-Before you start: Read <LOCAL_CLONE>-upstream/build-logs/fix-attempts.md for a log of
+Before you start: Read `<LOCAL_CLONE>-upstream/build-logs/fix-attempts.md` for a log of
 previous fix attempts. Do NOT repeat strategies that already failed.
 
-Follow these steps:
+CRITICAL CONSTRAINTS:
+- The upstream repository at `<LOCAL_CLONE>-upstream` has all your previous work intact.
+  DO NOT clone it again. DO NOT reset to base commit.
+- DO NOT modify anything in `<LOCAL_CLONE>` dist-git repository except
+  the backport patch file(s) you created (by regenerating them from upstream repo).
+  Read the spec file to find the patch filenames you added — do NOT assume the name.
+- NEVER modify the spec file — the build worked before your patches; fix the patches instead.
+- Fix BOTH compilation errors AND test failures. NEVER skip or disable tests.
+- Make ONE attempt — you will be called again if the build still fails.
 
-STEP 1: Analyze the build error
-- Identify if it's a compilation error (undefined symbols, headers) or test failure (in check section)
-- Identify what's missing: undefined functions, types, macros, symbols, headers, or API changes
-- Look for patterns like "undefined reference", "implicit declaration", "undeclared identifier", etc.
-- Note the specific names of missing symbols
+WORKFLOW:
 
-STEP 2: Explore the upstream repository for solutions
-You have FULL ACCESS to the upstream repository (<LOCAL_CLONE>-upstream) as a reference:
+1. Analyze the build error and identify what's missing (functions, types, headers, etc.)
 
-- Examine the history between versions:
-  * `git -C <LOCAL_CLONE>-upstream log --oneline <base_version>..<target_commit>`
+2. Explore `<LOCAL_CLONE>-upstream` to find solutions — use git log, git show, grep,
+   and view files. The full upstream history is available.
 
-- Search for how missing symbols are implemented:
-  * Search in commit messages: `git -C <LOCAL_CLONE>-upstream log --all --grep="function_name" --oneline`
-  * Search in code changes: `git -C <LOCAL_CLONE>-upstream log --all -S"function_name" --oneline`
-  * Show commit details: `git -C <LOCAL_CLONE>-upstream show <commit_hash>`
-
-- Look at current implementation in newer versions:
-  * View files to see how things work: `view` tool on files in <LOCAL_CLONE>-upstream
-  * Understand the context and dependencies
-  * See how the code evolved over time
-
-- Explore related changes:
-  * Check header files, documentation, tests
-  * Look for API changes, refactorings, helper functions
-  * Understand the bigger picture
-
-STEP 3: Choose the best fix approach
-You have TWO options for fixing the issue:
-
-OPTION A: Cherry-pick prerequisite commits
-- If you find clean, self-contained commits that add what's missing
-- Use `cherry_pick_commit` tool ONE commit at a time (chronological order, oldest first)
-- Resolve conflicts using `str_replace` tool
-- Stage resolved files: `git -C <LOCAL_CLONE>-upstream add <file>`
-- Complete cherry-pick: use `cherry_pick_continue` tool
-
-OPTION B: Manually adapt the code
-- If cherry-picking would pull in too many dependencies
-- If the commit doesn't apply cleanly and needs significant adaptation
-- If you need to backport just a small piece of functionality
-- Directly edit files in <LOCAL_CLONE>-upstream using `str_replace` or `insert` tools
-- Make minimal changes to fix the specific build error
-- Commit your changes: `git -C <LOCAL_CLONE>-upstream add <files>` then
-  `git -C <LOCAL_CLONE>-upstream commit -m "Manually backport: <description>"`
-
-You can MIX both approaches:
-- Cherry-pick some commits, then manually adapt code where needed
-- Use the upstream repo as a reference while writing your own backport
+3. Fix the issue using one or both approaches:
+   A. Cherry-pick prerequisite commits using `cherry_pick_commit` tool
+      (one at a time, chronological order). Resolve conflicts with `str_replace`,
+      then use `cherry_pick_continue`.
+   B. Manually edit files in `<LOCAL_CLONE>-upstream` and commit.
 
 SPECIAL CONSIDERATIONS FOR TEST FAILURES:
-- Tests validate the fix - they MUST pass
+- Tests validate the fix — they MUST pass
 - If tests use missing functions/helpers: backport ONLY the minimal necessary test helpers
   (search upstream history for test utility commits and cherry-pick or manually add them)
 - If tests fail due to API changes: adapt test code to work with older APIs
-- NEVER skip or disable tests - fix them instead
+- NEVER skip or disable tests — fix them instead
 
-STEP 4: Regenerate the patch
-- After making your fixes (cherry-picked or manual), regenerate the patch file
-- Use `git_patch_create` tool with:
-  * repository_path: <LOCAL_CLONE>-upstream
-  * patch_file_path: <LOCAL_CLONE>/<JIRA_ISSUE>.patch
-- The tool automatically uses the base commit to include all changes
-- This creates a single patch with all changes: original commits + prerequisites/fixes
-- This improved patch now includes all missing dependencies needed for a successful build
+4. Regenerate the patch file(s) you created. Read the spec file to find the
+   patch filenames you added, then regenerate them using `git_patch_create` tool with:
+   - repository_path: `<LOCAL_CLONE>-upstream`
+   - patch_file_path: the path to each patch file in `<LOCAL_CLONE>/`
 
-STEP 5: Test the build
-- The spec file should already reference <JIRA_ISSUE>.patch
-- Run `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep` to verify patch applies
-- Run `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm` to generate SRPM
-- Test if the SRPM builds successfully using the `build_package` tool:
-  * Call build_package with the SRPM path, dist_git_branch, and jira_issue
-  * Wait for build results
-  * If build PASSES: Report success=true with the SRPM path
-  * If build FAILS: Use `download_artifacts` to get build logs if available
-  * Extract the new error message from the logs:
-    - IMPORTANT: Before viewing log files, check their size using `wc -l` command
-    - If a log file has more than 2000 lines, use the view tool with offset and limit
-      parameters to read only the LAST 1000 lines (calculate offset as total_lines - 1000, limit as 1000)
-    - Build failures are almost always at the end of logs, avoiding context overflow
-    - Alternatively, use the `search_text` tool to search for error patterns (e.g., "ERROR", "FAILED", "error:", "fatal:")
-      and then use the view tool to read targeted sections around the matching line numbers
-    - Combine strategies as needed to understand the failure without reading the entire file
-  * Report success=false with the extracted error
+5. Test the build:
+   - `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
+   - `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`
+   - Call `build_package` with the SRPM path, dist_git_branch, and jira_issue
+   - If build fails: use `download_artifacts` to get logs and identify the new error
 
-Report your results:
-- If build passes: Report success=true with the SRPM path
-- If build fails: Report success=false with the extracted error message
-- If you can't find a fix: Report success=false explaining why
+6. Append a summary to `<LOCAL_CLONE>-upstream/build-logs/fix-attempts.md` documenting:
+   - What you identified as the root cause
+   - Which commits you cherry-picked or what manual edits you made
+   - The build result (pass/fail and error if applicable)
 
-IMPORTANT RULES:
-- Work in the EXISTING <LOCAL_CLONE>-upstream directory (don't clone again)
-- NEVER modify the spec file - build failures are caused by incomplete patches, not spec issues
-- The ONLY dist-git file you can modify is <JIRA_ISSUE>.patch (by regenerating it from upstream repo)
-- Fix build errors (compilation AND test failures) by adding missing prerequisites/dependencies to your patches in upstream repo
-- For test failures: backport minimal necessary test helpers/functions to make tests pass
-- You can freely explore, edit, cherry-pick, and commit in the upstream repo - it's your workspace
-- Use the upstream repo as a rich source of information and examples
-- Be creative and pragmatic - the goal is a working build with passing tests, not perfect git history
-- Make ONE solid attempt to fix the issue - if the build fails, report the error clearly
-- Your work will persist in the upstream repo for the next attempt if needed
-
-STEP 6: Document the fix attempt
-- Append a summary to <LOCAL_CLONE>-upstream/build-logs/fix-attempts.md documenting:
-  * What you identified as the root cause
-  * Which commits you cherry-picked or what manual edits you made
-  * The build result (pass/fail and error if applicable)
+Report success=true with SRPM path if build passes.
+Report success=false with the extracted error if build fails or you can't find a fix.
 
 ---
 
@@ -1052,8 +908,7 @@ The final output must be a JSON object:
 ```json
 {
     "success": true,
-    "status": "Detailed description of backporting steps taken and how conflicts were resolved",
-    "srpm_path": "/absolute/path/to/generated.srpm",
+    "status": "Detailed description of backport steps taken including conflict resolution",
     "merge_request_url": "https://gitlab.com/...",
     "error": null
 }
@@ -1065,7 +920,6 @@ On failure:
 {
     "success": false,
     "status": "",
-    "srpm_path": null,
     "merge_request_url": null,
     "error": "Specific details about the error"
 }

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -227,10 +227,13 @@ BACKPORT_INSTRUCTIONS = """
                 - Use `git_patch_create` tool with:
                   * repository_path: <UPSTREAM_REPO>
                   * patch_file_path: use the naming convention from step 0
-                    (default: <JIRA_ISSUE>.patch) in the current working
+                    (default: `<JIRA_ISSUE>.patch`) in the current working
                     directory (the dist-git repository root)
                 - The tool automatically uses the base commit recorded in step 4e to include
                   ALL cherry-picked commits, not just the last one
+                - For multi-patch (when maintainer rules request one patch per commit),
+                  use `run_shell_command` with `git format-patch -1 <hash> --stdout > <name>`
+                  per commit instead of `git_patch_create`
                 - IMPORTANT: Only create NEW patch files. Do NOT modify
                   existing patches in the dist-git repository
 
@@ -261,9 +264,11 @@ BACKPORT_INSTRUCTIONS = """
                 - Use `git_patch_create` tool with:
                   * repository_path: <UNPACKED_SOURCES>
                   * patch_file_path: use the naming convention from step 0
-                    (default: <JIRA_ISSUE>.patch) in the current working
+                    (default: `<JIRA_ISSUE>.patch`) in the current working
                     directory (the dist-git repository root)
                 - The tool automatically captures all applied changes into one patch file.
+                - For multi-patch, use `run_shell_command` with `git format-patch`
+                  per commit instead of `git_patch_create`
 
       5. Update the spec file. Add new `Patch` tag(s) for each patch file generated in step 4.
          Add the new `Patch` tag(s) after all existing `Patch` tags and, if `Patch` tags are numbered,
@@ -474,10 +479,13 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
                 - Use `git_patch_create` tool with:
                   * repository_path: <UPSTREAM_REPO>
                   * patch_file_path: use the naming convention from step 0
-                    (default: <JIRA_ISSUE>.patch) in the current working
+                    (default: `<JIRA_ISSUE>.patch`) in the current working
                     directory (the dist-git repository root)
                 - The tool automatically uses the base commit recorded in step 3i to include
                   ALL cherry-picked commits, not just the last one
+                - For multi-patch (when maintainer rules request one patch per commit),
+                  use `run_shell_command` with `git format-patch -1 <hash> --stdout > <name>`
+                  per commit instead of `git_patch_create`
                 - IMPORTANT: Only create NEW patch files. Do NOT modify
                   existing patches in the dist-git repository
 
@@ -510,9 +518,11 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
                 - Use `git_patch_create` tool with:
                   * repository_path: <UNPACKED_SOURCES>
                   * patch_file_path: use the naming convention from step 0
-                    (default: <JIRA_ISSUE>.patch) in the current working
+                    (default: `<JIRA_ISSUE>.patch`) in the current working
                     directory (the dist-git repository root)
                 - The tool automatically captures all applied changes into one patch file.
+                - For multi-patch, use `run_shell_command` with `git format-patch`
+                  per commit instead of `git_patch_create`
 
       4. Update the spec file. Add new `Patch` tag(s) for each patch file generated above.
          Add the new `Patch` tag(s) after all existing `Patch` tags and, if `Patch` tags are numbered,

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -107,6 +107,13 @@ BACKPORT_INSTRUCTIONS = """
          commit message footers (Jira/CVE references appended automatically),
          and MR creation/description.
 
+         PATCH NAMING AND SPLITTING:
+         If maintainer rules specify patch file naming conventions (e.g., descriptive
+         names like `<PACKAGE>-<description>.patch`, or splitting into one patch per
+         upstream commit), follow those conventions for all new patch files and spec
+         `Patch` tags. Otherwise use the default: a single squashed patch named
+         `<JIRA_ISSUE>.patch`.
+
       1. Knowing Jira issue <JIRA_ISSUE>, CVE ID <CVE_ID> or both, use the `git_log_search` tool to check
          in the dist-git repository whether the issue/CVE has already been resolved. If it has,
          end the process with `success=True` and `status="Backport already applied"`.
@@ -216,23 +223,21 @@ BACKPORT_INSTRUCTIONS = """
                   5. If a cherry-pick results in an empty commit (changes already present),
                      use `cherry_pick_continue` with `allow_empty=True`, or skip the commit.
 
-            4g. Generate the final patch file from upstream:
+            4g. Generate the final patch file(s) from upstream:
                 - Use `git_patch_create` tool with:
                   * repository_path: <UPSTREAM_REPO>
-                  * patch_file_path: <JIRA_ISSUE>.patch in the current working
+                  * patch_file_path: use the naming convention from step 0
+                    (default: <JIRA_ISSUE>.patch) in the current working
                     directory (the dist-git repository root)
-                    (e.g., if JIRA is RHEL-114639, use /path/to/distgit/RHEL-114639.patch)
                 - The tool automatically uses the base commit recorded in step 4e to include
                   ALL cherry-picked commits, not just the last one
                 - IMPORTANT: Only create NEW patch files. Do NOT modify
                   existing patches in the dist-git repository
-                - This patch file is now ready to be added to the spec file
 
-            4h. The cherry-pick workflow is complete! The generated patch file contains the cleanly
-                cherry-picked fix. Continue with steps 5-7 below to add this patch to the spec file,
-                verify it with `<PKG_TOOL> prep`, and build the SRPM.
+            4h. The cherry-pick workflow is complete! Continue with steps 5-7 below to add
+                the patch(es) to the spec file, verify with `<PKG_TOOL> prep`, and build the SRPM.
 
-                Note: You do NOT need to apply this patch to <UNPACKED_SOURCES>. The patch file
+                Note: You do NOT need to apply patches to <UNPACKED_SOURCES>. The patch files
                 will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
 
          B. GIT AM WORKFLOW (Fallback approach):
@@ -252,18 +257,19 @@ BACKPORT_INSTRUCTIONS = """
                 - Use the `git_apply_finish` tool to finish the patch application.
                 - Repeat for each pre-downloaded patch file.
 
-            B2. After ALL patches have been applied, generate a single combined patch:
+            B2. After ALL patches have been applied, generate the output patch(es):
                 - Use `git_patch_create` tool with:
                   * repository_path: <UNPACKED_SOURCES>
-                  * patch_file_path: <JIRA_ISSUE>.patch in the current working
+                  * patch_file_path: use the naming convention from step 0
+                    (default: <JIRA_ISSUE>.patch) in the current working
                     directory (the dist-git repository root)
                 - The tool automatically captures all applied changes into one patch file.
 
-      5. Update the spec file. Add ONE new `Patch` tag for <JIRA_ISSUE>.patch.
-         Add the new `Patch` tag after all existing `Patch` tags and, if `Patch` tags are numbered,
-         make sure it has the highest number. Make sure the patch is applied in the "%prep" section
+      5. Update the spec file. Add new `Patch` tag(s) for each patch file generated in step 4.
+         Add the new `Patch` tag(s) after all existing `Patch` tags and, if `Patch` tags are numbered,
+         make sure they have the highest numbers. Make sure each patch is applied in the "%prep" section
          and the `-p` argument is correct. Add upstream URLs as comments above
-         the `Patch:` tag - these URLs reference the related upstream commits or pull/merge requests.
+         the `Patch:` tag(s) - these URLs reference the related upstream commits or pull/merge requests.
          IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order.
 
       6. Run
@@ -329,6 +335,13 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
          build triggering (automatic after you finish), Release field updates,
          commit message footers (Jira/CVE references appended automatically),
          and MR creation/description.
+
+         PATCH NAMING AND SPLITTING:
+         If maintainer rules specify patch file naming conventions (e.g., descriptive
+         names like `<PACKAGE>-<description>.patch`, or splitting into one patch per
+         upstream commit), follow those conventions for all new patch files and spec
+         `Patch` tags. Otherwise use the default: a single squashed patch named
+         `<JIRA_ISSUE>.patch`.
 
       1. Knowing Jira issue <JIRA_ISSUE>, CVE ID <CVE_ID> or both, use the `git_log_search` tool to check
          in the dist-git repository whether the issue/CVE has already been resolved. If it has,
@@ -457,23 +470,21 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
                   5. If a cherry-pick results in an empty commit (changes already present),
                      use `cherry_pick_continue` with `allow_empty=True`, or skip the commit.
 
-            3k. Generate the final patch file from upstream:
+            3k. Generate the final patch file(s) from upstream:
                 - Use `git_patch_create` tool with:
                   * repository_path: <UPSTREAM_REPO>
-                  * patch_file_path: <JIRA_ISSUE>.patch in the current working
+                  * patch_file_path: use the naming convention from step 0
+                    (default: <JIRA_ISSUE>.patch) in the current working
                     directory (the dist-git repository root)
-                    (e.g., if JIRA is RHEL-114639, use /path/to/distgit/RHEL-114639.patch)
                 - The tool automatically uses the base commit recorded in step 3i to include
                   ALL cherry-picked commits, not just the last one
                 - IMPORTANT: Only create NEW patch files. Do NOT modify
                   existing patches in the dist-git repository
-                - This patch file is now ready to be added to the spec file
 
-            3l. The cherry-pick workflow is complete! The generated patch file contains the cleanly
-                cherry-picked fix. Continue with steps 4-6 below to add this patch to the spec file,
-                verify it with `<PKG_TOOL> prep`, and build the SRPM.
+            3l. The cherry-pick workflow is complete! Continue with steps 4-6 below to add
+                the patch(es) to the spec file, verify with `<PKG_TOOL> prep`, and build the SRPM.
 
-                Note: You do NOT need to apply this patch to <UNPACKED_SOURCES>. The patch file
+                Note: You do NOT need to apply patches to <UNPACKED_SOURCES>. The patch files
                 will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
 
          C. GIT AM WORKFLOW (Fallback approach):
@@ -495,14 +506,15 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
                 - Use the `git_apply_finish` tool to finish the patch application.
                 - Repeat for each pre-downloaded patch file.
 
-            C2. After ALL patches have been applied, generate a single combined patch:
+            C2. After ALL patches have been applied, generate the output patch(es):
                 - Use `git_patch_create` tool with:
                   * repository_path: <UNPACKED_SOURCES>
-                  * patch_file_path: <JIRA_ISSUE>.patch in the current working
+                  * patch_file_path: use the naming convention from step 0
+                    (default: <JIRA_ISSUE>.patch) in the current working
                     directory (the dist-git repository root)
                 - The tool automatically captures all applied changes into one patch file.
 
-      4. Update the spec file. Add ONE new `Patch` tag for each new patch file.
+      4. Update the spec file. Add new `Patch` tag(s) for each patch file generated above.
          Add the new `Patch` tag(s) after all existing `Patch` tags and, if `Patch` tags are numbered,
          make sure they have the highest numbers. Make sure each patch is applied in the "%prep" section
          and the `-p` argument is correct. Do NOT add any comments to the spec file.
@@ -609,7 +621,8 @@ BACKPORT_FIX_BUILD_ERROR_PROMPT = """
       - The upstream repository at {{local_clone}}-upstream has all your previous work intact.
         DO NOT clone it again. DO NOT reset to base commit.
       - DO NOT modify anything in {{local_clone}} dist-git repository except
-        {{jira_issue}}.patch (by regenerating it from upstream repo).
+        the backport patch file(s) you created (by regenerating them from upstream repo).
+        Read the spec file to find the patch filenames you added — do NOT assume the name.
       - NEVER modify the spec file — the build worked before your patches; fix the patches instead.
       - Fix BOTH compilation errors AND test failures. NEVER skip or disable tests.
       - Make ONE attempt — you will be called again if the build still fails.
@@ -637,9 +650,10 @@ BACKPORT_FIX_BUILD_ERROR_PROMPT = """
       - If tests fail due to API changes: adapt test code to work with older APIs
       - NEVER skip or disable tests — fix them instead
 
-      4. Regenerate the patch using `git_patch_create` tool with:
+      4. Regenerate the patch file(s) you created. Read the spec file to find the
+         patch filenames you added, then regenerate them using `git_patch_create` tool with:
          - repository_path: {{local_clone}}-upstream
-         - patch_file_path: {{local_clone}}/{{jira_issue}}.patch
+         - patch_file_path: the path to each patch file in {{local_clone}}/
 
       5. Test the build:
          - `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep`


### PR DESCRIPTION
In the end I went with the prompt change alone as the agent has already worked pretty well with taking the suggestions from rules/ into the account.

The SKILL.md was regenerated

cc @mruprich 