### PR TITLE
Fix applicability check: avoid NFS negative lookup cache on clone path

### DIFF
--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -473,10 +473,10 @@ async def clone_and_prep_sources(
     target branch does not exist yet but we know the base commit from Koji.
     """
     working_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / "applicability" / jira_issue
+    if working_dir.is_dir():
+        shutil.rmtree(working_dir)
     working_dir.mkdir(parents=True, exist_ok=True)
     local_clone = working_dir / package
-    if local_clone.is_dir():
-        shutil.rmtree(local_clone)
 
     namespace = "centos-stream" if is_cs_branch(dist_git_branch) else "rhel"
     repository = f"https://gitlab.com/redhat/{namespace}/rpms/{package}"

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -472,6 +472,8 @@ async def clone_and_prep_sources(
     refs and that specific commit is checked out.  This is used when the
     target branch does not exist yet but we know the base commit from Koji.
     """
+    if not jira_issue or Path(jira_issue).is_absolute() or ".." in jira_issue:
+        raise ValueError(f"Invalid jira_issue: {jira_issue}")
     working_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / "applicability" / jira_issue
     if working_dir.is_dir():
         shutil.rmtree(working_dir)


### PR DESCRIPTION
clone_and_prep_sources() was checking local_clone.is_dir() before the remote clone_repository MCP call. On the shared NFS PVC (netapp-nfs, ReadWriteMany), this stat() created a negative lookup cache entry for the clone subdirectory. When MCP gateway subsequently created the directory on the server, the triage agent's NFS client still had the stale ENOENT cached, causing FileNotFoundError on the rhpkg/centpkg prep subprocess — misreported as "not installed" even though both binaries are present in the container.

This broke every single applicability check: prep always "failed", the fallback extraction also hit the stale cache (spec file not found), and the check was silently skipped. CVEs with already-applied fixes (like RHEL-181797) were sent to the backport agent unnecessarily.

The fix matches fork_and_prepare_dist_git (used by backport/rebase agents) which works correctly: clean up via the parent directory, never stat the clone path before the remote clone creates it.

Assisted-by: Claude Opus 4.6

