### PR TITLE
Get rid of Redis socket timeout

### DIFF
--- a/ymir/common/base_utils.py
+++ b/ymir/common/base_utils.py
@@ -52,7 +52,7 @@ async def redis_client(redis_url: str) -> AsyncGenerator[redis.Redis]:
         async with redis_client("redis://localhost:6379/0") as client:
             await client.ping()
     """
-    client = redis.Redis.from_url(redis_url)
+    client = redis.Redis.from_url(redis_url, socket_timeout=None)
     try:
         await client.ping()
         logger.debug("Connected to Redis")


### PR DESCRIPTION
redis-py 8.0.0 introduced a 5 seconds socket timeout, but our agents are BRPOPping with 30 seconds timeout. Explicitly unset socket timeout to make things work again.