### PR TITLE
Fix assigning agent type

### DIFF
--- a/trace_server/server.py
+++ b/trace_server/server.py
@@ -43,6 +43,7 @@ import gzip
 import io
 import json
 import os
+import re
 import sqlite3
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -101,8 +102,97 @@ def _get_val(value: dict):
     return None
 
 
-def _extract_spans(otlp_data: dict) -> list[tuple]:
-    rows = []
+class SpanRow:
+    __slots__ = (
+        "agent_type",
+        "attributes",
+        "end_time",
+        "jira_issue",
+        "name",
+        "parent_span_id",
+        "span_id",
+        "start_time",
+        "status_code",
+        "trace_id",
+    )
+
+    def __init__(
+        self,
+        *,
+        trace_id,
+        span_id,
+        parent_span_id,
+        name,
+        start_time,
+        end_time,
+        status_code,
+        jira_issue,
+        agent_type,
+        attributes,
+    ):
+        self.trace_id = trace_id
+        self.span_id = span_id
+        self.parent_span_id = parent_span_id
+        self.name = name
+        self.start_time = start_time
+        self.end_time = end_time
+        self.status_code = status_code
+        self.jira_issue = jira_issue
+        self.agent_type = agent_type
+        self.attributes = attributes
+
+    def as_tuple(self):
+        return (
+            self.trace_id,
+            self.span_id,
+            self.parent_span_id,
+            self.name,
+            self.start_time,
+            self.end_time,
+            self.status_code,
+            self.jira_issue,
+            self.agent_type,
+            self.attributes,
+        )
+
+
+_CAMEL_CASE_RE = re.compile(r"(?<=[a-z])(?=[A-Z])")
+
+
+def _agent_type_from_name(name: str) -> str:
+    return _CAMEL_CASE_RE.sub("_", name.removesuffix("Agent").removesuffix("Analyst")).lower()
+
+
+def _propagate_agent_types(spans: list[SpanRow]) -> None:
+    """Set agent_type on descendant spans by walking down from *Agent spans."""
+    agent_types = {s.span_id: s.agent_type for s in spans if s.agent_type and s.span_id}
+    if not agent_types:
+        return
+
+    children: dict[str, list[SpanRow]] = {}
+    for s in spans:
+        if s.parent_span_id:
+            children.setdefault(s.parent_span_id, []).append(s)
+
+    visited: set[str] = set()
+
+    for span_id, at in agent_types.items():
+        if not span_id or span_id in visited:
+            continue
+        stack = [(span_id, at)]
+        while stack:
+            curr_id, curr_at = stack.pop()
+            if not curr_id or curr_id in visited:
+                continue
+            visited.add(curr_id)
+            for child in children.get(curr_id, []):
+                if not child.agent_type:
+                    child.agent_type = curr_at
+                stack.append((child.span_id, child.agent_type))
+
+
+def _extract_spans(otlp_data: dict) -> list[SpanRow]:
+    spans = []
     for rs in otlp_data.get("resourceSpans") or []:
         resource = rs.get("resource") or {}
         resource_attrs = {
@@ -118,34 +208,37 @@ def _extract_spans(otlp_data: dict) -> list[tuple]:
                     if isinstance(a, dict) and "key" in a
                 }
                 all_attrs = {**resource_attrs, **span_attrs}
-                jira_issue = _get_val(all_attrs.get("jira.issue"))
-                agent_type = _get_val(all_attrs.get("agent.type"))
+                name = span.get("name") or ""
                 status = span.get("status") or {}
                 status_code = status.get("code")
                 if status_code is None:
                     status_code = 0
                 elif isinstance(status_code, str):
                     status_code = _STATUS_CODE_NAMES.get(status_code, 0)
