### PR TITLE
Route prep_sources through MCP gateway instead of running rhpkg directly

### DIFF
--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -489,27 +489,17 @@ async def clone_and_prep_sources(
         available_tools=available_tools,
     )
 
-    if is_cs_branch(dist_git_branch):
-        pkg_cmd = [
-            "centpkg",
-            f"--name={package}",
-            "--namespace=rpms",
-            f"--release={dist_git_branch}",
-        ]
-    else:
-        pkg_cmd = [
-            "rhpkg",
-            f"--name={package}",
-            "--namespace=rpms",
-            f"--release={dist_git_branch}",
-            "--offline",
-            "--released",
-        ]
-    exit_code, _, stderr = await run_subprocess([*pkg_cmd, "prep"], cwd=local_clone)
-    if exit_code == 0:
+    try:
+        await run_tool(
+            "prep_sources",
+            dist_git_path=str(local_clone),
+            package=package,
+            dist_git_branch=dist_git_branch,
+            available_tools=available_tools,
+        )
         unpacked = get_unpacked_sources(local_clone, package)
         return local_clone, unpacked, True
-
-    logger.warning(f"prep failed for {package}, falling back to manual extraction: {stderr}")
-    unpacked = await _fallback_extract_sources(local_clone, package)
-    return local_clone, unpacked, False
+    except Exception as e:
+        logger.warning(f"prep failed for {package}, falling back to manual extraction: {e}")
+        unpacked = await _fallback_extract_sources(local_clone, package)
+        return local_clone, unpacked, False

--- a/ymir/tools/privileged/lookaside.py
+++ b/ymir/tools/privileged/lookaside.py
@@ -93,9 +93,12 @@ class PrepSourcesTool(Tool[PrepSourcesToolInput, ToolRunOptions, StringToolOutpu
         context: RunContext,
     ) -> StringToolOutput:
         await _try_init_kerberos()
+        cmd = _pkg_cmd(tool_input.package, tool_input.dist_git_branch)
+        if not is_cs_branch(tool_input.dist_git_branch):
+            cmd.extend(["--offline", "--released"])
+        cmd.append("prep")
         proc = await asyncio.create_subprocess_exec(
-            *_pkg_cmd(tool_input.package, tool_input.dist_git_branch),
-            "prep",
+            *cmd,
             cwd=tool_input.dist_git_path,
         )
         if await proc.wait():

--- a/ymir/tools/privileged/tests/unit/test_lookaside.py
+++ b/ymir/tools/privileged/tests/unit/test_lookaside.py
@@ -61,7 +61,7 @@ async def test_prep_sources(branch):
 
     async def create_subprocess_exec(cmd, *args, **kwargs):
         assert cmd == "rhpkg" if branch.startswith("rhel") else "centpkg"
-        assert args[3] == "prep"
+        assert args[-1] == "prep"
 
         async def wait():
             return 0


### PR DESCRIPTION
Privileged operations should go through the MCP gateway regardless of what is installed locally. Consistent with how download_sources is already handled.
