### PR TITLE
Include already-triaged and already-rebuilt siblings in rebuild conso…

### DIFF
--- a/ymir/agents/rebuild_consolidation.py
+++ b/ymir/agents/rebuild_consolidation.py
@@ -45,8 +45,7 @@ def build_rebuild_siblings_jql(
         f'AND key != "{issue_key}" '
         f'AND labels = "SecurityTracking" '
         f"AND labels not in "
-        f'("ymir_triaged_rebuild", "ymir_rebuilt", '
-        f'"ymir_triaged_not_affected", "ymir_triaged_backport", "ymir_triaged_rebase") '
+        f'("ymir_triaged_not_affected", "ymir_triaged_backport", "ymir_triaged_rebase") '
         f'AND status in ("New", "Planning")'
     )
 

--- a/ymir/agents/tests/unit/test_rebuild_consolidation.py
+++ b/ymir/agents/tests/unit/test_rebuild_consolidation.py
@@ -8,8 +8,8 @@ def test_build_rebuild_siblings_jql():
     assert 'key != "RHEL-100"' in jql
     assert 'labels = "SecurityTracking"' in jql
     assert "labels not in" in jql
-    assert '"ymir_triaged_rebuild"' in jql
-    assert '"ymir_rebuilt"' in jql
+    assert '"ymir_triaged_rebuild"' not in jql
+    assert '"ymir_rebuilt"' not in jql
     assert '"ymir_triaged_not_affected"' in jql
     assert '"ymir_triaged_backport"' in jql
     assert '"ymir_triaged_rebase"' in jql

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1279,7 +1279,10 @@ async def main() -> None:
                                 await tasks.set_jira_labels(
                                     jira_issue=consolidated.issue_key,
                                     labels_to_add=[JiraLabels.TRIAGED_REBUILD.value],
-                                    labels_to_remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+                                    labels_to_remove=[
+                                        JiraLabels.TRIAGE_IN_PROGRESS.value,
+                                        JiraLabels.REBUILT.value,
+                                    ],
                                     dry_run=dry_run,
                                 )
                             except Exception as e:


### PR DESCRIPTION
…lidation

Remove ymir_triaged_rebuild and ymir_rebuilt from the JQL exclusion list in rebuild sibling consolidation. This ensures that every rebuild MR references all known Jira issues for the same package and fix_version, even if some were already queued or rebuilt by an earlier triage.

Without this, issues arriving at different times produce separate rebuild MRs for the same package — each covering a different subset of Jiras, with the same release bump, so neither can be merged alongside the other.

With this change, a later rebuild MR always consolidates all earlier siblings into its Resolves list. If a prior MR already exists (queued or merged), it becomes a subset and can be closed in favour of the newer, more complete one.

When a consolidated sibling already carries ymir_rebuilt from a previous rebuild, the label is swapped to ymir_triaged_rebuild so it re-enters the pipeline cleanly.

Assisted-by: Claude Opus 4.6
