### PR TITLE
Isolate mock repo state per Jira issue for concurrent e2e tests

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -108,6 +108,7 @@ RUN git config --global user.email "redhat-ymir-agent@redhat.com" \
     && git config --global user.name "RHEL Packaging Agent" \
     && git config --global core.editor "true" \
     && git config --global --add safe.directory '/git-repos/*' \
-    && git config --global --add safe.directory '/git-repos/applicability/*'
+    && git config --global --add safe.directory '/git-repos/applicability/*' \
+    && git config --global include.path /git-repos/.mock_gitconfig
 
 CMD ["/bin/bash"]

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -112,6 +112,7 @@ RUN git config --global user.email "redhat-ymir-agent@redhat.com" \
     && git config --global user.name "RHEL Packaging Agent" \
     && git config --global core.editor "true" \
     && git config --global --add safe.directory '/git-repos/*' \
-    && git config --global --add safe.directory '/git-repos/applicability/*'
+    && git config --global --add safe.directory '/git-repos/applicability/*' \
+    && git config --global include.path /git-repos/.mock_gitconfig
 
 CMD ["/bin/bash"]

--- a/Containerfile.mcp
+++ b/Containerfile.mcp
@@ -31,7 +31,7 @@ RUN dnf -y install \
     && dnf clean all
 
 # Install beeai mcp server
-RUN pip3 install --no-cache-dir "litellm!=1.82.7,!=1.82.8" beeai-framework[mcp]==0.1.80
+RUN pip3 install --no-cache-dir "litellm!=1.82.7,!=1.82.8" beeai-framework[mcp]==0.1.80 "specfile>=0.36.0"
 
 # Create user
 RUN useradd -m -G wheel mcp

--- a/scripts/run-mock-triage.py
+++ b/scripts/run-mock-triage.py
@@ -60,27 +60,33 @@ def extract_zstream_override(fixture: dict) -> str:
     return json.dumps(override) if override else ""
 
 
-def setup_mock_repos(fixture: dict, base_dir: Path) -> dict[str, str]:
-    """Clone repos at pre-fix state and return git env vars for URL rewriting.
+def setup_mock_repos(fixture: dict, base_dir: Path) -> Path | None:
+    """Clone repos at pre-fix state and write a shared gitconfig.
 
     Each bare clone has its branch ref rewound to the pre-fix commit so that
     the agent sees the repository state *before* the fix was applied.
+
+    The ``insteadOf`` URL rewrites are written to a ``.mock_gitconfig``
+    file in *base_dir*.  Gateway sub-processes pick this up via
+    ``GIT_CONFIG_GLOBAL``.
 
     Args:
         fixture: The loaded fixture data describing repos to mock.
         base_dir: Directory in which bare clones are created.
 
     Returns:
