### PR TITLE
Mount testing-jiras into agent containers for e2e mock repos

### DIFF
--- a/ymir/agents/tests/e2e/backport_agent/test_backport.py
+++ b/ymir/agents/tests/e2e/backport_agent/test_backport.py
@@ -91,7 +91,7 @@ def _load_test_cases(fixtures_dir: str | Path) -> list[BackportAgentTestCase]:
     return cases
 
 
-test_cases = _load_test_cases(os.getenv("BACKPORT_MOCK_REPOS_DIR", str(DEFAULT_FIXTURES_DIR)))
+test_cases = _load_test_cases(os.getenv("BACKPORT_MOCK_REPOS_DIR") or str(DEFAULT_FIXTURES_DIR))
 
 
 _span_processor = None
@@ -131,7 +131,7 @@ def mock_centos_stream_repos():
     Yields:
         Control to the test session after repos are prepared.
     """
-    fixtures_dir = os.getenv("BACKPORT_MOCK_REPOS_DIR", str(DEFAULT_FIXTURES_DIR))
+    fixtures_dir = os.getenv("BACKPORT_MOCK_REPOS_DIR") or str(DEFAULT_FIXTURES_DIR)
     configs = load_all_fixture_configs(fixtures_dir)
 
     if SHARED_BARE_REPOS_DIR.exists():
@@ -166,7 +166,7 @@ def _load_reference_patch(test_case: "BackportAgentTestCase") -> str | None:
     ref_patch_rel = test_case.expected.get("reference_patch")
     if not ref_patch_rel:
         return None
-    fixtures_dir = Path(os.getenv("BACKPORT_MOCK_REPOS_DIR", str(DEFAULT_FIXTURES_DIR)))
+    fixtures_dir = Path(os.getenv("BACKPORT_MOCK_REPOS_DIR") or str(DEFAULT_FIXTURES_DIR))
     ref_patch_path = fixtures_dir / ref_patch_rel
     if ref_patch_path.is_file():
         return ref_patch_path.read_text()

--- a/ymir/agents/tests/e2e/mock_repos/README.md
+++ b/ymir/agents/tests/e2e/mock_repos/README.md
@@ -10,6 +10,18 @@ Clone the repository and set `MOCK_REPOS_HOST` in your `.env`:
 MOCK_REPOS_HOST=/path/to/testing-jiras/mock_data
 ```
 
+It is recommended to run the E2E tests via compose.
+
+You can also symlink the `mock_data/` subdirectories here for running tests on the host:
+```bash
+ln -s /path/to/testing-jiras/mock_data/triage ymir/agents/tests/e2e/mock_repos/triage
+ln -s /path/to/testing-jiras/mock_data/backport ymir/agents/tests/e2e/mock_repos/backport
+```
+
+> **Note:** Symlinks only work when running tests on the host. Podman bind
+> mounts do not follow symlinks pointing outside the mounted tree, so
+> containerized e2e tests require the compose-based approach.
+
 This mounts the fixture data into E2E test containers at `/home/beeai/mock_repos/`.
 The compose services set `MOCK_REPOS_DIR` and `BACKPORT_MOCK_REPOS_DIR` to point
 at the `triage/` and `backport/` subdirectories respectively.

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -199,7 +199,7 @@ def mock_centos_stream_repos(tmp_path_factory):
     Yields:
         Control to the test session after repos are prepared.
     """
-    fixtures_dir = os.getenv("MOCK_REPOS_DIR", str(DEFAULT_FIXTURES_DIR))
+    fixtures_dir = os.getenv("MOCK_REPOS_DIR") or str(DEFAULT_FIXTURES_DIR)
     configs = load_all_fixture_configs(fixtures_dir)
 
     if git_repo_basepath := os.getenv("GIT_REPO_BASEPATH"):


### PR DESCRIPTION
Symlinks to host paths don't work inside podman containers because bind mounts don't follow symlinks pointing outside the mounted tree. Mount the testing-jiras directory directly via TESTING_JIRAS_DIR and pass MOCK_REPOS_DIR to agent containers so fixture configs are found. Also update both READMEs to document the compose-based setup alongside the host symlink approach.

Assisted-by: Claude