### PR TITLE
Improve E2E test local setup and set User-Agent on all HTTP requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,13 @@ only need to clone it once; the tests run entirely offline against the local cop
 ### Running
 
 ```bash
-make run-triage-agent-e2e-tests DRY_RUN=true
+make run-triage-agent-e2e-tests
 make run-backport-agent-e2e-tests
 ```
+
+Both targets hardcode `MOCK_JIRA=true` and `DRY_RUN=true`. The mock Jira files are writable,
+so without `DRY_RUN=true` the agent would write comments back to them and corrupt the fixtures
+on subsequent runs.
 
 ## Merging Policy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,34 @@
 # Contributing Guidelines
 
+## Running E2E Tests Locally
+
+E2E tests exercise a real LLM against mock Jira fixtures and git repos. They require access to
+the private `git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git` repository.
+
+### Setup
+
+1. Clone the testing-jiras repository somewhere on your machine.
+
+2. Add `JIRA_MOCK_FILES_HOST` to your local `.env` pointing at its `jiras/` directory:
+   ```
+   JIRA_MOCK_FILES_HOST=/path/to/testing-jiras/jiras
+   ```
+   This makes compose mount that directory into the `mcp-gateway` container at the path
+   where mock Jira files are expected.
+
+3. Symlink the mock repo fixtures for git operations:
+   ```bash
+   ln -s /path/to/testing-jiras/mock_data/triage ymir/agents/tests/e2e/mock_repos/triage
+   ln -s /path/to/testing-jiras/mock_data/backport ymir/agents/tests/e2e/mock_repos/backport
+   ```
+
+### Running
+
+```bash
+make run-triage-agent-e2e-tests DRY_RUN=true
+make run-backport-agent-e2e-tests
+```
+
 ## Merging Policy
 
 Prefer rebase-merging over creating a merge commit, unless preserving the branch's history is necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,9 @@
 
 ## Running E2E Tests Locally
 
-E2E tests exercise a real LLM against mock Jira fixtures and git repos. They require access to
-the private `git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git` repository.
+E2E tests exercise a real LLM against mock Jira fixtures and git repos. They require test data
+from the private `git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git` repository — you
+only need to clone it once; the tests run entirely offline against the local copy.
 
 ### Setup
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run-triage-agent-standalone:
 run-triage-agent-e2e-tests:
 	$(COMPOSE) -f $(COMPOSE_FILE) --profile=e2e-test run --rm \
 		-e MOCK_JIRA="true" \
-		-e DRY_RUN=$(DRY_RUN) \
+		-e DRY_RUN="true" \
 		triage-agent-e2e-tests
 
 .PHONY: run-backport-agent-e2e-tests

--- a/compose.yaml
+++ b/compose.yaml
@@ -108,7 +108,7 @@ services:
       - .secrets/mcp-gateway.env
     volumes:
       - ./ymir/tools:/home/mcp/ymir/tools:ro,z
