### PR TITLE
Drop KRB5CCNAME requirement from init_kerberos_ticket

### DIFF
--- a/ymir/common/base_utils.py
+++ b/ymir/common/base_utils.py
@@ -146,42 +146,25 @@ async def init_kerberos_ticket() -> str:
         if not keytab_principal:
             raise KerberosError("Failed to extract principal from keytab file")
 
-    # klist exits with a status of 1 if no cache file exists, so we
-    # need to check for the file first.
+    # klist exits with a status of 1 if no credentials cache is found
+    proc = await asyncio.create_subprocess_exec(
+        "klist",
+        "-l",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
 
-    ccache_file = os.getenv("KRB5CCNAME")
-    if not ccache_file:
-        raise KerberosError("KRB5CCNAME environment variable is not set")
-
-    # Parse KRB5CCNAME which can be in the format TYPE:value (e.g., FILE:/path, KCM:1000)
-    # Only check file existence if TYPE is FILE and the file doesn't exist
-    should_run_klist = True
-    if ":" in ccache_file:
-        cache_type, cache_path = ccache_file.split(":", 1)
-        if cache_type == "FILE" and not os.path.exists(cache_path):
-            should_run_klist = False
-    else:
-        # Legacy format without type prefix - treat as a file path
-        if not os.path.exists(ccache_file):
-            should_run_klist = False
-
-    if should_run_klist:
-        proc = await asyncio.create_subprocess_exec(
-            "klist",
-            "-l",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+    klist_error = None
+    if proc.returncode:
+        klist_error = (
+            f"klist exited with {proc.returncode}:\n"
+            f"stdout: {stdout.decode(errors='replace')}\n"
+            f"stderr: {stderr.decode(errors='replace')}"
         )
-        stdout, stderr = await proc.communicate()
-
-        # klist returns an exit status of 1 if
-        if proc.returncode:
-            logger.error("klist command failed:\nstdout: %s\nstderr: %s", stdout.decode(), stderr.decode())
-            raise KerberosError("Failed to list Kerberos tickets")
-
-        principals = parse_klist_principals(stdout.decode())
-    else:
         principals = []
+    else:
+        principals = parse_klist_principals(stdout.decode())
 
     if keytab_file and keytab_principal:
         if keytab_principal in principals:
@@ -210,7 +193,10 @@ async def init_kerberos_ticket() -> str:
     if principals:
         logger.info("Using existing ticket for %s", principals[0])
         return principals[0]
-    raise KerberosError("No valid Kerberos ticket found and KEYTAB_FILE is not set")
+    msg = "No valid Kerberos ticket found and KEYTAB_FILE is not set"
+    if klist_error:
+        msg += f"\n{klist_error}"
+    raise KerberosError(msg)
 
 
 async def run_subprocess(

--- a/ymir/common/tests/unit/test_utils.py
+++ b/ymir/common/tests/unit/test_utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import subprocess
 
 import httpx
@@ -23,43 +22,19 @@ class TestInitKerberosTicket:
     """Test cases for init_kerberos_ticket() function."""
 
     @pytest.mark.asyncio
-    async def test_missing_krb5ccname_raises_error(self, monkeypatch):
-        """Test that missing KRB5CCNAME environment variable raises KerberosError."""
+    async def test_klist_fails_no_keytab_raises_error(self, monkeypatch):
+        """Test that klist failure with no keytab raises KerberosError with klist details."""
         monkeypatch.delenv("KRB5CCNAME", raising=False)
         monkeypatch.delenv("KEYTAB_FILE", raising=False)
 
-        with pytest.raises(KerberosError, match="KRB5CCNAME environment variable is not set"):
-            await init_kerberos_ticket()
-
-    @pytest.mark.asyncio
-    async def test_ccache_file_not_exists_no_keytab_raises_error(self, monkeypatch):
-        """Test that non-existent ccache file with no keytab raises error."""
-        monkeypatch.delenv("KEYTAB_FILE", raising=False)
-        monkeypatch.setenv("KRB5CCNAME", "/nonexistent/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/nonexistent/ccache").and_return(False)
-        flexmock(asyncio).should_receive("create_subprocess_exec").never()
-
-        # we should avoid calling klist when the ccache file doesn't exist
-        with pytest.raises(
-            KerberosError,
-            match="No valid Kerberos ticket found and KEYTAB_FILE is not set",
-        ):
-            await init_kerberos_ticket()
-
-    @pytest.mark.asyncio
-    async def test_klist_command_failure_raises_error(self, monkeypatch):
-        """Test that klist command failure raises KerberosError."""
         mock_proc = flexmock(returncode=1)
         mock_proc.should_receive("communicate").and_return(_coro((b"error output", b"stderr output")))
 
-        monkeypatch.delenv("KEYTAB_FILE", raising=False)
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
         flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
             "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).and_return(_coro(mock_proc))
 
-        with pytest.raises(KerberosError, match="Failed to list Kerberos tickets"):
+        with pytest.raises(KerberosError, match="klist exited with 1"):
             await init_kerberos_ticket()
 
     @pytest.mark.asyncio
@@ -74,8 +49,6 @@ class TestInitKerberosTicket:
         mock_proc.should_receive("communicate").and_return(_coro((klist_output, b"")))
 
         monkeypatch.delenv("KEYTAB_FILE", raising=False)
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
         flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
             "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).and_return(_coro(mock_proc))
@@ -95,8 +68,6 @@ class TestInitKerberosTicket:
         mock_proc.should_receive("communicate").and_return(_coro((klist_output, b"")))
 
         monkeypatch.delenv("KEYTAB_FILE", raising=False)
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
         flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
             "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).and_return(_coro(mock_proc))
@@ -117,8 +88,6 @@ class TestInitKerberosTicket:
         mock_proc.should_receive("communicate").and_return(_coro((klist_output, b"")))
 
         monkeypatch.delenv("KEYTAB_FILE", raising=False)
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
         flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
             "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).and_return(_coro(mock_proc))
@@ -141,8 +110,6 @@ class TestInitKerberosTicket:
         mock_proc.should_receive("communicate").and_return(_coro((klist_output, b"")))
 
         monkeypatch.setenv("KEYTAB_FILE", "/path/to/keytab")
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
         flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
             "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).and_return(_coro(mock_proc))
@@ -169,8 +136,6 @@ class TestInitKerberosTicket:
         mock_kinit_proc.should_receive("communicate").and_return(_coro((b"error output", b"stderr output")))
 
         monkeypatch.setenv("KEYTAB_FILE", "/path/to/keytab")
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
 
         def mock_create_subprocess(*args, **kwargs):
             if args[0] == "klist":
@@ -203,8 +168,6 @@ class TestInitKerberosTicket:
         mock_kinit_proc.should_receive("communicate").and_return(_coro((b"error output", b"stderr output")))
 
         monkeypatch.setenv("KEYTAB_FILE", "/path/to/keytab")
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
 
         def mock_create_subprocess(*args, **kwargs):
             if args[0] == "klist":
@@ -228,7 +191,6 @@ class TestInitKerberosTicket:
     async def test_keytab_extract_principal_failure(self, monkeypatch):
         """Test extract_principal failure raises error."""
         monkeypatch.setenv("KEYTAB_FILE", "/path/to/keytab")
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
 
         from ymir.common import base_utils
 
@@ -239,36 +201,20 @@ class TestInitKerberosTicket:
         with pytest.raises(KerberosError, match="Failed to extract principal from keytab file"):
             await init_kerberos_ticket()
 
-    @pytest.mark.parametrize(
-        ("ccache_name", "path_to_check", "expect_exists_call"),
-        [
-            ("KCM:1000", None, False),
-            ("FILE:/path/to/ccache", "/path/to/ccache", True),
-            ("/path/to/ccache", "/path/to/ccache", True),
-        ],
-        ids=["kcm_type", "file_type", "legacy_format"],
-    )
     @pytest.mark.asyncio
-    async def test_krb5ccname_type_handling(
-        self, monkeypatch, ccache_name, path_to_check, expect_exists_call
-    ):
-        """Test that KRB5CCNAME is handled correctly for different types."""
+    async def test_no_krb5ccname_finds_keyring_ticket(self, monkeypatch):
+        """Test that tickets are found via system default cache (e.g. KEYRING)
+        when KRB5CCNAME is not set."""
         klist_output = (
             b"Principal name                 Cache name\n"
             b"--------------                 ----------\n"
-            b"user@EXAMPLE.COM         KCM:1000\n"
+            b"user@EXAMPLE.COM         KEYRING:persistent:1000\n"
         )
         mock_proc = flexmock(returncode=0)
         mock_proc.should_receive("communicate").and_return(_coro((klist_output, b"")))
 
+        monkeypatch.delenv("KRB5CCNAME", raising=False)
         monkeypatch.delenv("KEYTAB_FILE", raising=False)
-        monkeypatch.setenv("KRB5CCNAME", ccache_name)
-
-        if expect_exists_call:
-            flexmock(os.path).should_receive("exists").with_args(path_to_check).and_return(True)
-        else:
-            flexmock(os.path).should_receive("exists").never()
-
         flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
             "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).and_return(_coro(mock_proc))
@@ -289,8 +235,6 @@ class TestInitKerberosTicket:
         mock_proc.should_receive("communicate").and_return(_coro((klist_output, b"")))
 
         monkeypatch.delenv("KEYTAB_FILE", raising=False)
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
         flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
             "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).and_return(_coro(mock_proc))
@@ -311,8 +255,6 @@ class TestInitKerberosTicket:
         mock_proc.should_receive("communicate").and_return(_coro((klist_output, b"")))
 
         monkeypatch.delenv("KEYTAB_FILE", raising=False)
-        monkeypatch.setenv("KRB5CCNAME", "/path/to/ccache")
-        flexmock(os.path).should_receive("exists").with_args("/path/to/ccache").and_return(True)
         flexmock(asyncio).should_receive("create_subprocess_exec").with_args(
             "klist", "-l", stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).and_return(_coro(mock_proc))


### PR DESCRIPTION
This came up when testing agents-as-skills. Modern systems are, by default, configured to store Kerberos tickets in the Linux kernel memory and thus use KEYRING type (eg Fedora 43 etc) not FILE type. The reliance on KRB5CCNAME and FILE checking is thus counter-productive ie it doesnt add much in terms of diagnostics or failure handling but instead prevents default KEYRING flow from functioning correctly OOB. Instead of trying to check and manage KRB5CCNAME we should instead rely on Kerberos/GSS to do that for us as they are designed to do. Side note: It would probably be better to use the  Kerberos/GSS API directly, since we already have gssapi dependency, instead of spawning sub-processes however it is out of scope for this patch.