### PR TITLE
Always return awaited value (or value that never had to be awaited)

### DIFF
--- a/ymir/common/base_utils.py
+++ b/ymir/common/base_utils.py
@@ -24,17 +24,16 @@ async def fix_await(v: T | Awaitable[T]) -> T:
 
     Typing for the asyncio redis client is messed up, and functions
     return `T | Awaitable[T]` instead of `T`. This function
-    fixes the type error by asserting that the value is awaitable
-    before awaiting it.
+    fixes the type error by either awaiting, if the value is awaitable
+    or returning it immediately.
 
     For a proper fix, see: https://github.com/redis/redis-py/pull/3619
 
-
-    Usage: `await fixAwait(redis.get("key"))`
+    Usage: `await fix_await(redis.get("key"))`
     """
-    if not inspect.isawaitable(v):
-        raise TypeError(f"expected an awaitable, got {type(v)}")
-    return await v
+    if inspect.isawaitable(v):
+        return await v
+    return v
 
 
 @asynccontextmanager


### PR DESCRIPTION
Looking at the function, I'm not sure we actually need to raise an error here. If the value is not awaitable, it is still a result of some operation and we can just return it as it is.

Out of 21 uses of this function, only in 5 cases is the returned value actually used. And in all of them, the non-awaitable value should still be used.

For example:

```
queue_items = await fix_await(redis_conn.lrange(queue_name, 0, -1))
```

If, for some reason, redis returns list immediately it makes sense to use it.