-        A dict with ``GIT_CONFIG_COUNT``/``KEY``/``VALUE`` entries for
-        ``insteadOf`` URL rewriting.
+        Path to the ``.mock_gitconfig`` file, or ``None`` when no repos
+        are configured.
     """
     repos = fixture.get("repos", [])
     if not repos:
-        return {}
+        return None
 
-    git_env: dict[str, str] = {}
+    git_cmd = git.Git()
+    gitconfig_path = base_dir / ".mock_gitconfig"
+    gitconfig_path.unlink(missing_ok=True)
 
-    for i, repo_info in enumerate(repos):
+    for repo_info in repos:
         package = repo_info["package"]
         local_path = base_dir / f"{package}.git"
 
@@ -99,11 +105,14 @@ def setup_mock_repos(fixture: dict, base_dir: Path) -> dict[str, str]:
                 repo.git.update_ref("-d", ref.path)
         repo.git.gc("--prune=now", "-q")
 
-        git_env[f"GIT_CONFIG_KEY_{i}"] = f"url.file://{local_path}.insteadOf"
-        git_env[f"GIT_CONFIG_VALUE_{i}"] = repo_info["remote_url"]
+        git_cmd.config(
+            "--file",
+            str(gitconfig_path),
+            f"url.file://{local_path}.insteadOf",
+            repo_info["remote_url"],
+        )
 
-    git_env["GIT_CONFIG_COUNT"] = str(len(repos))
-    return git_env
+    return gitconfig_path
 
 
 def ensure_writable(directory: Path) -> None:
@@ -119,9 +128,26 @@ def build_mcp_config(
     upstream_search_url: str,
     blocked_urls: str,
     mock_zstreams: str,
-    git_env: dict[str, str],
+    gitconfig_path: Path | None,
     log_dir: Path,
 ) -> dict:
+    """Build the MCP server configuration for privileged and unprivileged gateways.
+
+    Args:
+        jira_mock_dir: Directory containing mock Jira issue files.
+        mock_data_dir: Directory with per-issue fixture JSON configs.
+        upstream_search_url: URL for the upstream search API.
+        blocked_urls: Comma-separated remote URLs to block from curl/wget.
+        mock_zstreams: JSON string with z-stream overrides (or empty).
+        gitconfig_path: Path to ``.mock_gitconfig`` with ``insteadOf``
+            rewrites, or ``None`` when no repos are mocked.
+        log_dir: Directory for gateway debug log files.
+
+    Returns:
+        A dict suitable for writing as an MCP JSON config file.
+    """
+    gitconfig_env = {"GIT_CONFIG_GLOBAL": str(gitconfig_path)} if gitconfig_path else {}
+
     privileged_env = {
         "MCP_TRANSPORT": "stdio",
         "MOCK_JIRA": "true",
@@ -136,7 +162,7 @@ def build_mcp_config(
         "MOCK_BLOCKED_URLS": blocked_urls,
         "MOCK_ZSTREAMS": mock_zstreams,
         "DEBUG_FILE": str(log_dir / "ymir-privileged.log"),
-        **git_env,
+        **gitconfig_env,
     }
 
     return {
@@ -154,7 +180,7 @@ def build_mcp_config(
                     "MOCK_BLOCKED_URLS": blocked_urls,
                     "MOCK_ZSTREAMS": mock_zstreams,
                     "DEBUG_FILE": str(log_dir / "ymir-unprivileged.log"),
-                    **git_env,
+                    **gitconfig_env,
                 },
             },
         }
@@ -232,7 +258,7 @@ def main() -> None:
     mock_repo_dir.mkdir(parents=True, exist_ok=True)
 
     print(f"Setting up mock repos in {mock_repo_dir} ...")
-    git_env = setup_mock_repos(fixture, mock_repo_dir)
+    gitconfig_path = setup_mock_repos(fixture, mock_repo_dir)
 
     # -- Ensure JIRA mock files are writable ----------------------------------
 
@@ -246,7 +272,13 @@ def main() -> None:
     log_dir.mkdir(parents=True, exist_ok=True)
 
     mcp_config = build_mcp_config(
-        jira_mock_dir, mock_data_dir, upstream_search_url, blocked_urls, mock_zstreams, git_env, log_dir
+        jira_mock_dir,
+        mock_data_dir,
+        upstream_search_url,
+        blocked_urls,
+        mock_zstreams,
+        gitconfig_path,
+        log_dir,
     )
 
     tmp_fd, tmp_path = tempfile.mkstemp(prefix="mock-triage-mcp-", suffix=".json")

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -46,6 +46,7 @@ from ymir.agents.utils import (
 from ymir.common.base_utils import fix_await, is_cs_branch, redis_client
 from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.logging_setup import configure_logging
+from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
     BackportData,
     BackportInputSchema,
@@ -905,13 +906,17 @@ async def run_workflow(
     if max_incremental_fix_attempts is None:
         max_incremental_fix_attempts = max_build_attempts
 
-    local_tool_options = {"working_directory": None}
+    local_tool_options: dict[str, Any] = {"working_directory": None}
+    if mock_env := get_mock_local_tool_env(jira_issue):
+        local_tool_options["env"] = mock_env
     # In tests SILENT_RUN is typically unset, so Jira status updates are
     # attempted (and skipped via dry_run).  Set SILENT_RUN=true to suppress
     # Jira transitions even when dry_run is False.
     silent_run = os.getenv("SILENT_RUN", "false").lower() == "true"
 
-    async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
+    async with mcp_tools(
+        os.environ["MCP_GATEWAY_URL"], call_meta={"jira_issue": jira_issue}
+    ) as gateway_tools:
         if backport_agent_factory:
             result = backport_agent_factory(gateway_tools, local_tool_options)
             backport_agent = await result if asyncio.iscoroutine(result) else result

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -41,6 +41,7 @@ from ymir.agents.utils import (
 from ymir.common.base_utils import fix_await, is_cs_branch, redis_client
 from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.logging_setup import configure_logging
+from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
     BuildInputSchema,
     BuildOutputSchema,
@@ -227,7 +228,7 @@ async def main() -> None:
     dry_run = os.getenv("DRY_RUN", "False").lower() == "true"
     max_build_attempts = int(os.getenv("MAX_BUILD_ATTEMPTS", "10"))
 
-    local_tool_options = {"working_directory": None}
+    local_tool_options: dict[str, Any] = {"working_directory": None}
 
     class State(PackageUpdateState):
         version: str
@@ -243,8 +244,12 @@ async def main() -> None:
         package, dist_git_branch, version, jira_issue, justification=None, redis_conn=None
     ):
         local_tool_options["working_directory"] = None
+        if mock_env := get_mock_local_tool_env(jira_issue):
+            local_tool_options["env"] = mock_env
 
-        async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
+        async with mcp_tools(
+            os.environ["MCP_GATEWAY_URL"], call_meta={"jira_issue": jira_issue}
+        ) as gateway_tools:
             rebase_agent = create_rebase_agent(gateway_tools, local_tool_options)
             build_agent = create_build_agent(gateway_tools, local_tool_options)
             log_agent = create_log_agent(gateway_tools, local_tool_options)

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -27,6 +27,7 @@ from ymir.agents.utils import (
 from ymir.common.base_utils import fix_await, redis_client
 from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.logging_setup import configure_logging
+from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
     ConsolidatedIssue,
     ErrorData,
@@ -72,8 +73,12 @@ async def main() -> None:
         consolidation_summary=None,
     ):
         local_tool_options["working_directory"] = None
+        if mock_env := get_mock_local_tool_env(jira_issue):
+            local_tool_options["env"] = mock_env
 
-        async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
+        async with mcp_tools(
+            os.environ["MCP_GATEWAY_URL"], call_meta={"jira_issue": jira_issue}
+        ) as gateway_tools:
             log_agent = create_log_agent(gateway_tools, local_tool_options)
 
             workflow = Workflow(State, name="RebuildWorkflow")

--- a/ymir/agents/tests/e2e/backport_agent/test_backport.py
+++ b/ymir/agents/tests/e2e/backport_agent/test_backport.py
@@ -18,6 +18,7 @@ from ymir.agents.tests.e2e.backport_agent.artifact_capture import (
 from ymir.agents.tests.e2e.backport_agent.evaluation import BackportEvaluator
 from ymir.common.mock_repos import (
     apply_zstream_override,
+    cleanup_mock_gitconfig,
     load_all_fixture_configs,
     setup_mock_repos,
 )
@@ -37,7 +38,6 @@ class BackportAgentTestCase:
         self.finished_state: BackportState | None = None
         self.artifacts: CapturedArtifacts | None = None
         self.error: BaseException | None = None
-        self.git_env: dict | None = None
         self.zstream_override: dict[str, str] | None = None
 
     def __repr__(self) -> str:
@@ -50,8 +50,6 @@ class BackportAgentTestCase:
         metrics_middleware = MetricsMiddleware()
 
         async def testing_factory(gateway_tools, local_tool_options):
-            if self.git_env:
-                local_tool_options["env"] = self.git_env
             agent = await create_backport_agent(
                 gateway_tools,
                 local_tool_options,
@@ -100,7 +98,6 @@ def observability_fixture():
 
 
 SHARED_BARE_REPOS_DIR = Path(os.environ.get("GIT_REPO_BASEPATH", "/git-repos")) / "mock_bare"
-SHARED_GITCONFIG = Path(os.environ.get("GIT_REPO_BASEPATH", "/git-repos")) / ".mock_gitconfig"
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -108,9 +105,16 @@ def mock_centos_stream_repos():
     """Clone CentOS Stream RPM repos at pre-fix state for each backport test case.
 
     Bare clones are placed in the shared ``/git-repos/`` volume so that both
