### PR TITLE
fix(sentry): secrets are stored as a Kubernetes Secret

### DIFF
--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -35,7 +35,7 @@ spec:
             name: chat-env
         - configMapRef:
             name: endpoints-env
-        - configMapRef:
+        - secretRef:
             name: sentry-env
         image: 'beeai-agent:c10s'
         imagePullPolicy: Always

--- a/openshift/deployment-backport-agent-c9s.yml
+++ b/openshift/deployment-backport-agent-c9s.yml
@@ -35,7 +35,7 @@ spec:
             name: chat-env
         - configMapRef:
             name: endpoints-env
-        - configMapRef:
+        - secretRef:
             name: sentry-env
         image: 'beeai-agent:c9s'
         imagePullPolicy: Always

--- a/openshift/deployment-rebase-agent-c10s.yml
+++ b/openshift/deployment-rebase-agent-c10s.yml
@@ -35,7 +35,7 @@ spec:
             name: chat-env
         - configMapRef:
             name: endpoints-env
-        - configMapRef:
+        - secretRef:
             name: sentry-env
 
         image: 'beeai-agent:c10s'

--- a/openshift/deployment-rebase-agent-c9s.yml
+++ b/openshift/deployment-rebase-agent-c9s.yml
@@ -35,7 +35,7 @@ spec:
             name: chat-env
         - configMapRef:
             name: endpoints-env
-        - configMapRef:
+        - secretRef:
             name: sentry-env
 
         image: 'beeai-agent:c9s'

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -35,7 +35,7 @@ spec:
             name: chat-env
         - configMapRef:
             name: endpoints-env
-        - configMapRef:
+        - secretRef:
             name: sentry-env
         image: 'beeai-agent:c10s'
         imagePullPolicy: Always

--- a/openshift/deployment-rebuild-agent-c9s.yml
+++ b/openshift/deployment-rebuild-agent-c9s.yml
@@ -35,7 +35,7 @@ spec:
             name: chat-env
         - configMapRef:
             name: endpoints-env
-        - configMapRef:
+        - secretRef:
             name: sentry-env
         image: 'beeai-agent:c9s'
         imagePullPolicy: Always

--- a/openshift/deployment-triage-agent.yml
+++ b/openshift/deployment-triage-agent.yml
@@ -33,7 +33,7 @@ spec:
             name: chat-env
         - configMapRef:
             name: endpoints-env
-        - configMapRef:
+        - secretRef:
             name: sentry-env
 
         image: 'beeai-agent:c10s'


### PR DESCRIPTION
Not a config map.

TODO:
- [x] Already deployed, is a fix from the deployment of the previous PR

Cc @lbarcziova as you took over the Skald role, it is deployed and you should see whatever gets raised in `jtnr-001-ymir` project in the Sentry.

_edit_: given that the nightly rebuild passes… Quay is supposedly fixed, but it randomly fails to accept pushes…