### PR TITLE
Run prep locally in agent container, not via MCP gateway

### DIFF
--- a/templates/build.env
+++ b/templates/build.env
@@ -6,15 +6,15 @@
 # the .env file. Without .env, containers build normally without any internal-only packages.
 
 # Repo URL for CentOS Stream 9 agent image (curl'd into the container)
-INTERNAL_REPO_URL_C9S=
+INTERNAL_REPO_URL_C9S=https://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-rhel-9-baseos.repo
 
 # Repo URL for CentOS Stream 10 agent image (curl'd into the container)
-INTERNAL_REPO_URL_C10S=
+INTERNAL_REPO_URL_C10S=https://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-rhel-10-baseos.repo
 
 # Repo URL for MCP gateway (Fedora-based, curl'd into the container)
-INTERNAL_REPO_URL_MCP=
+INTERNAL_REPO_URL_MCP=https://download.devel.redhat.com/rel-eng/RCMTOOLS/rcm-tools-2-fedora.repo
 
 # Space-separated list of extra packages to install per container
-INTERNAL_PACKAGES_C9S=
-INTERNAL_PACKAGES_C10S=
-INTERNAL_PACKAGES_MCP=
+INTERNAL_PACKAGES_C9S=rhpkg
+INTERNAL_PACKAGES_C10S=rhpkg
+INTERNAL_PACKAGES_MCP=rhpkg

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -489,6 +489,9 @@ async def clone_and_prep_sources(
         available_tools=available_tools,
     )
 
