### PR TITLE
fix(sentry): factor out redis-related logging

### DIFF
--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -88,6 +88,7 @@ from ymir.tools.unprivileged.wicked_git import (
 )
 
 logger = logging.getLogger(__name__)
+redis_logger = logging.getLogger("agent.redis")
 
 
 BACKPORT_INSTRUCTIONS = """
@@ -1413,19 +1414,19 @@ async def main() -> None:
             if container_version == "c9s"
             else RedisQueues.BACKPORT_QUEUE_C10S.value
         )
-        logger.info(
+        redis_logger.info(
             f"Connected to Redis, max retries set to {max_retries}, listening to queue: {backport_queue}"
         )
 
         while True:
-            logger.info(f"Waiting for tasks from {backport_queue} (timeout: 30s)...")
+            redis_logger.info(f"Waiting for tasks from {backport_queue} (timeout: 30s)...")
             element = await fix_await(redis.brpop([backport_queue], timeout=30))
             if element is None:
-                logger.info("No tasks received, continuing to wait...")
+                redis_logger.info("No tasks received, continuing to wait...")
                 continue
 
             _, payload = element
-            logger.info("Received task from queue.")
+            redis_logger.info("Received task from queue.")
 
             task = Task.model_validate_json(payload)
             triage_state = task.metadata

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -65,6 +65,7 @@ from ymir.tools.unprivileged.text import (
 )
 
 logger = logging.getLogger(__name__)
+redis_logger = logging.getLogger("agent.redis")
 
 
 def get_instructions() -> str:
@@ -526,19 +527,19 @@ async def main() -> None:
             if container_version == "c9s"
             else RedisQueues.REBASE_QUEUE_C10S.value
         )
-        logger.info(
+        redis_logger.info(
             f"Connected to Redis, max retries set to {max_retries}, listening to queue: {rebase_queue}"
         )
 
         while True:
-            logger.info(f"Waiting for tasks from {rebase_queue} (timeout: 30s)...")
+            redis_logger.info(f"Waiting for tasks from {rebase_queue} (timeout: 30s)...")
             element = await fix_await(redis.brpop([rebase_queue], timeout=30))
             if element is None:
-                logger.info("No tasks received, continuing to wait...")
+                redis_logger.info("No tasks received, continuing to wait...")
                 continue
 
             _, payload = element
-            logger.info("Received task from queue.")
+            redis_logger.info("Received task from queue.")
 
             task = Task.model_validate_json(payload)
             triage_state = task.metadata

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -39,6 +39,7 @@ from ymir.common.models import (
 )
 
 logger = logging.getLogger(__name__)
+redis_logger = logging.getLogger("agent.redis")
 
 
 async def main() -> None:
@@ -333,19 +334,19 @@ async def main() -> None:
             if container_version == "c9s"
             else RedisQueues.REBUILD_QUEUE_C10S.value
         )
-        logger.info(
+        redis_logger.info(
             f"Connected to Redis, max retries set to {max_retries}, listening to queue: {rebuild_queue}"
         )
 
         while True:
-            logger.info(f"Waiting for tasks from {rebuild_queue} (timeout: 30s)...")
+            redis_logger.info(f"Waiting for tasks from {rebuild_queue} (timeout: 30s)...")
             element = await fix_await(redis.brpop([rebuild_queue], timeout=30))
             if element is None:
-                logger.info("No tasks received, continuing to wait...")
+                redis_logger.info("No tasks received, continuing to wait...")
                 continue
 
             _, payload = element
-            logger.info("Received task from queue.")
+            redis_logger.info("Received task from queue.")
 
             try:
                 task = Task.model_validate_json(payload)

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -67,6 +67,7 @@ from ymir.tools.unprivileged.commands import RunShellCommandTool
 from ymir.tools.unprivileged.version_mapper import VersionMapperTool
 
 logger = logging.getLogger(__name__)
+redis_logger = logging.getLogger("agent.redis")
 
 
 def _should_update_jira(silent_run: bool, resolution: Resolution = None) -> bool:
@@ -1191,17 +1192,17 @@ async def main() -> None:
     logger.info(f"Starting triage agent in queue mode (AUTO_CHAIN={'enabled' if auto_chain else 'disabled'})")
     async with redis_client(os.environ["REDIS_URL"]) as redis:
         max_retries = int(os.getenv("MAX_RETRIES", 3))
-        logger.info(f"Connected to Redis, max retries set to {max_retries}")
+        redis_logger.info(f"Connected to Redis, max retries set to {max_retries}")
 
         while True:
-            logger.info("Waiting for tasks from triage_queue (timeout: 30s)...")
+            redis_logger.info("Waiting for tasks from triage_queue (timeout: 30s)...")
             element = await fix_await(redis.brpop([RedisQueues.TRIAGE_QUEUE.value], timeout=30))
             if element is None:
-                logger.info("No tasks received, continuing to wait...")
+                redis_logger.info("No tasks received, continuing to wait...")
                 continue
 
             _, payload = element
-            logger.info("Received task from queue")
+            redis_logger.info("Received task from queue")
 
             task = Task.model_validate_json(payload)
             input = InputSchema.model_validate(task.metadata)

--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -175,6 +175,7 @@ def init_sentry() -> None:
     import sentry_sdk
     from sentry_sdk.integrations.asyncio import AsyncioIntegration
     from sentry_sdk.integrations.litellm import LiteLLMIntegration
+    from sentry_sdk.integrations.logging import ignore_logger
 
     sentry_sdk.init(
         dsn=dsn,
@@ -191,3 +192,4 @@ def init_sentry() -> None:
             LiteLLMIntegration(),
         ],
     )
+    ignore_logger("agent.redis")


### PR DESCRIPTION
As I have enabled log-collection to Sentry, I have noticed that the logs are massively spammed by the queue-processing logging, e.g.,

• “Waiting for tasks from rebase_queue_c10s (timeout: 30s)...”
• “No tasks received, continuing to wait...”

Therefore I introduce a separate logger for these highly recurrent messages that can be explicitly ignored by Sentry.

### TODO

- [ ] I have also noticed that `logging.getLogger(__name__)` is not very helpful, since in all cases it gets expanded to just `__main__`, I think it would be for the better to adjust that