-    the test container and the MCP gateway can access them.  A
-    ``.mock_gitconfig`` file with ``insteadOf`` entries is written to the same
-    volume; the gateway picks it up via ``GIT_CONFIG_GLOBAL``.
+    the test container and the MCP gateway can access them.
+
+    For each issue, ``setup_mock_repos`` writes a per-issue gitconfig
+    (``.mock_gitconfig_{issue_key}``) as well as a shared
+    ``.mock_gitconfig``.  The MCP gateway scopes ``GIT_CONFIG_GLOBAL``
+    to the per-issue file via ``_meta``, giving each concurrent test
+    case its own ``insteadOf`` scope.
+
+    Yields:
+        Control to the test session after repos are prepared.
     """
     fixtures_dir = os.getenv("BACKPORT_MOCK_REPOS_DIR", str(DEFAULT_FIXTURES_DIR))
     configs = load_all_fixture_configs(fixtures_dir)
@@ -119,52 +123,21 @@ def mock_centos_stream_repos():
         shutil.rmtree(SHARED_BARE_REPOS_DIR)
     SHARED_BARE_REPOS_DIR.mkdir(parents=True, exist_ok=True)
 
-    per_issue_envs: list[dict[str, str]] = []
-
     for issue_key, config in configs.items():
         repos = config.get("repos", [])
         if not repos:
             continue
 
-        git_env = setup_mock_repos(repos, issue_key, SHARED_BARE_REPOS_DIR)
-        per_issue_envs.append(git_env)
+        setup_mock_repos(repos, issue_key, SHARED_BARE_REPOS_DIR)
 
         for tc in test_cases:
             if tc.jira_issue == issue_key:
-                tc.git_env = git_env
                 tc.zstream_override = config.get("zstream_override")
                 break
 
-    _write_mock_gitconfig(per_issue_envs)
-
     yield
 
-    SHARED_GITCONFIG.unlink(missing_ok=True)
-
-
-def _write_mock_gitconfig(envs: list[dict[str, str]]) -> None:
-    """Write a gitconfig file with ``insteadOf`` entries from all test cases.
-
-    The MCP gateway reads this via ``GIT_CONFIG_GLOBAL``.
-    """
-    lines: list[str] = []
-    for git_env in envs:
-        count = int(git_env.get("GIT_CONFIG_COUNT", "0"))
-        for i in range(count):
-            key = git_env.get(f"GIT_CONFIG_KEY_{i}", "")
-            value = git_env.get(f"GIT_CONFIG_VALUE_{i}", "")
-            if not key or not value:
-                continue
-            # key looks like 'url.file:///path/to.git.insteadOf'
-            # gitconfig format: [url "file:///path/to.git"] insteadOf = <value>
-            section_key, _, option = key.rpartition(".")
-            if not section_key:
-                continue
-            section_name, _, section_param = section_key.partition(".")
-            lines.append(f'[{section_name} "{section_param}"]')
-            lines.append(f"\t{option} = {value}")
-    if lines:
-        SHARED_GITCONFIG.write_text("\n".join(lines) + "\n")
+    cleanup_mock_gitconfig()
 
 
 def _files_touched_by_patch(patch_text: str) -> set[str]:

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,7 @@ from ymir.agents.observability import setup_observability
 from ymir.agents.triage_agent import TriageState, create_triage_agent, run_workflow
 from ymir.common.mock_repos import (
     apply_zstream_override,
+    cleanup_mock_gitconfig,
     load_all_fixture_configs,
     setup_mock_repos,
 )
@@ -28,7 +30,6 @@ class TriageAgentTestCase:
         self.metrics: dict = None
         self.finished_state: TriageState | None = None
         self.error: BaseException | None = None
-        self.git_env: dict | None = None
         self.zstream_override: dict[str, str] | None = None
 
     async def run(self) -> None:
@@ -37,8 +38,7 @@ class TriageAgentTestCase:
 
         metrics_middleware = MetricsMiddleware()
 
-        def testing_factory(gateway_tools):
-            local_tool_options = {"env": self.git_env} if self.git_env else None
+        def testing_factory(gateway_tools, local_tool_options=None):
             triage_agent = create_triage_agent(gateway_tools, local_tool_options)
             triage_agent.middlewares.append(metrics_middleware)
             return triage_agent
@@ -162,34 +162,44 @@ def observability_fixture():
 def mock_centos_stream_repos(tmp_path_factory):
     """Clone CentOS Stream RPM repos at pre-fix state for each test case.
 