-                rows.append(
-                    (
-                        span.get("traceId", ""),
-                        span.get("spanId", ""),
-                        span.get("parentSpanId", ""),
-                        span.get("name", ""),
-                        int(span.get("startTimeUnixNano") or 0),
-                        int(span.get("endTimeUnixNano") or 0) or None,
-                        int(status_code),
-                        jira_issue,
-                        agent_type,
-                        json.dumps(all_attrs),
+                spans.append(
+                    SpanRow(
+                        trace_id=span.get("traceId") or "",
+                        span_id=span.get("spanId") or "",
+                        parent_span_id=span.get("parentSpanId") or "",
+                        name=name,
+                        start_time=int(span.get("startTimeUnixNano") or 0),
+                        end_time=int(span.get("endTimeUnixNano") or 0) or None,
+                        status_code=int(status_code),
+                        jira_issue=_get_val(all_attrs.get("jira.issue")),
+                        agent_type=_agent_type_from_name(name)
+                        if name.endswith(("Agent", "Analyst"))
+                        else None,
+                        attributes=json.dumps(all_attrs),
                     )
                 )
-    return rows
+
+    _propagate_agent_types(spans)
+    return spans
 
 
 def ingest_spans(otlp_data: dict) -> int:
-    rows = _extract_spans(otlp_data)
-    if not rows:
+    spans = _extract_spans(otlp_data)
+    if not spans:
         return 0
     db = get_db()
     db.executemany(
@@ -153,10 +246,10 @@ def ingest_spans(otlp_data: dict) -> int:
            (trace_id, span_id, parent_span_id, name, start_time, end_time,
             status_code, jira_issue, agent_type, attributes)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        rows,
+        [s.as_tuple() for s in spans],
     )
     db.commit()
-    return len(rows)
+    return len(spans)
 
 
 def query_issues() -> list[str]:

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import itertools
 import logging
 import os
@@ -900,7 +899,6 @@ async def run_workflow(
     backport_agent_factory=None,
     max_build_attempts=10,
     max_incremental_fix_attempts=None,
-    span_processor=None,
 ):
     if max_incremental_fix_attempts is None:
         max_incremental_fix_attempts = max_build_attempts
@@ -1149,20 +1147,18 @@ async def run_workflow(
                 return "comment_in_jira"
 
             fresh_build_agent = create_build_agent(gateway_tools, local_tool_options)
-            ctx = span_processor.agent_type_context("build") if span_processor else contextlib.nullcontext()
-            with ctx:
-                response = await fresh_build_agent.run(
-                    render_prompt(
-                        template=get_build_prompt(),
-                        input=BuildInputSchema(
-                            srpm_path=state.backport_result.srpm_path,
-                            dist_git_branch=state.dist_git_branch,
-                            jira_issue=state.jira_issue,
-                        ),
+            response = await fresh_build_agent.run(
+                render_prompt(
+                    template=get_build_prompt(),
+                    input=BuildInputSchema(
+                        srpm_path=state.backport_result.srpm_path,
+                        dist_git_branch=state.dist_git_branch,
+                        jira_issue=state.jira_issue,
                     ),
-                    expected_output=BuildOutputSchema,
-                    **get_agent_execution_config(),
-                )
+                ),
+                expected_output=BuildOutputSchema,
+                **get_agent_execution_config(),
+            )
             build_result = BuildOutputSchema.model_validate_json(response.last_message.text)
             if build_result.success:
                 state.incremental_fix_attempts = 0
@@ -1238,20 +1234,18 @@ async def run_workflow(
             if source_changelog:
                 logger.info(f"Extracted source changelog for reuse: {source_changelog}")
 
-            ctx = span_processor.agent_type_context("log") if span_processor else contextlib.nullcontext()
-            with ctx:
-                response = await log_agent.run(
-                    render_prompt(
-                        template=get_log_prompt(),
-                        input=LogInputSchema(
-                            jira_issue=state.jira_issue,
-                            changes_summary=state.backport_log[-1],
-                            source_changelog=source_changelog,
-                        ),
+            response = await log_agent.run(
+                render_prompt(
+                    template=get_log_prompt(),
+                    input=LogInputSchema(
+                        jira_issue=state.jira_issue,
+                        changes_summary=state.backport_log[-1],
+                        source_changelog=source_changelog,
                     ),
-                    expected_output=LogOutputSchema,
-                    **get_agent_execution_config(),
-                )
+                ),
+                expected_output=LogOutputSchema,
+                **get_agent_execution_config(),
+            )
             log_output = LogOutputSchema.model_validate_json(response.last_message.text)
 
             if redis_conn and not dry_run:
@@ -1369,7 +1363,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     resolve_chat_model_override("backport")
 
-    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"], agent_type="backport")
+    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     max_build_attempts = int(os.getenv("MAX_BUILD_ATTEMPTS", "10"))
@@ -1396,7 +1390,6 @@ async def main() -> None:
                 dry_run=dry_run,
                 max_build_attempts=max_build_attempts,
                 max_incremental_fix_attempts=max_incremental_fix_attempts,
-                span_processor=span_processor,
             )
             logger.info(f"Direct run completed: {state.backport_result.model_dump_json(indent=4)}")
             return
@@ -1471,7 +1464,6 @@ async def main() -> None:
                         dry_run=dry_run,
                         max_build_attempts=max_build_attempts,
                         max_incremental_fix_attempts=max_incremental_fix_attempts,
-                        span_processor=span_processor,
                     )
                     logger.info(
                         f"Backport processing completed for {backport_data.jira_issue}, "

--- a/ymir/agents/merge_request_agent.py
+++ b/ymir/agents/merge_request_agent.py
@@ -179,7 +179,7 @@ def extract_jira_issue(mr_description: str) -> str:
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
-    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"], agent_type="merge_request")
+    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     max_build_attempts = int(os.getenv("MAX_BUILD_ATTEMPTS", "10"))
@@ -290,19 +290,18 @@ async def main() -> None:
                 return "comment_in_mr"
 
             async def run_build_agent(state):
-                with span_processor.agent_type_context("build"):
-                    response = await build_agent.run(
-                        render_prompt(
-                            template=get_build_prompt(),
-                            input=BuildInputSchema(
-                                srpm_path=state.mr_update_result.srpm_path,
-                                dist_git_branch=state.dist_git_branch,
-                                jira_issue=state.jira_issue,
-                            ),
+                response = await build_agent.run(
+                    render_prompt(
+                        template=get_build_prompt(),
+                        input=BuildInputSchema(
+                            srpm_path=state.mr_update_result.srpm_path,
+                            dist_git_branch=state.dist_git_branch,
+                            jira_issue=state.jira_issue,
                         ),
-                        expected_output=BuildOutputSchema,
-                        **get_agent_execution_config(),
-                    )
+                    ),
+                    expected_output=BuildOutputSchema,
+                    **get_agent_execution_config(),
+                )
                 build_result = BuildOutputSchema.model_validate_json(response.last_message.text)
                 if build_result.success:
                     return "stage_changes"

--- a/ymir/agents/observability.py
+++ b/ymir/agents/observability.py
@@ -14,10 +14,6 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 class AgentSpanProcessor(SpanProcessor):
     _jira_issue_var: ContextVar[str | None] = ContextVar("jira_issue", default=None)
-    _agent_type_var: ContextVar[str | None] = ContextVar("agent_type", default=None)
-
-    def __init__(self, agent_type: str) -> None:
-        self._default_agent_type = agent_type
 
     def set_jira_issue(self, jira_issue: str | None) -> None:
         self._jira_issue_var.set(jira_issue)
@@ -30,18 +26,8 @@ class AgentSpanProcessor(SpanProcessor):
         finally:
             self._jira_issue_var.reset(token)
 
-    @contextlib.contextmanager
-    def agent_type_context(self, agent_type: str):
-        token = self._agent_type_var.set(agent_type)
-        try:
-            yield
-        finally:
-            self._agent_type_var.reset(token)
-
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         if span.is_recording():
-            agent_type = self._agent_type_var.get() or self._default_agent_type
-            span.set_attribute("agent.type", agent_type)
             jira_issue = self._jira_issue_var.get()
             if jira_issue:
                 span.set_attribute("jira.issue", jira_issue)
@@ -56,10 +42,10 @@ class AgentSpanProcessor(SpanProcessor):
         return True
 
 
-def setup_observability(endpoint: str, agent_type: str) -> AgentSpanProcessor:
+def setup_observability(endpoint: str) -> AgentSpanProcessor:
     resource = Resource(attributes={})
     tracer_provider = trace_sdk.TracerProvider(resource=resource)
-    processor = AgentSpanProcessor(agent_type)
+    processor = AgentSpanProcessor()
     tracer_provider.add_span_processor(processor)
     tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint)))
     trace_api.set_tracer_provider(tracer_provider)

--- a/ymir/agents/preliminary_testing_agent.py
+++ b/ymir/agents/preliminary_testing_agent.py
@@ -450,7 +450,7 @@ async def _flag_attention(
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
-    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"], agent_type="preliminary_testing")
+    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     ignore_needs_attention = os.getenv("IGNORE_NEEDS_ATTENTION", "false").lower() == "true"

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -218,7 +218,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     resolve_chat_model_override("rebase")
 
-    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"], agent_type="rebase")
+    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     max_build_attempts = int(os.getenv("MAX_BUILD_ATTEMPTS", "10"))
@@ -309,19 +309,18 @@ async def main() -> None:
                 return "comment_in_jira"
 
             async def run_build_agent(state):
-                with span_processor.agent_type_context("build"):
-                    response = await build_agent.run(
-                        render_prompt(
-                            template=get_build_prompt(),
-                            input=BuildInputSchema(
-                                srpm_path=state.rebase_result.srpm_path,
-                                dist_git_branch=state.dist_git_branch,
-                                jira_issue=state.jira_issue,
-                            ),
+                response = await build_agent.run(
+                    render_prompt(
+                        template=get_build_prompt(),
+                        input=BuildInputSchema(
+                            srpm_path=state.rebase_result.srpm_path,
+                            dist_git_branch=state.dist_git_branch,
+                            jira_issue=state.jira_issue,
                         ),
-                        expected_output=BuildOutputSchema,
-                        **get_agent_execution_config(),
-                    )
+                    ),
+                    expected_output=BuildOutputSchema,
+                    **get_agent_execution_config(),
+                )
                 build_result = BuildOutputSchema.model_validate_json(response.last_message.text)
                 if build_result.success:
                     return "update_release"
@@ -373,18 +372,17 @@ async def main() -> None:
                 return "run_log_agent"
 
             async def run_log_agent(state):
-                with span_processor.agent_type_context("log"):
-                    response = await log_agent.run(
-                        render_prompt(
-                            template=get_log_prompt(),
-                            input=LogInputSchema(
-                                jira_issue=state.jira_issue,
-                                changes_summary=state.rebase_log[-1],
-                            ),
+                response = await log_agent.run(
+                    render_prompt(
+                        template=get_log_prompt(),
+                        input=LogInputSchema(
+                            jira_issue=state.jira_issue,
+                            changes_summary=state.rebase_log[-1],
                         ),
-                        expected_output=LogOutputSchema,
-                        **get_agent_execution_config(),
-                    )
+                    ),
+                    expected_output=LogOutputSchema,
+                    **get_agent_execution_config(),
+                )
                 log_output = LogOutputSchema.model_validate_json(response.last_message.text)
 
                 if redis_conn and not dry_run:

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -42,7 +42,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     resolve_chat_model_override("rebuild")
 
-    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"], agent_type="rebuild")
+    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
 
@@ -138,18 +138,17 @@ async def main() -> None:
                 else:
                     summary = f"Rebuild of {state.package} against updated dependencies for {issues_str}."
 
-                with span_processor.agent_type_context("log"):
-                    response = await log_agent.run(
-                        render_prompt(
-                            template=get_log_prompt(),
-                            input=LogInputSchema(
-                                jira_issue=issues_str,
-                                changes_summary=summary,
-                            ),
+                response = await log_agent.run(
+                    render_prompt(
+                        template=get_log_prompt(),
+                        input=LogInputSchema(
+                            jira_issue=issues_str,
+                            changes_summary=summary,
                         ),
-                        expected_output=LogOutputSchema,
-                        **get_agent_execution_config(),
-                    )
+                    ),
+                    expected_output=LogOutputSchema,
+                    **get_agent_execution_config(),
+                )
                 state.log_result = LogOutputSchema.model_validate_json(response.last_message.text)
                 return "stage_changes"
 

--- a/ymir/agents/tests/e2e/backport_agent/test_backport.py
+++ b/ymir/agents/tests/e2e/backport_agent/test_backport.py
@@ -96,7 +96,7 @@ test_cases = _load_test_cases(os.getenv("BACKPORT_MOCK_REPOS_DIR", str(DEFAULT_F
 
 @pytest.fixture(scope="session", autouse=True)
 def observability_fixture():
-    return setup_observability(os.environ["COLLECTOR_ENDPOINT"], agent_type="backport")
+    return setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
 
 SHARED_BARE_REPOS_DIR = Path(os.environ.get("GIT_REPO_BASEPATH", "/git-repos")) / "mock_bare"

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -155,7 +155,7 @@ test_cases = [
 
 @pytest.fixture(scope="session", autouse=True)
 def observability_fixture():
-    return setup_observability(os.environ["COLLECTOR_ENDPOINT"], agent_type="triage")
+    return setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import logging
 import os
 import shutil
@@ -635,13 +634,7 @@ def create_triage_agent(gateway_tools, local_tool_options=None) -> ReasoningAgen
 
 
 async def run_workflow(
-    jira_issue,
-    dry_run,
-    triage_agent_factory,
-    auto_chain=False,
-    force_cve_triage=False,
-    silent_run=False,
-    span_processor=None,
+    jira_issue, dry_run, triage_agent_factory, auto_chain=False, force_cve_triage=False, silent_run=False
 ):
     async with mcp_tools(os.getenv("MCP_GATEWAY_URL")) as gateway_tools:
         triage_agent = triage_agent_factory(gateway_tools)
@@ -1030,17 +1023,11 @@ async def run_workflow(
                     prep_ok=prep_ok,
                 )
 
-                ctx = (
-                    span_processor.agent_type_context("applicability")
-                    if span_processor
-                    else contextlib.nullcontext()
+                response = await applicability_agent.run(
+                    prompt,
+                    expected_output=ApplicabilityResult,
+                    **get_agent_execution_config(),
                 )
-                with ctx:
-                    response = await applicability_agent.run(
-                        prompt,
-                        expected_output=ApplicabilityResult,
-                        **get_agent_execution_config(),
-                    )
                 applicability = ApplicabilityResult.model_validate_json(response.last_message.text)
 
                 if not applicability.is_affected:
@@ -1140,7 +1127,7 @@ async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     resolve_chat_model_override("triage")
 
-    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"], agent_type="triage")
+    span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     auto_chain = os.getenv("AUTO_CHAIN", "true").lower() == "true"
@@ -1158,7 +1145,6 @@ async def main() -> None:
                 auto_chain=auto_chain,
                 force_cve_triage=force_cve_triage,
                 silent_run=silent_run,
-                span_processor=span_processor,
             )
             logger.info(f"Direct run completed: {state.triage_result.model_dump_json(indent=4)}")
             if state.cve_eligibility_result:
@@ -1243,7 +1229,6 @@ async def main() -> None:
                         auto_chain=auto_chain,
                         force_cve_triage=input.force_cve_triage,
                         silent_run=silent_run,
-                        span_processor=span_processor,
                     )
                     output = state.triage_result
                     logger.info(

--- a/ymir/supervisor/main.py
+++ b/ymir/supervisor/main.py
@@ -264,7 +264,7 @@ def main(
 
     collector_endpoint = os.environ.get("COLLECTOR_ENDPOINT")
     if collector_endpoint is not None:
-        setup_observability(collector_endpoint, agent_type="supervisor")
+        setup_observability(collector_endpoint)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The previous solution didn't work, BeeAI instrumentor collects events during agent execution and converts them to spans at the end, so the only way to properly assign agent type is to do it retroactively at once.
This is also the reason real-time monitoring is not possible - all agent-emitted spans appear only after the agent finishes.