-      - ./ymir/tools/privileged/tests/data:/home/mcp/ymir/tools/privileged/tests/data:rw,z
+      - ${JIRA_MOCK_FILES_HOST:-./ymir/tools/privileged/tests/data}:/home/mcp/ymir/tools/privileged/tests/data:rw,z
       - ./ymir/common:/home/mcp/ymir/common:ro,z
       - .secrets/keytab:/home/mcp/keytab:ro,z,U
       - git-repos:/git-repos

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -207,7 +207,7 @@ BACKPORT_INSTRUCTIONS = """
             4f. Cherry-pick the fix in upstream:
                 GETTING COMMITS:
                   FOR PULL REQUESTS (if is_pr is True from step 4a):
-                    * Download the PR patch: `curl -L <original_url> -o /tmp/pr.patch`
+                    * Download the PR patch: `curl -L -A "redhat-ymir-agent" <original_url> -o /tmp/pr.patch`
                     * Parse commit hashes from lines starting with "From <hash>"
                     * Fetch PR branch: `git -C <UPSTREAM_REPO> fetch origin pull/<pr_number>/head:pr-branch`
                     * Skip any merge commits — only cherry-pick non-merge commits
@@ -467,7 +467,7 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
             3j. Cherry-pick the fix in upstream:
                 GETTING COMMITS:
                   FOR PULL REQUESTS (if is_pr is True from step 3e):
-                    * Download the PR patch: `curl -L <original_url> -o /tmp/pr.patch`
+                    * Download the PR patch: `curl -L -A "redhat-ymir-agent" <original_url> -o /tmp/pr.patch`
                     * Parse commit hashes from lines starting with "From <hash>"
                     * Fetch PR branch: `git -C <UPSTREAM_REPO> fetch origin pull/<pr_number>/head:pr-branch`
                     * Skip any merge commits — only cherry-pick non-merge commits

--- a/ymir/agents/tests/e2e/mock_repos/README.md
+++ b/ymir/agents/tests/e2e/mock_repos/README.md
@@ -4,8 +4,12 @@ This directory contains mock repo fixture files organized by agent type.
 The fixtures come from `git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git`
 if you have access.
 
-Clone the repository and copy (or symlink) the contents of its `mock_data/`
-directory here, preserving the subdirectory structure.
+Clone the repository and symlink its `mock_data/` subdirectories here:
+
+```bash
+ln -s /path/to/testing-jiras/mock_data/triage ymir/agents/tests/e2e/mock_repos/triage
+ln -s /path/to/testing-jiras/mock_data/backport ymir/agents/tests/e2e/mock_repos/backport
+```
 
 ## Expected layout
 

--- a/ymir/agents/utilities/compare_xunit.py
+++ b/ymir/agents/utilities/compare_xunit.py
@@ -6,6 +6,8 @@ import aiohttp
 import tomli_w
 from pydantic import BaseModel, Field
 
+from ymir.tools.constants import YMIR_USER_AGENT
+
 
 class XUnitComparisonStatus(BaseModel):
     generated: bool
@@ -267,7 +269,7 @@ async def compare_xunit_files(
     if metadata is None:
         metadata = {}
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers={"User-Agent": YMIR_USER_AGENT}) as session:
 
         async def fetch_url(url: str) -> str:
             async with session.get(url) as response:

--- a/ymir/supervisor/http_utils.py
+++ b/ymir/supervisor/http_utils.py
@@ -4,6 +4,8 @@ from contextvars import ContextVar
 import aiohttp
 import requests
 
+from ymir.tools.constants import YMIR_USER_AGENT
+
 # We use *both* aiohttp and requests in various places, so we need to
 # set up sessions for both libraries. (We can't convert everything to
 # aiohttp because of our usage of requests_gssapi, but aiohttp is nice
@@ -26,7 +28,7 @@ async def with_aiohttp_session():
     session = _aiohttp_session.get()
 
     if session is None:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(headers={"User-Agent": YMIR_USER_AGENT}) as session:
             token = _aiohttp_session.set(session)
             try:
                 yield session

--- a/ymir/supervisor/http_utils.py
+++ b/ymir/supervisor/http_utils.py
@@ -67,6 +67,7 @@ async def with_requests_session():
 
     if session is None:
         with requests.Session() as session:
+            session.headers.update({"User-Agent": YMIR_USER_AGENT})
             token = _requests_session.set(session)
             try:
                 yield session

--- a/ymir/tools/constants.py
+++ b/ymir/tools/constants.py
@@ -1,5 +1,6 @@
 import aiohttp
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=30)
+YMIR_USER_AGENT = "redhat-ymir-agent"
 
 BREWHUB_URL = "https://brewhub.engineering.redhat.com/brewhub"

--- a/ymir/tools/privileged/copr.py
+++ b/ymir/tools/privileged/copr.py
@@ -23,7 +23,7 @@ from ymir.common import load_rhel_config
 from ymir.common.base_utils import KerberosError, init_kerberos_ticket
 from ymir.common.validators import AbsolutePath
 from ymir.tools.base import CloneableTool as Tool
-from ymir.tools.constants import AIOHTTP_TIMEOUT
+from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
 
 COPR_CONFIG = {
     "copr_url": "https://copr.devel.redhat.com",
@@ -298,7 +298,9 @@ class DownloadArtifactsTool(Tool[DownloadArtifactsToolInput, ToolRunOptions, Str
     ) -> StringToolOutput:
         artifacts_urls = tool_input.artifacts_urls
         target_path = tool_input.target_path
-        async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+        async with aiohttp.ClientSession(
+            timeout=AIOHTTP_TIMEOUT, headers={"User-Agent": YMIR_USER_AGENT}
+        ) as session:
             for url in artifacts_urls:
                 logger.info(f"Downloading build artifact from: {url}")
                 try:

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -31,7 +31,7 @@ from ymir.common.models import (
 )
 from ymir.common.validators import AbsolutePath
 from ymir.tools.base import CloneableTool as Tool
-from ymir.tools.constants import AIOHTTP_TIMEOUT
+from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
 from ymir.tools.privileged.utils import clean_stale_repositories
 
 logger = logging.getLogger(__name__)
@@ -99,12 +99,13 @@ def _get_api_diff_url(url: str) -> str:
 
 
 def _get_auth_headers(url: str) -> dict[str, str]:
-    """Return PRIVATE-TOKEN header if *url* points to a private Red Hat GitLab project."""
+    """Return headers for requests; always includes User-Agent, adds PRIVATE-TOKEN for private GitLab."""
+    headers: dict[str, str] = {"User-Agent": YMIR_USER_AGENT}
     if _is_private_gitlab(url):
         token = os.getenv("GITLAB_TOKEN")
         if token:
-            return {"PRIVATE-TOKEN": token}
-    return {}
+            headers["PRIVATE-TOKEN"] = token
+    return headers
 
 
 def _get_authenticated_url(repository_url: str) -> str:

--- a/ymir/tools/privileged/logdetective.py
+++ b/ymir/tools/privileged/logdetective.py
@@ -8,6 +8,7 @@ from beeai_framework.tools import JSONToolOutput, ToolError, ToolRunOptions
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from ymir.tools.base import CloneableTool as Tool
+from ymir.tools.constants import YMIR_USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -164,7 +165,7 @@ class AnalyzeLogsTool(Tool[AnalyzeLogsToolInput, ToolRunOptions, AnalyzeLogsTool
             if metadata:
                 payload["build_metadata"] = metadata
 
-        headers: dict = {"Content-Type": "application/json"}
+        headers: dict = {"Content-Type": "application/json", "User-Agent": YMIR_USER_AGENT}
         if LOG_DETECTIVE_TOKEN:
             headers["Authorization"] = f"Bearer {LOG_DETECTIVE_TOKEN}"
 

--- a/ymir/tools/privileged/maintainer_rules.py
+++ b/ymir/tools/privileged/maintainer_rules.py
@@ -8,7 +8,7 @@ from beeai_framework.emitter import Emitter
 from beeai_framework.tools import StringToolOutput, Tool, ToolError, ToolRunOptions
 from pydantic import BaseModel, Field
 
-from ymir.tools.constants import AIOHTTP_TIMEOUT
+from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,9 @@ class MaintainerRulesTool(Tool[MaintainerRulesInput, ToolRunOptions, StringToolO
         file_path = quote(tool_input.file_path, safe="")
         url = f"{GITLAB_API_URL}/projects/{project_path}/repository/files/{file_path}/raw?ref=main"
 
-        headers = {"PRIVATE-TOKEN": token} if (token := os.getenv("GITLAB_TOKEN")) else {}
+        headers: dict[str, str] = {"User-Agent": YMIR_USER_AGENT}
+        if token := os.getenv("GITLAB_TOKEN"):
+            headers["PRIVATE-TOKEN"] = token
 
         try:
             async with (

--- a/ymir/tools/privileged/tests/data/README.md
+++ b/ymir/tools/privileged/tests/data/README.md
@@ -2,7 +2,20 @@
 This directory is meant to contain Jira mock files from
 `git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git` if you have the access.
 
-Clone the repository and copy (or symlink) the contents of its `jiras/` directory here.
+Clone the repository and either:
+
+- **Run via compose (recommended):** set `JIRA_MOCK_FILES_HOST` in your local `.env` to point
+  at the cloned `jiras/` directory so compose mounts it directly into the container:
+  ```
+  JIRA_MOCK_FILES_HOST=/path/to/testing-jiras/jiras
+  ```
+
+- **Run directly on host:** symlink the contents of its `jiras/` directory here:
+  ```bash
+  ln -s /path/to/testing-jiras/jiras/RHEL-112546 ymir/tools/privileged/tests/data/RHEL-112546
+  # repeat for each issue
+  ```
+
 If you want agents to be able to write to them, add the writing permission bit for all users.
 
 The expected layout of the private repository is:

--- a/ymir/tools/unprivileged/greenwave.py
+++ b/ymir/tools/unprivileged/greenwave.py
@@ -8,7 +8,7 @@ from beeai_framework.tools import StringToolOutput, ToolRunOptions
 from pydantic import BaseModel, Field
 
 from ymir.tools.base import CloneableTool as Tool
-from ymir.tools.constants import AIOHTTP_TIMEOUT
+from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,9 @@ class FetchGreenWaveTool(Tool[FetchGreenWaveInput, ToolRunOptions, StringToolOut
 
         try:
             async with (
-                aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session,
+                aiohttp.ClientSession(
+                    timeout=AIOHTTP_TIMEOUT, headers={"User-Agent": YMIR_USER_AGENT}
+                ) as session,
                 session.get(url) as response,
             ):
                 if response.status == 200:

--- a/ymir/tools/unprivileged/read_readme.py
+++ b/ymir/tools/unprivileged/read_readme.py
@@ -6,6 +6,8 @@ from beeai_framework.emitter import Emitter
 from beeai_framework.tools import StringToolOutput, Tool, ToolRunOptions
 from pydantic import BaseModel, Field
 
+from ymir.tools.constants import YMIR_USER_AGENT
+
 logger = logging.getLogger(__name__)
 
 README_PATTERNS = [
@@ -39,7 +41,7 @@ class ReadReadmeTool(Tool[ReadReadmeInput, ToolRunOptions, StringToolOutput]):
         options: ToolRunOptions | None,
         context: RunContext,
     ) -> StringToolOutput:
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(headers={"User-Agent": YMIR_USER_AGENT}) as session:
             for prefix, suffix in README_PATTERNS:
                 if input.repo_url.startswith(prefix):
                     url = input.repo_url.removesuffix("/") + suffix

--- a/ymir/tools/unprivileged/search_resultsdb.py
+++ b/ymir/tools/unprivileged/search_resultsdb.py
@@ -9,6 +9,8 @@ from beeai_framework.emitter import Emitter
 from beeai_framework.tools import Tool, ToolError, ToolOutput, ToolRunOptions
 from pydantic import BaseModel, Field
 
+from ymir.tools.constants import YMIR_USER_AGENT
+
 logger = logging.getLogger(__name__)
 
 
@@ -52,7 +54,10 @@ async def search_resultsdb(package_nvr: str, name_pattern: str) -> list[ResultsD
         f"&limit={MAX_RESULTS}"
     )
     logger.info("Fetching resultsdb data from %s", url)
-    async with aiohttp.ClientSession() as session, session.get(url) as response:
+    async with (
+        aiohttp.ClientSession(headers={"User-Agent": YMIR_USER_AGENT}) as session,
+        session.get(url) as response,
+    ):
         if response.status == 200:
             response_json = await response.json()
 

--- a/ymir/tools/unprivileged/upstream_tools.py
+++ b/ymir/tools/unprivileged/upstream_tools.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 from ymir.common.base_utils import run_subprocess
 from ymir.common.validators import AbsolutePath
 from ymir.tools.base import CloneableTool as Tool
-from ymir.tools.constants import AIOHTTP_TIMEOUT
+from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
 
 
 class ExtractUpstreamRepositoryInput(BaseModel):
@@ -112,7 +112,7 @@ class ExtractUpstreamRepositoryTool(
 
                 headers = {
                     "Accept": "application/json",
-                    "User-Agent": "RHEL-Backport-Agent",
+                    "User-Agent": YMIR_USER_AGENT,
                 }
 
                 try:
@@ -163,7 +163,7 @@ class ExtractUpstreamRepositoryTool(
                 # Fetch compare information to get the list of commits
                 headers = {
                     "Accept": "application/json",
-                    "User-Agent": "RHEL-Backport-Agent",
+                    "User-Agent": YMIR_USER_AGENT,
                 }
                 commits = []
                 commit_hash = target_ref


### PR DESCRIPTION
## Summary

- Make Jira mock files path configurable via `JIRA_MOCK_FILES_HOST` env var in `compose.yaml`, so the `testing-jiras/jiras/` directory can be mounted directly into the `mcp-gateway` container without copying files
- Document the full local E2E test setup in `CONTRIBUTING.md` (symlinks for mock repos, `JIRA_MOCK_FILES_HOST` for Jira fixtures)
- Set `User-Agent: redhat-ymir-agent` on all outgoing `aiohttp` HTTP requests to prevent upstream servers (e.g. `thekelleys.org.uk` for dnsmasq) from rejecting requests as bots

## Test plan

- [x] Run `make run-triage-agent-e2e-tests DRY_RUN=true` locally with `JIRA_MOCK_FILES_HOST` set to verify tests pass
- [x] Verify no regressions in unit tests: `make check-in-container`

🤖 Generated with [Claude Code](https://claude.com/claude-code)