-    Fixture configs are loaded from ``MOCK_REPOS_DIR`` (env var) or the
-    ``mock_repos/`` directory next to this test file. Each bare clone has its
-    branch ref rewound to the pre-fix commit. A per-test-case env dict is
-    built with ``GIT_CONFIG_COUNT`` / ``GIT_CONFIG_KEY_*`` /
-    ``GIT_CONFIG_VALUE_*`` so that git's ``insteadOf`` URL rewriting
-    transparently redirects the agent's git commands to the local clone.
+    Bare clones are placed on the shared ``/git-repos/`` volume so that
+    both the test container and the MCP gateway can access them.
+
+    For each issue, ``setup_mock_repos`` writes a per-issue gitconfig
+    (``.mock_gitconfig_{issue_key}``) as well as a shared
+    ``.mock_gitconfig``.  The MCP gateway scopes ``GIT_CONFIG_GLOBAL``
+    to the per-issue file via ``_meta`` on each ``call_tool`` request,
+    so concurrent test cases using the same remote URL at different
+    commits get the correct bare clone.
 
     Yields:
         Control to the test session after repos are prepared.
     """
     fixtures_dir = os.getenv("MOCK_REPOS_DIR", str(DEFAULT_FIXTURES_DIR))
     configs = load_all_fixture_configs(fixtures_dir)
-    repo_dir = tmp_path_factory.mktemp("centos_stream_repos")
+
+    if git_repo_basepath := os.getenv("GIT_REPO_BASEPATH"):
+        repo_dir = Path(git_repo_basepath) / "e2e_mock_clones"
+        shutil.rmtree(repo_dir, ignore_errors=True)
+        repo_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        repo_dir = tmp_path_factory.mktemp("centos_stream_repos")
 
     for issue_key, config in configs.items():
         repos = config.get("repos", [])
         if not repos:
             continue
 
-        git_env = setup_mock_repos(repos, issue_key, repo_dir)
+        setup_mock_repos(repos, issue_key, repo_dir)
 
         for tc in test_cases:
             if tc.input == issue_key:
-                tc.git_env = git_env
                 tc.zstream_override = config.get("zstream_override")
                 break
 
     yield
+
+    cleanup_mock_gitconfig()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -39,6 +39,7 @@ from ymir.common.base_utils import fix_await, redis_client
 from ymir.common.config import load_rhel_config
 from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.logging_setup import configure_logging
+from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
     ApplicabilityResult,
     ClarificationNeededData,
@@ -641,8 +642,12 @@ def create_triage_agent(gateway_tools, local_tool_options=None) -> ReasoningAgen
 async def run_workflow(
     jira_issue, dry_run, triage_agent_factory, auto_chain=False, force_cve_triage=False, silent_run=False
 ):
-    async with mcp_tools(os.getenv("MCP_GATEWAY_URL")) as gateway_tools:
-        triage_agent = triage_agent_factory(gateway_tools)
+    local_tool_options = None
+    if mock_env := get_mock_local_tool_env(jira_issue):
+        local_tool_options = {"env": mock_env}
+
+    async with mcp_tools(os.getenv("MCP_GATEWAY_URL"), call_meta={"jira_issue": jira_issue}) as gateway_tools:
+        triage_agent = triage_agent_factory(gateway_tools, local_tool_options)
 
         workflow = Workflow(TriageState, name="TriageWorkflow")
 
@@ -1012,8 +1017,10 @@ async def run_workflow(
                     except Exception:
                         logger.warning(f"Could not fetch patch from {url}")
 
-                local_tool_options = {"working_directory": local_clone}
-                applicability_agent = create_applicability_agent(gateway_tools, local_tool_options)
+                applicability_tool_options: dict = {"working_directory": local_clone}
+                if mock_env:
+                    applicability_tool_options["env"] = mock_env
+                applicability_agent = create_applicability_agent(gateway_tools, applicability_tool_options)
                 prompt = build_applicability_prompt(
                     jira_issue=state.jira_issue,
                     package=package,

--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -9,7 +9,10 @@ from beeai_framework.template import PromptTemplate
 from pydantic import BaseModel
 
 from ymir.common.base_utils import check_subprocess, run_subprocess  # noqa: F401 — re-exported
-from ymir.common.mock_repos import apply_zstream_override_from_env, setup_mock_repos_from_env
+from ymir.common.mock_repos import (
+    apply_zstream_override_from_env,
+    setup_mock_repos_from_env,
+)
 from ymir.common.utils import get_absolute_path, mcp_tools, run_tool  # noqa: F401 — re-exported
 
 logger = logging.getLogger(__name__)
@@ -119,12 +122,14 @@ def set_litellm_debug() -> None:
 def build_agent_factory_with_mock_repos(
     agent_factory: Callable[[list, dict[str, Any] | None], Any], jira_issue: str
 ) -> Callable[[list, dict[str, Any] | None], Any]:
-    """Wrap an agent factory with mock repo support when configured.
+    """Prepare mock repos for the standalone agent path.
 
-    If ``MOCK_REPOS_DIR`` is set, prepares mock repos and returns a factory
-    that injects the resulting ``git_env`` into ``local_tool_options``.
-    Also applies ``MOCK_ZSTREAMS`` (standalone env-var) and any per-issue
-    ``zstream_override`` found in the config file.
+    If ``MOCK_REPOS_DIR`` is set, prepares bare clones and writes
+    ``insteadOf`` rewrites to both the shared ``.mock_gitconfig`` and a
+    per-issue file.  The agent container picks up the shared file via
+    ``include.path`` in its global gitconfig; the MCP gateway uses the
+    per-issue file scoped through ``_meta`` (see ``_get_mock_git_env``
+    in ``ymir/tools/privileged/gitlab.py``).
 
     Args:
         agent_factory: The original agent factory callable
@@ -132,8 +137,8 @@ def build_agent_factory_with_mock_repos(
         jira_issue: The Jira issue key (e.g. ``RHEL-15216``).
 
     Returns:
-        The original factory unchanged when mocking is not configured,
-        or a wrapper that injects mock ``git_env``.
+        The original factory unchanged (mock repos are visible through
+        gitconfig files, no per-tool env injection needed).
     """
     apply_zstream_override_from_env()
 
