### PR TITLE
Bump mcp-server-git-repos, phoenix-data, and trace-server-data PVCs to 150Gi

### DIFF
--- a/openshift/pvc-mcp-server-git-repos.yml
+++ b/openshift/pvc-mcp-server-git-repos.yml
@@ -12,6 +12,6 @@ spec:
   - ReadWriteMany
   resources:
     requests:
-      storage: 6Gi
+      storage: 150Gi
   storageClassName: netapp-nfs
   volumeMode: Filesystem

--- a/openshift/pvc-phoenix-data.yml
+++ b/openshift/pvc-phoenix-data.yml
@@ -12,6 +12,6 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 150Gi
   storageClassName: netapp-nfs
   volumeMode: Filesystem

--- a/openshift/pvc-trace-server-data.yml
+++ b/openshift/pvc-trace-server-data.yml
@@ -12,6 +12,6 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 150Gi
   storageClassName: netapp-nfs
   volumeMode: Filesystem


### PR DESCRIPTION
## Summary

- Bumps `mcp-server-git-repos` PVC from 6Gi → 150Gi (holds per-issue dist-git clones).
- Bumps `phoenix-data` PVC from 10Gi → 150Gi (holds the trace database).

Both were close to their limits.

## Test plan

- [ ] `oc apply -f openshift/pvc-mcp-server-git-repos.yml` and `oc apply -f openshift/pvc-phoenix-data.yml` succeed.
- [ ] `oc get pvc mcp-server-git-repos phoenix-data` shows `CAPACITY` of `150Gi`.
- [ ] If either resize stalls in `FileSystemResizePending`, rollout-restart the consuming deployment (`mcp-gateway` / `phoenix`).