### PR TITLE
Placeholder for Log Detective credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -163,7 +163,7 @@
         "filename": "openshift/deployment-backport-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 83,
         "is_secret": false
       }
     ],
@@ -173,7 +173,7 @@
         "filename": "openshift/deployment-backport-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 83,
         "is_secret": false
       }
     ],
@@ -183,7 +183,7 @@
         "filename": "openshift/deployment-rebase-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 83,
         "is_secret": false
       }
     ],
@@ -193,7 +193,7 @@
         "filename": "openshift/deployment-rebase-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 83,
         "is_secret": false
       }
     ],
@@ -203,7 +203,7 @@
         "filename": "openshift/deployment-rebuild-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 79,
+        "line_number": 82,
         "is_secret": false
       }
     ],
@@ -213,7 +213,7 @@
         "filename": "openshift/deployment-rebuild-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 79,
+        "line_number": 82,
         "is_secret": false
       }
     ],
@@ -348,5 +348,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-01T03:02:44Z"
+  "generated_at": "2026-06-01T15:03:23Z"
 }

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -35,6 +35,22 @@ Agents are deployed in the `jotnar-ymir--jotnar-ymir` project.
   SENTRY_DSN
   ```
 
+  `log-detective-env`:
+  ```
+  LOG_DETECTIVE_TOKEN
+  LOG_DETECTIVE_URL
+  ```
+  Values from Bitwarden - jotnar group - Log Detective Production Credentials (token = password field, URL = notes field).
+  ```bash
+  # Add to .secrets/beeai-agent.env (values from Bitwarden, see above):
+  #   LOG_DETECTIVE_TOKEN=<password field>
+  #   LOG_DETECTIVE_URL=<notes field>
+  source .secrets/beeai-agent.env
+  oc create secret generic log-detective-env \
+    --from-literal=LOG_DETECTIVE_TOKEN=$LOG_DETECTIVE_TOKEN \
+    --from-literal=LOG_DETECTIVE_URL=$LOG_DETECTIVE_URL
+  ```
+
   Values of these secrets are documented in [README](https://github.com/packit/jotnar?tab=readme-ov-file#service-accounts--authentication).
 
 - Create RHEL configuration ConfigMap manually:

--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -37,6 +37,9 @@ spec:
             name: endpoints-env
         - configMapRef:
             name: sentry-env
+        - secretRef:
+            name: log-detective-env
+            optional: true
         image: 'beeai-agent:c10s'
         imagePullPolicy: Always
         name: backport-agent-c10s

--- a/openshift/deployment-backport-agent-c9s.yml
+++ b/openshift/deployment-backport-agent-c9s.yml
@@ -37,6 +37,9 @@ spec:
             name: endpoints-env
         - configMapRef:
             name: sentry-env
+        - secretRef:
+            name: log-detective-env
+            optional: true
         image: 'beeai-agent:c9s'
         imagePullPolicy: Always
         name: backport-agent-c9s

--- a/openshift/deployment-rebase-agent-c10s.yml
+++ b/openshift/deployment-rebase-agent-c10s.yml
@@ -37,7 +37,9 @@ spec:
             name: endpoints-env
         - configMapRef:
             name: sentry-env
-
+        - secretRef:
+            name: log-detective-env
+            optional: true
         image: 'beeai-agent:c10s'
         imagePullPolicy: Always
         name: rebase-agent-c10s

--- a/openshift/deployment-rebase-agent-c9s.yml
+++ b/openshift/deployment-rebase-agent-c9s.yml
@@ -37,7 +37,9 @@ spec:
             name: endpoints-env
         - configMapRef:
             name: sentry-env
-
+        - secretRef:
+            name: log-detective-env
+            optional: true
         image: 'beeai-agent:c9s'
         imagePullPolicy: Always
         name: rebase-agent-c9s

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -37,6 +37,9 @@ spec:
             name: endpoints-env
         - configMapRef:
             name: sentry-env
+        - secretRef:
+            name: log-detective-env
+            optional: true
         image: 'beeai-agent:c10s'
         imagePullPolicy: Always
         name: rebuild-agent-c10s

--- a/openshift/deployment-rebuild-agent-c9s.yml
+++ b/openshift/deployment-rebuild-agent-c9s.yml
@@ -37,6 +37,9 @@ spec:
             name: endpoints-env
         - configMapRef:
             name: sentry-env
+        - secretRef:
+            name: log-detective-env
+            optional: true
         image: 'beeai-agent:c9s'
         imagePullPolicy: Always
         name: rebuild-agent-c9s

--- a/templates/beeai-agent.env
+++ b/templates/beeai-agent.env
@@ -55,7 +55,21 @@ GEMINI_API_KEY=
 # GOOGLE_VERTEX_LOCATION=global
 # GOOGLE_APPLICATION_CREDENTIALS=/home/beeai/jotnar-vertex-dev.json
 
+# =============================================================================
+# EXTERNAL SERVICES
+# =============================================================================
+
+# --- Log Detective Public production credentials ---
+# If setup, backport/rebase/rebuild agents use LD to analyze build failures.
+# Lookup: Bitwarden - jotnar group - Log Detective Production Credentials.
+# Token is in the 'password' field, server URL is in 'notes' field.
+# LOG_DETECTIVE_URL=
+# LOG_DETECTIVE_TOKEN=
+
+# =============================================================================
 # BeeAI Framework Configuration
+# =============================================================================
+
 BEEAI_MAX_ITERATIONS=255
 BEEAI_MAX_RETRIES_PER_STEP=5
 BEEAI_TOTAL_MAX_RETRIES=25


### PR DESCRIPTION
Setting up Log Detective secrets, such that backport/rebase/rebuild agents have access to them.

Will need to be checked after actual deployment.

EDIT: Since LD agent is separately deployed from other Ymir agents, we probably should have a fallback mechanism for failed build log analysis (what is implemented currently) - up for discussion.

RELEASE NOTES BEGIN

Added instructions for setting up access to public Log Detective API for development and Ymir pods.

RELEASE NOTES END
