### PR TITLE
Get detailed info in prelim_testing_agent

### DIFF
--- a/ymir/agents/preliminary_testing_agent.py
+++ b/ymir/agents/preliminary_testing_agent.py
@@ -30,7 +30,7 @@ from ymir.agents.utils import (
     mcp_tools,
     run_tool,
 )
-from ymir.tools.unprivileged.greenwave import FetchGreenWaveTool
+from ymir.tools.unprivileged.greenwave import FetchGreenWaveTool, FetchTestingFarmResultsTool
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +98,32 @@ available sources, and make your decision based on whichever results you can obt
    "url" field contains the full MR URL. The "repositoryUrl" contains the project URL
    from which you can derive the project path (remove the leading https://gitlab.com/).
 
+   **If any OSCI job (especially tier0 or tier1) is reported as failed in the MR comments,**
+   use the get_failed_pipeline_jobs_from_merge_request tool with the MR URL to retrieve
+   the list of failed pipeline jobs and their details (job name, URL, artifacts URL).
+   Include this information in your comment so the failed jobs can be investigated directly.
+   For tier0 or tier1 specifically, note each failed job individually with its job URL
+   and a small summary of the failure.
+
+3. **Individual test failures within tier* jobs**: Whenever a tier* test job (e.g.
+   osci.brew-build./plans/tier0.functional, osci.brew-build./plans/tier1-public.functional,
+   osci.brew-build./plans/tier1-internal.functional, etc.) has an artifact URL available,
+   use the fetch_testing_farm_results tool to retrieve the results-junit.xml and list the
+   individual tests that failed. This applies to FAILED, NEEDS_INSPECTION, and WAIVED
+   tier* results — for waived jobs, listing the underlying test failures explains why a
+   waiver was needed.
+   Do NOT fetch artifacts or list failures for non-tier* jobs such as
+   osci.brew-build.rpminspect.static-analysis, osci.brew-build.rpmdeplint.functional,
+   osci.brew-build.installability.functional, or leapp.* — these are not tier tests.
+   When presenting results from results-junit.xml, list each failing testcase as:
+   * {{<classname>/<testname>}} — FAILED/ERROR: <failure message (first line only)>
+
+   Additionally, if the GreenWave page contains a waiver comment/reason for the waived job,
+   compare it against the actual failures found in the results-junit.xml:
+   - If the waiver reason matches the actual failure, note that it is consistent.
+   - If the actual failure differs from the waiver reason, flag this as a discrepancy —
+     it may mean the test is now failing for a new reason not covered by the existing waiver.
+
 If a tool call fails or returns an error, note it in your comment but continue
 analyzing with the results you were able to obtain. Only return tests-error if
 you could not obtain results from ANY source.
@@ -106,6 +132,14 @@ Call the final_answer tool passing in the state and a comment as follows.
 The comment should use JIRA comment syntax (headings, bullet points, links).
 Do NOT wrap your comment in a {{panel}} macro — that will be added automatically.
 
+When listing individual test outcomes in your comment, use these icons consistently:
+- ✅ PASSED
+- ☑️ WAIVED
+- ❌ FAILED
+- ⏳ RUNNING / PENDING
+- ⚠️ NOT_RUNNING
+- 🔴 ERROR
+
 If all available gating tests have passed (and MR OSCI results passed, if available):
     state: tests-passed
     comment: [Brief summary of what passed, with links to the GreenWave page and MR
@@ -113,8 +147,19 @@ If all available gating tests have passed (and MR OSCI results passed, if availa
 
 If any required/gating tests have failed:
     state: tests-failed
-    comment: [List the failed tests with URLs, explain which are from GreenWave and
-              which from MR comments]
+    comment: [List the failed tests with URLs. For any tier* test failures (e.g.
+              osci.tier0, osci.tier1, osci.brew-build./plans/tier*), list each
+              failed job individually with its job URL and artifacts URL if available.
+              Also list any waived tier* tests with ☑️ so it is clear which ones
+              were exempted rather than genuinely passing.
+              Explain which failures are from GreenWave and which from MR comments.]
+
+If all available gating tests have passed or were waived:
+    state: tests-passed
+    comment: [Brief summary. If any tier* tests were waived, list them with ☑️ WAIVED
+              and their underlying failing test cases (from results-junit.xml).
+              Do NOT list non-tier* waivers (rpminspect, rpmdeplint, installability, leapp)
+              in the waived section — only mention them in the non-gating/informational table.]
 
 If tests are still running (pipeline status is running, or GreenWave shows tests in progress):
     state: tests-running
@@ -151,6 +196,7 @@ def create_preliminary_testing_agent(gateway_tools: list) -> ReasoningAgent:
         tools=[
             ThinkTool(),
             FetchGreenWaveTool(),
+            FetchTestingFarmResultsTool(),
         ]
         + [
             t
@@ -159,6 +205,7 @@ def create_preliminary_testing_agent(gateway_tools: list) -> ReasoningAgent:
             in [
                 "fetch_gitlab_mr_notes",
                 "get_jira_details",
+                "get_failed_pipeline_jobs_from_merge_request",
             ]
         ],
         memory=UnconstrainedMemory(),
@@ -449,6 +496,9 @@ async def _flag_attention(
 
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+    logging.getLogger("litellm").setLevel(logging.WARNING)
 
     span_processor = setup_observability(os.environ["COLLECTOR_ENDPOINT"])
 
@@ -467,9 +517,23 @@ async def main() -> None:
             dry_run=dry_run,
             ignore_needs_attention=ignore_needs_attention,
         )
-        logger.info("Completed: state=%s", result.state)
+        state_icon = {
+            TestingState.PASSED: "✅",
+            TestingState.WAIVED: "☑️",
+            TestingState.FAILED: "❌",
+            TestingState.RUNNING: "⏳",
+            TestingState.PENDING: "⏳",
+            TestingState.NOT_RUNNING: "⚠️",
+            TestingState.ERROR: "🔴",
+        }.get(result.state, "❓")
+
+        separator = "=" * 60
+        print(f"\n{separator}")
+        print(f"  RESULT: {state_icon}  {result.state.upper()}")
+        print(separator)
         if result.comment:
-            logger.info("Comment: %s", result.comment)
+            print(result.comment)
+        print(f"{separator}\n")
 
 
 if __name__ == "__main__":

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -628,9 +628,14 @@ class FailedPipelineJob(BaseModel):
     id: str = Field(description="Pipeline job ID as a string")
     name: str = Field(description="Name of the job")
     url: str = Field(description="Full URL to the job in GitLab")
-    status: str = Field(description="Job status")
+    status: str = Field(description="Job status (e.g. failed, canceled)")
     stage: str = Field(description="Pipeline stage the job belongs to")
     artifacts_url: str = Field(description="URL to browse job artifacts, empty string if no artifacts")
+    allow_failure: bool = Field(
+        default=False,
+        description="True if the job is allowed to fail (allow_failure: true in .gitlab-ci.yml). "
+        "A job with allow_failure=true does not block the pipeline even when it fails.",
+    )
 
 
 class CommentReply(BaseModel):

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -730,6 +730,7 @@ class GetFailedPipelineJobsFromMergeRequestTool(
                             if hasattr(job, "artifacts_file") and job.artifacts_file
                             else ""
                         ),
+                        allow_failure=getattr(job, "allow_failure", False),
                     )
                     for job in jobs
                     if job.status == "failed"

--- a/ymir/tools/unprivileged/greenwave.py
+++ b/ymir/tools/unprivileged/greenwave.py
@@ -1,5 +1,6 @@
 import logging
-from urllib.parse import quote as urlquote, urlparse
+from urllib.parse import quote as urlquote
+from urllib.parse import urlparse
 
 import aiohttp
 from beeai_framework.context import RunContext

--- a/ymir/tools/unprivileged/greenwave.py
+++ b/ymir/tools/unprivileged/greenwave.py
@@ -1,5 +1,5 @@
 import logging
-from urllib.parse import quote as urlquote
+from urllib.parse import quote as urlquote, urlparse
 
 import aiohttp
 from beeai_framework.context import RunContext
@@ -9,6 +9,8 @@ from pydantic import BaseModel, Field
 
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT
+
+TESTING_FARM_ARTIFACTS_URL = "https://artifacts.osci.redhat.com/testing-farm"
 
 logger = logging.getLogger(__name__)
 
@@ -69,3 +71,78 @@ class FetchGreenWaveTool(Tool[FetchGreenWaveInput, ToolRunOptions, StringToolOut
         except Exception as e:
             logger.error("Error fetching GreenWave gating status: %s", e)
             return StringToolOutput(result=f"Error fetching GreenWave gating status: {e}")
+
+
+class FetchTestingFarmResultsInput(BaseModel):
+    artifact_url: str = Field(
+        description=(
+            "Base artifact URL for a Testing Farm run, e.g. "
+            "http://artifacts.osci.redhat.com/testing-farm/<uuid>. "
+            "Can also be a full URL to a specific file such as results-junit.xml."
+        )
+    )
+
+
+class FetchTestingFarmResultsTool(Tool[FetchTestingFarmResultsInput, ToolRunOptions, StringToolOutput]):
+    """
+    Fetches test results from a Testing Farm artifact URL.
+    Retrieves results-junit.xml to show which individual tests passed, failed, or errored.
+    """
+
+    name = "fetch_testing_farm_results"  # type: ignore
+    description = (  # type: ignore
+        "Fetch individual test results from a Testing Farm artifact URL. "
+        "Given a base artifact URL (e.g. from a GreenWave NEEDS_INSPECTION/FAILED/WAIVED result "
+        "or from a GitLab MR pipeline job), retrieves the results-junit.xml file which lists "
+        "each individual test case and its outcome (passed, failed, error). "
+        "Use this to find out which specific tests failed inside a tier* job."
+    )
+    input_schema = FetchTestingFarmResultsInput  # type: ignore
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "testing_farm", self.name],
+            creator=self,
+        )
+
+    async def _run(
+        self,
+        input: FetchTestingFarmResultsInput,
+        options: ToolRunOptions | None,
+        context: RunContext,
+    ) -> StringToolOutput:
+        base_url = input.artifact_url.rstrip("/")
+
+        parsed = urlparse(base_url)
+        if parsed.netloc != "artifacts.osci.redhat.com" or parsed.scheme not in ("http", "https"):
+            return StringToolOutput(
+                result=f"Invalid artifact URL: {input.artifact_url}. "
+                "Only URLs from artifacts.osci.redhat.com are allowed."
+            )
+
+        # If a full path to a specific file was given, fetch it directly
+        if base_url.endswith((".xml", ".yaml", ".html")):
+            urls_to_try = [base_url]
+        else:
+            urls_to_try = [
+                f"{base_url}/results-junit.xml",
+                f"{base_url}/results.xml",
+            ]
+
+        async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+            for url in urls_to_try:
+                logger.info("Fetching Testing Farm results from %s", url)
+                try:
+                    async with session.get(url) as response:
+                        if response.status == 200:
+                            # Limit reading to 10MB to prevent OOM on large files
+                            content_bytes = await response.content.read(10 * 1024 * 1024)
+                            content = content_bytes.decode("utf-8", errors="replace")
+                            return StringToolOutput(result=content)
+                        logger.warning("Got HTTP %d for %s", response.status, url)
+                except Exception as e:
+                    logger.warning("Error fetching %s: %s", url, e)
+
+        return StringToolOutput(
+            result=f"Could not fetch test results from {input.artifact_url} — tried {urls_to_try}"
+        )


### PR DESCRIPTION
This PR enables preliminary_testing_agent.py to check results in the artifacts, if any of them failed and gives reasoning why it did so. It also adds another check, when waived result has a waive comment. Comment is compared with the agents analysis to check whether the waive reason is same. Also some icons for readability were added.
<img width="1915" height="586" alt="Screenshot From 2026-06-01 13-41-30" src="https://github.com/user-attachments/assets/1d390c57-a1c3-4642-b28e-25d4dc089f59" />
