### PR TITLE
Skip Z-stream dependency check for maintenance CVEs

### DIFF
--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field
 from ymir.common import CVEEligibilityResult, TriageEligibility, load_rhel_config
 from ymir.common.base_utils import get_jira_auth_headers
 from ymir.common.constants import JIRA_SEARCH_PATH
-from ymir.common.version_utils import get_fix_version_variants, normalize_fix_version, parse_rhel_version
+from ymir.common.version_utils import get_fix_version_variants, normalize_fix_version
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT
 
@@ -472,15 +472,6 @@ class CheckCveTriageEligibilityTool(
         upcoming_z_streams = rhel_config.get("upcoming_z_streams", {})
         current_z_streams = rhel_config.get("current_z_streams", {})
         latest_z_streams = current_z_streams | upcoming_z_streams
-
-        parsed = parse_rhel_version(target_version)
-        is_maintenance = parsed and parsed[0] in _get_maintenance_majors(rhel_config)
-
-        if is_maintenance:
-            logger.info(f"Maintenance Z-stream CVE detected ({target_version})")
-            blocker = await self._check_for_dependency_blocker(issue_key, fields, target_version)
-            if blocker is not None:
-                return blocker
 
         needs_internal_fix = False
         severity = fields.get(SEVERITY_CUSTOM_FIELD, {}).get("value", "")

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -788,7 +788,8 @@ async def test_eligibility_zstream():
 
 
 @pytest.mark.asyncio
-async def test_eligibility_maintenance_zstream_clone_shipped():
+async def test_eligibility_maintenance_zstream_no_dependency_check():
+    """Maintenance Z-stream CVEs skip the dependency check entirely."""
     issue = _make_jira_issue(
         labels=["SecurityTracking"],
         fix_versions=[{"name": "rhel-8.10.z"}],
@@ -800,32 +801,8 @@ async def test_eligibility_maintenance_zstream_clone_shipped():
     flexmock(jira_tools).should_receive("load_rhel_config").and_return(
         _create_async_return(RHEL_CONFIG)
     ).once()
-    flexmock(jira_tools).should_receive("_check_zstream_clones_shipped").with_args(
-        "CVE-2025-12345", "curl", "RHEL-12345"
-    ).and_return(_create_async_return((True, []))).once()
+    flexmock(jira_tools).should_receive("_check_zstream_clones_shipped").never()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
     assert result["eligibility"] == TriageEligibility.IMMEDIATELY
     assert result["needs_internal_fix"] is True
-
-
-@pytest.mark.asyncio
-async def test_eligibility_maintenance_zstream_clones_pending():
-    issue = _make_jira_issue(
-        labels=["SecurityTracking"],
-        fix_versions=[{"name": "rhel-8.10.z"}],
-        summary="CVE-2025-12345 buffer overflow in curl [rhel-8.10.z]",
-        severity="Important",
-        components=[{"name": "curl"}],
-    )
-    flexmock(aiohttp.ClientSession).should_receive("get").replace_with(_mock_jira_get(issue))
-    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
-        _create_async_return(RHEL_CONFIG)
-    ).once()
-    flexmock(jira_tools).should_receive("_check_zstream_clones_shipped").with_args(
-        "CVE-2025-12345", "curl", "RHEL-12345"
-    ).and_return(_create_async_return((False, ["RHEL-555"]))).once()
-
-    result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
-    assert result["eligibility"] == TriageEligibility.PENDING_DEPENDENCIES
-    assert result["pending_zstream_issues"] == ["RHEL-555"]


### PR DESCRIPTION
Maintenance-stream CVEs (e.g. c8s/rhel-8.10.z) no longer need to wait for a sibling Z-stream clone to ship before becoming eligible for triage. The dependency check is only relevant for Y-stream CVEs.

See: https://groups.google.com/a/redhat.com/g/rhel-devel/c/IajzVPo_QIw/m/kkYlMvD2CwAJ

Assisted-by: Claude Opus 4.6

