### PR TITLE
fix(sentry): ignore logging of redis altogether

### DIFF
--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -175,7 +175,10 @@ def init_sentry() -> None:
     import sentry_sdk
     from sentry_sdk.integrations.asyncio import AsyncioIntegration
     from sentry_sdk.integrations.litellm import LiteLLMIntegration
-    from sentry_sdk.integrations.logging import ignore_logger
+    from sentry_sdk.integrations.logging import (
+        ignore_logger,
+        ignore_logger_for_sentry_logs,
+    )
 
     sentry_sdk.init(
         dsn=dsn,
@@ -193,3 +196,4 @@ def init_sentry() -> None:
         ],
     )
     ignore_logger("agent.redis")
+    ignore_logger_for_sentry_logs("agent.redis")


### PR DESCRIPTION
As it turns out `ignore_logger` itself does ignore only events (e.g., errors) or breadcrumbs (items of traces for exceptions).

In case we want to ignore all of these spammy events in Sentry Logs (that are not affected at all by the previous call), we need to use this method too.