@@ -143,10 +148,7 @@ def build_agent_factory_with_mock_repos(
 
     logger.info("Mock repos configured for %s via MOCK_REPOS_DIR", jira_issue)
 
-    def _factory(gateway_tools, local_tool_options=None):
-        return agent_factory(gateway_tools, {"env": git_env})
-
-    return _factory
+    return agent_factory
 
 
 def format_mr_justification(justification: str | None) -> str:

--- a/ymir/common/mock_repos.py
+++ b/ymir/common/mock_repos.py
@@ -83,6 +83,136 @@ def load_all_fixture_configs(fixtures_dir: str | Path) -> dict[str, dict]:
     return configs
 
 
+def get_mock_gitconfig_path(issue_key: str | None = None) -> Path:
+    """Return the path to a mock gitconfig file.
+
+    When *issue_key* is ``None`` the shared (combined) file is returned.
+    When an *issue_key* is given the per-issue file is returned instead;
+    this avoids ``insteadOf`` collisions when two issues need the same
+    remote URL at different commits.
+
+    The file lives under ``$GIT_REPO_BASEPATH`` (defaults to
+    ``/git-repos``).  Agent containers include the shared file via
+    ``git config --global include.path``; the MCP gateway uses
+    ``GIT_CONFIG_GLOBAL`` (overridden per-subprocess when per-issue
+    files are available).
+    """
+    base = Path(os.environ.get("GIT_REPO_BASEPATH", "/git-repos"))
+    if issue_key:
+        return base / f".mock_gitconfig_{issue_key}"
+    return base / ".mock_gitconfig"
+
+
+def get_mock_local_tool_env(issue_key: str) -> dict[str, str] | None:
+    """Return a subprocess env dict that includes the per-issue gitconfig.
+
+    If a per-issue gitconfig file exists for *issue_key*, returns a copy
+    of ``os.environ`` augmented with ``GIT_CONFIG_COUNT``/``KEY``/``VALUE``
+    entries that add an ``include.path`` for the per-issue file.  Git
+    processes these env-based entries with highest priority, so the
+    per-issue ``insteadOf`` rewrites override any conflicting entries in
+    the shared ``.mock_gitconfig`` (included via the global gitconfig).
+
+    Returns ``None`` when no per-issue gitconfig exists (e.g. production).
+    """
+    if not (per_issue := get_mock_gitconfig_path(issue_key)).is_file():
+        return None
+    env = os.environ.copy()
+    env["GIT_CONFIG_COUNT"] = "1"
+    env["GIT_CONFIG_KEY_0"] = "include.path"
+    env["GIT_CONFIG_VALUE_0"] = str(per_issue)
+    return env
+
+
+def write_mock_gitconfig(git_env: dict[str, str], issue_key: str | None = None) -> None:
+    """Append ``insteadOf`` rewrites from *git_env* to gitconfig file(s).
+
+    Entries from *git_env* (``GIT_CONFIG_COUNT``/``KEY``/``VALUE``) are
+    converted to standard gitconfig ``[url "…"] insteadOf = …`` sections
+    and **appended** to the shared file.
+
+    When *issue_key* is provided a **per-issue** gitconfig is written in
+    addition to the shared (combined) file.  The MCP gateway reads the
+    issue key from MCP request ``_meta`` and sets ``GIT_CONFIG_GLOBAL``
+    to the per-issue file on each git subprocess, giving each test case
+    its own ``insteadOf`` scope.
+
+    Stale entries pointing to non-existent local paths are pruned first.
+
+    Args:
+        git_env: Dict with ``GIT_CONFIG_COUNT``, ``GIT_CONFIG_KEY_<n>``,
+            and ``GIT_CONFIG_VALUE_<n>`` entries describing URL rewrites.
+        issue_key: Optional Jira issue key.  When set, a per-issue
+            gitconfig is written alongside the combined one.
+    """
+    gitconfig_path = get_mock_gitconfig_path()
+    gitconfig_path.parent.mkdir(parents=True, exist_ok=True)
+
+    _write_mock_gitconfig_append(git_env, gitconfig_path)
+    if issue_key:
+        per_issue_path = get_mock_gitconfig_path(issue_key)
+        _write_gitconfig_fresh(git_env, per_issue_path)
+
+
+def _write_mock_gitconfig_append(git_env: dict[str, str], gitconfig_path: Path) -> None:
+    """Append *git_env* entries to the shared gitconfig, pruning stale ones first."""
+    # Prune stale entries from previous runs
+    if gitconfig_path.exists():
+        try:
+            with git.GitConfigParser(str(gitconfig_path), read_only=True) as parser:
+                stale_sections = []
+                for section in parser.sections():
+                    if section.startswith('url "file://'):
+                        path_str = section[len('url "file://') : -1]
+                        if not Path(path_str).exists():
+                            stale_sections.append(f"url.file://{path_str}")
+            if stale_sections:
+                git_cmd = git.Git()
+                for section in stale_sections:
+                    git_cmd.config("--file", str(gitconfig_path), "--remove-section", section)
+        except Exception as e:
+            logger.warning("Failed to clean up stale gitconfig entries: %s", e)
+
+    # Append new entries — wrap in try/except because concurrent writers
+    # may race for the git lockfile; the per-issue gitconfig is the
+    # authoritative source, so a failure here is non-fatal.
+    try:
+        git_cmd = git.Git()
+        count = int(git_env.get("GIT_CONFIG_COUNT", "0"))
+        for i in range(count):
+            key = git_env.get(f"GIT_CONFIG_KEY_{i}", "")
+            value = git_env.get(f"GIT_CONFIG_VALUE_{i}", "")
+            if not key or not value:
+                continue
+            git_cmd.config("--file", str(gitconfig_path), "--add", key, value)
+    except Exception as e:
+        logger.warning("Failed to append mock gitconfig entries: %s", e)
+        return
+
+    logger.info("Wrote insteadOf rewrites to %s", gitconfig_path)
+
+
+def _write_gitconfig_fresh(git_env: dict[str, str], gitconfig_path: Path) -> None:
+    """Write *git_env* entries to *gitconfig_path*, replacing any previous content."""
+    gitconfig_path.unlink(missing_ok=True)
+    git_cmd = git.Git()
+    count = int(git_env.get("GIT_CONFIG_COUNT", "0"))
+    for i in range(count):
+        key = git_env.get(f"GIT_CONFIG_KEY_{i}", "")
+        value = git_env.get(f"GIT_CONFIG_VALUE_{i}", "")
+        if not key or not value:
+            continue
+        git_cmd.config("--file", str(gitconfig_path), "--add", key, value)
+    logger.info("Wrote per-issue gitconfig to %s", gitconfig_path)
+
+
+def cleanup_mock_gitconfig() -> None:
+    """Remove the shared and per-issue ``.mock_gitconfig*`` files."""
+    base = Path(os.environ.get("GIT_REPO_BASEPATH", "/git-repos"))
+    for path in base.glob(".mock_gitconfig*"):
+        path.unlink(missing_ok=True)
+
+
 def setup_mock_repos(repos: list[dict], issue_key: str, base_dir: Path) -> dict[str, str]:
     """Clone repos at pre-fix state and return a ``git_env`` dict.
 
@@ -90,6 +220,11 @@ def setup_mock_repos(repos: list[dict], issue_key: str, base_dir: Path) -> dict[
     The mocked remote URLs are appended to the ``MOCK_BLOCKED_URLS``
     environment variable so that ``RunShellCommandTool`` blocks direct
     curl/wget access to them.
+
+    The ``insteadOf`` rewrites are also written to a shared
+    ``.mock_gitconfig`` file under ``$GIT_REPO_BASEPATH`` so that the
+    MCP gateway (separate container) and agent git commands (via
+    ``include.path``) can transparently redirect to the local clones.
 
     When multiple entries share the same package (and remote URL), a
     single bare clone is reused — additional branch refs are created
@@ -110,7 +245,7 @@ def setup_mock_repos(repos: list[dict], issue_key: str, base_dir: Path) -> dict[
     gitlab_token = os.getenv("GITLAB_TOKEN")
 
     cloned: dict[str, tuple[Path, git.Repo, list[str]]] = {}
-    remote_urls: dict[str, str] = {}
+    remote_urls: dict[str, list[str]] = {}
 
     for repo_info in repos:
         pkg = repo_info["package"]
@@ -128,7 +263,7 @@ def setup_mock_repos(repos: list[dict], issue_key: str, base_dir: Path) -> dict[
             )
             repo = git.Repo.clone_from(clone_url, str(local_path), bare=True)
             cloned[pkg] = (local_path, repo, [])
-            remote_urls[pkg] = repo_info["remote_url"]
+            remote_urls[pkg] = [repo_info["remote_url"]]
         else:
             local_path, repo, _ = cloned[pkg]
             logger.info(
@@ -138,22 +273,28 @@ def setup_mock_repos(repos: list[dict], issue_key: str, base_dir: Path) -> dict[
                 issue_key,
             )
             repo.git.fetch(clone_url, repo_info["pre_fix_ref"])
+            if repo_info["remote_url"] not in remote_urls[pkg]:
+                remote_urls[pkg].append(repo_info["remote_url"])
 
         keep_branch = repo_info["branch"]
         repo.git.update_ref(f"refs/heads/{keep_branch}", repo_info["pre_fix_ref"])
         cloned[pkg][2].append(f"refs/heads/{keep_branch}")
 
-    for i, (pkg, (local_path, repo, keep_refs)) in enumerate(cloned.items()):
+    idx = 0
+    for pkg, (local_path, repo, keep_refs) in cloned.items():
         refs_to_delete = [ref.path for ref in repo.references if ref.path not in keep_refs]
         for ref_path in refs_to_delete:
             repo.git.update_ref("-d", ref_path)
         repo.git.gc("--prune=now", "-q")
 
-        git_env[f"GIT_CONFIG_KEY_{i}"] = f"url.file://{local_path}.insteadOf"
-        git_env[f"GIT_CONFIG_VALUE_{i}"] = remote_urls[pkg]
+        for url in remote_urls[pkg]:
+            git_env[f"GIT_CONFIG_KEY_{idx}"] = f"url.file://{local_path}.insteadOf"
+            git_env[f"GIT_CONFIG_VALUE_{idx}"] = url
+            idx += 1
 
-    git_env["GIT_CONFIG_COUNT"] = str(len(cloned))
+    git_env["GIT_CONFIG_COUNT"] = str(idx)
 
+    write_mock_gitconfig(git_env, issue_key=issue_key)
     _register_blocked_urls([r["remote_url"] for r in repos])
 
     return git_env

--- a/ymir/common/pyproject.toml
+++ b/ymir/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-common"
-version = "0.4.0"
+version = "0.4.1"
 description = "Common utilities shared across Ymir AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]

--- a/ymir/common/tests/unit/test_utils.py
+++ b/ymir/common/tests/unit/test_utils.py
@@ -408,7 +408,7 @@ async def test_mcp_tools_success_on_first_attempt():
     """Connected immediately; sleep is never called."""
     flexmock(_ymir_utils).should_receive("sse_client").once().and_return(make_sse_cm())
     flexmock(_ymir_utils).should_receive("ClientSession").and_return(make_session_cm())
-    flexmock(_ymir_utils.MCPTool).should_receive("from_client").and_return(_coro(FAKE_TOOLS))
+    flexmock(_ymir_utils.MCPTool).should_receive("from_session").and_return(_coro(FAKE_TOOLS))
     flexmock(asyncio).should_receive("sleep").never()
 
     async with mcp_tools(FAKE_URL) as tools:
@@ -423,7 +423,7 @@ async def test_mcp_tools_retries_once_then_succeeds():
         make_sse_cm(exc=conn_err)
     ).and_return(make_sse_cm())
     flexmock(_ymir_utils).should_receive("ClientSession").and_return(make_session_cm())
-    flexmock(_ymir_utils.MCPTool).should_receive("from_client").and_return(_coro(FAKE_TOOLS))
+    flexmock(_ymir_utils.MCPTool).should_receive("from_session").and_return(_coro(FAKE_TOOLS))
     flexmock(asyncio).should_receive("sleep").once().with_args(3.0).replace_with(_noop)
 
     async with mcp_tools(FAKE_URL, retry_delay=3.0) as tools:

--- a/ymir/common/utils.py
+++ b/ymir/common/utils.py
@@ -18,11 +18,10 @@ from beeai_framework.tools.mcp import MCPTool
 from beeai_framework.tools.types import JSONToolOutput, StringToolOutput
 from mcp import ClientSession
 from mcp.client.sse import sse_client
-from mcp.types import TextContent
+from mcp.types import CallToolResult, TextContent
 from specfile.utils import EVR
 
 from ymir.common.constants import BREWHUB_URL
-from mcp.types import CallToolResult, TextContent
 
 logger = logging.getLogger(__name__)
 

--- a/ymir/common/utils.py
+++ b/ymir/common/utils.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -21,8 +22,44 @@ from mcp.types import TextContent
 from specfile.utils import EVR
 
 from ymir.common.constants import BREWHUB_URL
+from mcp.types import CallToolResult, TextContent
 
 logger = logging.getLogger(__name__)
+
+
+class _MetaInjectingSession:
+    """Transparent wrapper around ``ClientSession`` that injects ``meta``
+    into every ``call_tool`` invocation.
+
+    All other attribute accesses are forwarded to the underlying session so
+    that ``MCPTool.from_session`` (which calls ``list_tools``, ``initialize``,
+    etc.) keeps working unchanged.
+    """
+
+    def __init__(self, session: ClientSession, meta: dict[str, Any]) -> None:
+        self._session = session
+        self._meta = meta
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        read_timeout_seconds: timedelta | None = None,
+        progress_callback: Any = None,
+        *,
+        meta: dict[str, Any] | None = None,
+    ) -> CallToolResult:
+        merged = {**self._meta, **(meta or {})}
+        return await self._session.call_tool(
+            name,
+            arguments,
+            read_timeout_seconds=read_timeout_seconds,
+            progress_callback=progress_callback,
+            meta=merged,
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)
 
 
 def get_absolute_path(path: Path, tool: Tool) -> Path:
@@ -72,13 +109,29 @@ async def mcp_tools(
     filter: Callable[[str], bool] | None = None,
     max_retries: int = 10,
     retry_delay: float = 3.0,
+    call_meta: dict[str, Any] | None = None,
 ) -> AsyncGenerator[list[MCPTool]]:
+    """Connect to an MCP gateway and yield the available tools.
+
+    Args:
+        sse_url: SSE endpoint of the MCP gateway.
+        filter: Optional predicate to keep only matching tool names.
+        max_retries: How many connection attempts before giving up.
+        retry_delay: Seconds between retries.
+        call_meta: Optional dict injected as MCP ``_meta`` on every
+            ``call_tool`` invocation.  Use this to propagate context
+            such as ``{"jira_issue": "RHEL-12345"}`` so that the
+            gateway can scope operations per-caller.
+    """
     connected = False
     for attempt in range(max_retries):
         try:
             async with sse_client(sse_url) as (read, write), ClientSession(read, write) as session:
                 await session.initialize()
-                tools = await MCPTool.from_client(session)
+                effective_session: Any = session
+                if call_meta:
+                    effective_session = _MetaInjectingSession(session, call_meta)
+                tools = await MCPTool.from_session(effective_session)
                 if filter:
                     tools = [t for t in tools if filter(t.name)]
                 connected = True

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -16,6 +16,7 @@ from beeai_framework.tools import (
     ToolError,
     ToolRunOptions,
 )
+from mcp.server.lowlevel.server import request_ctx
 from ogr.exceptions import GitlabAPIException, OgrException
 from ogr.factory import get_project
 from ogr.services.gitlab.project import GitlabProject
@@ -64,6 +65,41 @@ def _has_mock_url_rewrites() -> bool:
         pass
     global_cfg = os.getenv("GIT_CONFIG_GLOBAL", "")
     return bool(global_cfg) and Path(global_cfg).is_file()
+
+
+def _get_mock_git_env() -> dict[str, str] | None:
+    """Build a subprocess ``env`` that scopes ``GIT_CONFIG_GLOBAL`` to the
+    per-issue gitconfig when the MCP request carries a ``jira_issue`` in
+    its ``_meta``.
+
+    Falls back to ``None`` (inherit process env) when no per-issue
+    gitconfig exists or when the request has no metadata.
+    """
+    try:
+        ctx = request_ctx.get()
+        meta = ctx.meta
+    except LookupError:
+        return None
+
+    if meta is None:
+        return None
+
+    issue_key = getattr(meta, "jira_issue", None)
+    if not issue_key:
+        extra = getattr(meta, "__pydantic_extra__", None) or {}
+        issue_key = extra.get("jira_issue")
+    if not issue_key:
+        return None
+
+    base = Path(os.environ.get("GIT_REPO_BASEPATH", "/git-repos"))
+    per_issue = base / f".mock_gitconfig_{issue_key}"
+    if not per_issue.is_file():
+        return None
+
+    env = os.environ.copy()
+    env["GIT_CONFIG_GLOBAL"] = str(per_issue)
+    logger.debug("Using per-issue gitconfig for %s: %s", issue_key, per_issue)
+    return env
 
 
 def _is_private_gitlab(url: str) -> bool:
@@ -431,24 +467,32 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
         # Otherwise embed the auth token in the URL as usual.
         clone_url = repository if _has_mock_url_rewrites() else _get_authenticated_url(repository)
 
+        # Per-issue gitconfig: if the MCP request carries a jira_issue in
+        # _meta, scope GIT_CONFIG_GLOBAL to the per-issue file so that
+        # concurrent test cases with the same remote URL get different
+        # bare clones.
+        git_env = _get_mock_git_env()
+
         clone_path.mkdir(parents=True, exist_ok=True)
 
         if branch:
-            proc = await asyncio.create_subprocess_exec("git", "init", cwd=clone_path)
+            proc = await asyncio.create_subprocess_exec("git", "init", cwd=clone_path, env=git_env)
             if await proc.wait():
                 raise ToolError(f"Failed to initialize git repo at {clone_path}")
 
             command = ["git", "fetch", clone_url, f"{branch}:refs/heads/{branch}"]
-            proc = await asyncio.create_subprocess_exec(command[0], *command[1:], cwd=clone_path)
+            proc = await asyncio.create_subprocess_exec(command[0], *command[1:], cwd=clone_path, env=git_env)
             if await proc.wait():
                 raise ToolError(f"Failed to fetch {branch} from {repository}")
 
-            proc = await asyncio.create_subprocess_exec("git", "checkout", branch, cwd=clone_path)
+            proc = await asyncio.create_subprocess_exec(
+                "git", "checkout", branch, cwd=clone_path, env=git_env
+            )
             if await proc.wait():
                 raise ToolError(f"Failed to checkout branch {branch}")
         else:
             command = ["git", "clone", clone_url, str(clone_path)]
-            proc = await asyncio.create_subprocess_exec(command[0], *command[1:])
+            proc = await asyncio.create_subprocess_exec(command[0], *command[1:], env=git_env)
             if await proc.wait():
                 raise ToolError(f"Failed to clone {repository}")
 

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -47,26 +47,6 @@ _REDHAT_WEB_PREFIX = "/redhat/"
 _REDHAT_API_PREFIX = "/api/v4/projects/redhat%2F"
 
 
-def _has_mock_url_rewrites() -> bool:
-    """Check whether git is configured with ``insteadOf`` URL rewrites.
-
-    Rewrites can be provided via ``GIT_CONFIG_COUNT``/``GIT_CONFIG_KEY_*``
-    env vars (used by local tools) or via ``GIT_CONFIG_GLOBAL`` pointing
-    to a gitconfig file (used when the MCP gateway shares a volume with the
-    test runner).
-
-    Returns:
-        True when either mechanism is active.
-    """
-    try:
-        if int(os.getenv("GIT_CONFIG_COUNT", "0")) > 0:
-            return True
-    except ValueError:
-        pass
-    global_cfg = os.getenv("GIT_CONFIG_GLOBAL", "")
-    return bool(global_cfg) and Path(global_cfg).is_file()
-
-
 def _get_mock_git_env() -> dict[str, str] | None:
     """Build a subprocess ``env`` that scopes ``GIT_CONFIG_GLOBAL`` to the
     per-issue gitconfig when the MCP request carries a ``jira_issue`` in
@@ -144,14 +124,24 @@ def _get_auth_headers(url: str) -> dict[str, str]:
     return headers
 
 
-def _get_authenticated_url(repository_url: str) -> str:
+def _get_git_auth_args(repository_url: str) -> list[str]:
+    """Return ``git -c`` args that authenticate via ``PRIVATE-TOKEN`` header.
+
+    Uses the same ``_is_private_gitlab`` guard as ``_get_auth_headers``
+    so the token is never sent to unrelated hosts.  Passing auth via
+    ``http.extraheader`` keeps the URL clean, which lets ``insteadOf``
+    rewrites (mock repos) work without special-casing.
+
+    Args:
+        repository_url: The git remote URL to authenticate against.
+
+    Returns:
+        A list of ``-c http.extraheader=…`` args for private Red Hat
+        GitLab repos, or an empty list otherwise.
     """
-    Helper function to add GitLab token authentication to repository URLs.
-    """
-    if token := os.getenv("GITLAB_TOKEN"):
-        url = urlparse(repository_url)
-        return url._replace(netloc=f"oauth2:{token}@{url.hostname}").geturl()
-    return repository_url
+    if _is_private_gitlab(repository_url) and (token := os.getenv("GITLAB_TOKEN")):
+        return ["-c", f"http.extraheader=PRIVATE-TOKEN: {token}"]
+    return []
 
 
 async def _get_merge_request_from_url(merge_request_url: str) -> GitlabPullRequest:
@@ -462,15 +452,7 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
         clone_path = tool_input.clone_path
         await clean_stale_repositories()
 
-        # When GIT_CONFIG_* env vars define insteadOf rewrites (mock repos),
-        # pass the original URL so git applies the rewrite itself.
-        # Otherwise embed the auth token in the URL as usual.
-        clone_url = repository if _has_mock_url_rewrites() else _get_authenticated_url(repository)
-
-        # Per-issue gitconfig: if the MCP request carries a jira_issue in
-        # _meta, scope GIT_CONFIG_GLOBAL to the per-issue file so that
-        # concurrent test cases with the same remote URL get different
-        # bare clones.
+        auth_args = _get_git_auth_args(repository)
         git_env = _get_mock_git_env()
 
         clone_path.mkdir(parents=True, exist_ok=True)
@@ -480,7 +462,7 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
             if await proc.wait():
                 raise ToolError(f"Failed to initialize git repo at {clone_path}")
 
-            command = ["git", "fetch", clone_url, f"{branch}:refs/heads/{branch}"]
+            command = ["git", *auth_args, "fetch", repository, f"{branch}:refs/heads/{branch}"]
             proc = await asyncio.create_subprocess_exec(command[0], *command[1:], cwd=clone_path, env=git_env)
             if await proc.wait():
                 raise ToolError(f"Failed to fetch {branch} from {repository}")
@@ -491,7 +473,7 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
             if await proc.wait():
                 raise ToolError(f"Failed to checkout branch {branch}")
         else:
-            command = ["git", "clone", clone_url, str(clone_path)]
+            command = ["git", *auth_args, "clone", repository, str(clone_path)]
             proc = await asyncio.create_subprocess_exec(command[0], *command[1:], env=git_env)
             if await proc.wait():
                 raise ToolError(f"Failed to clone {repository}")
@@ -529,8 +511,8 @@ class PushToRemoteRepositoryTool(Tool[PushToRemoteRepositoryToolInput, ToolRunOp
         clone_path = tool_input.clone_path
         branch = tool_input.branch
         force = tool_input.force
-        remote = _get_authenticated_url(repository)
-        command = ["git", "push", remote, branch]
+        auth_args = _get_git_auth_args(repository)
+        command = ["git", *auth_args, "push", repository, branch]
         if force:
             command.append("--force")
         proc = await asyncio.create_subprocess_exec(command[0], *command[1:], cwd=clone_path)

--- a/ymir/tools/pyproject.toml
+++ b/ymir/tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-tools"
-version = "0.5.0"
+version = "0.5.1"
 description = "Ymir MCP tools for AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]


### PR DESCRIPTION
Previously, all mock repos shared a single set of git insteadOf rewrites. When two test cases needed the same remote URL at different commits (e.g. RHEL-114607 and RHEL-177992 both using expat/c10s), the last writer won and the other test got the wrong commit.

Fix this by writing per-issue gitconfig files alongside the shared one, propagating the issue key via MCP _meta on every call_tool invocation, and having the gateway scope GIT_CONFIG_GLOBAL to the per-issue file in each git subprocess.

Key changes:
- mock_repos: write .mock_gitconfig_{issue_key} per issue
- utils: add _MetaInjectingSession wrapper, mcp_tools accepts call_meta
- gitlab: _get_mock_git_env() reads issue from request_ctx._meta
- agents: pass call_meta={"jira_issue": ...} in all workflows
- Containerfiles: include.path for shared gitconfig in agent containers
- run-mock-triage: switch from env var injection to gitconfig file