### PR TITLE
Fix Y-stream CVE eligibility: set needs_internal_fix=False

### DIFF
--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -557,7 +557,7 @@ class CheckCveTriageEligibilityTool(
                 is_cve=True,
                 eligibility=TriageEligibility.PENDING_DEPENDENCIES,
                 reason=f"CVE {cve_id} ({target_version}): waiting for at least one clone to ship",
-                needs_internal_fix=True,
+                needs_internal_fix=False,
                 pending_zstream_issues=pending_keys,
             ).model_dump()
         )
@@ -597,7 +597,7 @@ class CheckCveTriageEligibilityTool(
                 is_cve=True,
                 eligibility=TriageEligibility.IMMEDIATELY,
                 reason="Y-stream CVE: at least one Z-stream clone shipped, eligible for triage",
-                needs_internal_fix=True,
+                needs_internal_fix=False,
             ).model_dump()
         )
 

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -678,7 +678,7 @@ async def test_eligibility_ystream_any_clone_shipped():
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
     assert result["eligibility"] == TriageEligibility.IMMEDIATELY
-    assert result["needs_internal_fix"] is True
+    assert result["needs_internal_fix"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Y-stream content is built from CentOS Stream, so when a Z-stream clone has already shipped (the fix reached RHEL via the Z-stream path), the Y-stream issue should target CentOS Stream — not an internal RHEL branch. The previous hardcoded True was incorrect and caused Y-stream triage to route fixes to internal branches unnecessarily.

Assisted-by: Claude Opus 4.6