+    # Run prep locally rather than via MCP gateway: the agent container is
+    # RHEL-based so rpmbuild evaluates %prep macros correctly, whereas the
+    # MCP gateway runs Fedora and would expand them differently.
     if is_cs_branch(dist_git_branch):
         pkg_cmd = [
             "centpkg",
@@ -505,7 +508,15 @@ async def clone_and_prep_sources(
             "--offline",
             "--released",
         ]
-    exit_code, _, stderr = await run_subprocess([*pkg_cmd, "prep"], cwd=local_clone)
+    try:
+        exit_code, _, stderr = await run_subprocess([*pkg_cmd, "prep"], cwd=local_clone)
+    except FileNotFoundError:
+        logger.warning(
+            f"prep failed for {package}: {pkg_cmd[0]} is not installed, falling back to manual extraction"
+        )
+        unpacked = await _fallback_extract_sources(local_clone, package)
+        return local_clone, unpacked, False
+
     if exit_code == 0:
         unpacked = get_unpacked_sources(local_clone, package)
         return local_clone, unpacked, True

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -489,17 +489,27 @@ async def clone_and_prep_sources(
         available_tools=available_tools,
     )
 
-    try:
-        await run_tool(
-            "prep_sources",
-            dist_git_path=str(local_clone),
-            package=package,
-            dist_git_branch=dist_git_branch,
-            available_tools=available_tools,
-        )
+    if is_cs_branch(dist_git_branch):
+        pkg_cmd = [
+            "centpkg",
+            f"--name={package}",
+            "--namespace=rpms",
+            f"--release={dist_git_branch}",
+        ]
+    else:
+        pkg_cmd = [
+            "rhpkg",
+            f"--name={package}",
+            "--namespace=rpms",
+            f"--release={dist_git_branch}",
+            "--offline",
+            "--released",
+        ]
+    exit_code, _, stderr = await run_subprocess([*pkg_cmd, "prep"], cwd=local_clone)
+    if exit_code == 0:
         unpacked = get_unpacked_sources(local_clone, package)
         return local_clone, unpacked, True
-    except Exception as e:
-        logger.warning(f"prep failed for {package}, falling back to manual extraction: {e}")
-        unpacked = await _fallback_extract_sources(local_clone, package)
-        return local_clone, unpacked, False
+
+    logger.warning(f"prep failed for {package}, falling back to manual extraction: {stderr}")
+    unpacked = await _fallback_extract_sources(local_clone, package)
+    return local_clone, unpacked, False

--- a/ymir/tools/privileged/lookaside.py
+++ b/ymir/tools/privileged/lookaside.py
@@ -57,11 +57,15 @@ class DownloadSourcesTool(Tool[DownloadSourcesToolInput, ToolRunOptions, StringT
         context: RunContext,
     ) -> StringToolOutput:
         await _try_init_kerberos()
-        proc = await asyncio.create_subprocess_exec(
-            *_pkg_cmd(tool_input.package, tool_input.dist_git_branch),
-            "sources",
-            cwd=tool_input.dist_git_path,
-        )
+        cmd = _pkg_cmd(tool_input.package, tool_input.dist_git_branch)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                "sources",
+                cwd=tool_input.dist_git_path,
+            )
+        except FileNotFoundError as e:
+            raise ToolError(f"Failed to download sources: {cmd[0]} is not installed") from e
         if await proc.wait():
             raise ToolError("Failed to download sources")
         return StringToolOutput(result="Successfully downloaded sources from lookaside cache")
@@ -93,11 +97,17 @@ class PrepSourcesTool(Tool[PrepSourcesToolInput, ToolRunOptions, StringToolOutpu
         context: RunContext,
     ) -> StringToolOutput:
         await _try_init_kerberos()
-        proc = await asyncio.create_subprocess_exec(
-            *_pkg_cmd(tool_input.package, tool_input.dist_git_branch),
-            "prep",
-            cwd=tool_input.dist_git_path,
-        )
+        cmd = _pkg_cmd(tool_input.package, tool_input.dist_git_branch)
+        if not is_cs_branch(tool_input.dist_git_branch):
+            cmd.extend(["--offline", "--released"])
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                "prep",
+                cwd=tool_input.dist_git_path,
+            )
+        except FileNotFoundError as e:
+            raise ToolError(f"Failed to prep sources: {cmd[0]} is not installed") from e
         if await proc.wait():
             raise ToolError("Failed to prep sources")
         return StringToolOutput(result="Successfully prepped sources")

--- a/ymir/tools/privileged/lookaside.py
+++ b/ymir/tools/privileged/lookaside.py
@@ -93,12 +93,9 @@ class PrepSourcesTool(Tool[PrepSourcesToolInput, ToolRunOptions, StringToolOutpu
         context: RunContext,
     ) -> StringToolOutput:
         await _try_init_kerberos()
-        cmd = _pkg_cmd(tool_input.package, tool_input.dist_git_branch)
-        if not is_cs_branch(tool_input.dist_git_branch):
-            cmd.extend(["--offline", "--released"])
-        cmd.append("prep")
         proc = await asyncio.create_subprocess_exec(
-            *cmd,
+            *_pkg_cmd(tool_input.package, tool_input.dist_git_branch),
+            "prep",
             cwd=tool_input.dist_git_path,
         )
         if await proc.wait():

--- a/ymir/tools/privileged/tests/unit/test_lookaside.py
+++ b/ymir/tools/privileged/tests/unit/test_lookaside.py
@@ -61,7 +61,7 @@ async def test_prep_sources(branch):
 
     async def create_subprocess_exec(cmd, *args, **kwargs):
         assert cmd == "rhpkg" if branch.startswith("rhel") else "centpkg"
-        assert args[-1] == "prep"
+        assert args[3] == "prep"
 
         async def wait():
             return 0

--- a/ymir/tools/privileged/tests/unit/test_lookaside.py
+++ b/ymir/tools/privileged/tests/unit/test_lookaside.py
@@ -61,7 +61,8 @@ async def test_prep_sources(branch):
 
     async def create_subprocess_exec(cmd, *args, **kwargs):
         assert cmd == "rhpkg" if branch.startswith("rhel") else "centpkg"
-        assert args[3] == "prep"
+        # prep can be on various places due to --offline and --released flags
+        assert "prep" in args
 
         async def wait():
             return 0


### PR DESCRIPTION
## Summary
- Revert routing `prep_sources` through the MCP gateway (reverts 8d18da6) — the agent container is RHEL-based so `rpmbuild` evaluates `%prep` macros correctly, whereas the MCP gateway runs Fedora and would expand them differently.
- Add `FileNotFoundError` handling so that a missing `rhpkg`/`centpkg` gracefully falls back to manual extraction instead of crashing with an unhandled exception.
- Fill in `build.env` template with actual repo URLs and packages so `rhpkg` is available in agent containers.

## Test plan
- [ ] Verify prep works in agent container (RHEL-based) with `rhpkg` installed
- [ ] Verify graceful fallback when `rhpkg` is not installed
- [ ] All 145 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)