### PR TITLE
Sync reqs

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -60,19 +60,11 @@ RUN dnf -y install --allowerasing \
 COPY beeai-reasoning.patch /tmp
 COPY openinference-reasoning.patch /tmp
 
+# Copy dependency files
+COPY requirements-base.txt requirements-agent.txt /tmp/
+
 RUN pip3 install --no-cache-dir \
-      "litellm!=1.82.7,!=1.82.8" \
-      beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
-      google-cloud-aiplatform \
-      openinference-instrumentation-beeai \
-      arize-phoenix-otel \
-      redis \
-      specfile \
-      pytest \
-      pytest-asyncio \
-      GitPython>=3.1.0 \
-      unidiff \
-      sentry-sdk>=2.13.0 \
+      -r /tmp/requirements-agent.txt \
     && cd /usr/local/lib/python3.12/site-packages \
     && patch -p2 -i /tmp/beeai-reasoning.patch \
     && patch -p5 -i /tmp/openinference-reasoning.patch

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -59,21 +59,14 @@ RUN dnf -y install --allowerasing \
 COPY beeai-reasoning.patch /tmp
 COPY openinference-reasoning.patch /tmp
 
+# Copy dependency files
+COPY requirements-base.txt requirements-agent.txt /tmp/
+
 # Create Python 3.11 virtual environment and install Python packages
 RUN python3.11 -m venv --system-site-packages /opt/beeai-venv \
     && /opt/beeai-venv/bin/pip install --upgrade pip \
     && /opt/beeai-venv/bin/pip install --no-cache-dir \
-         "litellm!=1.82.7,!=1.82.8" \
-         beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
-         google-cloud-aiplatform \
-         openinference-instrumentation-beeai \
-         arize-phoenix-otel \
-         redis \
-         specfile \
-         koji \
-         GitPython>=3.1.0 \
-         unidiff \
-         sentry-sdk>=2.13.0 \
+        -r /tmp/requirements-agent.txt \
     && cd /opt/beeai-venv/lib/python3.11/site-packages \
     && patch -p2 -i /tmp/beeai-reasoning.patch \
     && patch -p5 -i /tmp/openinference-reasoning.patch

--- a/Containerfile.c9s-tests
+++ b/Containerfile.c9s-tests
@@ -20,23 +20,14 @@ RUN dnf -y install --allowerasing \
       python3.11-devel \
     && dnf clean all
 
+# Copy dependency files
+COPY requirements-base.txt requirements-test.txt /tmp/
+
 # Create Python 3.11 virtual environment and install Python packages
 RUN python3.11 -m venv --system-site-packages /opt/beeai-venv \
     && /opt/beeai-venv/bin/pip install --upgrade pip \
     && /opt/beeai-venv/bin/pip install --no-cache-dir \
-       "litellm!=1.82.7,!=1.82.8" \
-       beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
-       openinference-instrumentation-beeai \
-       arize-phoenix-otel \
-       aiohttp>=3.12.15 \
-       redis \
-       specfile \
-       pytest \
-       pytest-asyncio \
-       flexmock \
-       koji \
-       GitPython \
-       tomli-w
+        -r /tmp/requirements-test.txt
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/Containerfile.c9s-tests
+++ b/Containerfile.c9s-tests
@@ -25,10 +25,10 @@ RUN python3.11 -m venv --system-site-packages /opt/beeai-venv \
     && /opt/beeai-venv/bin/pip install --upgrade pip \
     && /opt/beeai-venv/bin/pip install --no-cache-dir \
        "litellm!=1.82.7,!=1.82.8" \
-       beeai-framework[vertexai,mcp,duckduckgo]==0.1.79 \
+       beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
        openinference-instrumentation-beeai \
        arize-phoenix-otel \
-       aiohttp \
+       aiohttp>=3.12.15 \
        redis \
        specfile \
        pytest \

--- a/Containerfile.mcp
+++ b/Containerfile.mcp
@@ -30,8 +30,11 @@ RUN dnf -y install \
       ${EXTRA_PACKAGES} \
     && dnf clean all
 
+# Copy dependency files
+COPY requirements-mcp.txt /tmp/
+
 # Install beeai mcp server
-RUN pip3 install --no-cache-dir "litellm!=1.82.7,!=1.82.8" beeai-framework[mcp]==0.1.80 "specfile>=0.36.0"
+RUN pip3 install --no-cache-dir -r /tmp/requirements-mcp.txt
 
 # Create user
 RUN useradd -m -G wheel mcp

--- a/Containerfile.supervisor
+++ b/Containerfile.supervisor
@@ -27,7 +27,7 @@ RUN dnf -y install --allowerasing \
       python3-devel \
     && pip3 install -v --no-cache-dir \
       "litellm!=1.82.7,!=1.82.8" \
-      beeai-framework[vertexai,mcp,duckduckgo]==0.1.79 \
+      beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
       google-cloud-aiplatform \
       openinference-instrumentation-beeai \
       arize-phoenix-otel \

--- a/Containerfile.supervisor
+++ b/Containerfile.supervisor
@@ -25,16 +25,15 @@ RUN dnf -y install --allowerasing \
       gcc \
       gcc-c++ \
       python3-devel \
-    && pip3 install -v --no-cache-dir \
-      "litellm!=1.82.7,!=1.82.8" \
-      beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
-      google-cloud-aiplatform \
-      openinference-instrumentation-beeai \
-      arize-phoenix-otel \
-      redis \
-      specfile \
     && dnf -y remove gcc gcc-c++ python3-devel \
     && dnf clean all
+
+# Copy dependency files
+COPY requirements-base.txt requirements-supervisor.txt /tmp/
+
+# Install remaining dependencies using pip
+RUN pip3 install -v --no-cache-dir \
+  -r /tmp/requirements-supervisor.txt
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -28,11 +28,12 @@ RUN git config --global user.email "ymir-tests@example.com" \
 # Set PYTHONPATH so ymir namespace package can be imported
 ENV PYTHONPATH=/src:$PYTHONPATH
 
-# Install BeeAI Framework and FastMCP
+# Copy dependency file
+COPY requirements-base.txt /tmp/
+
+# Install BeeAI Framework
 RUN pip3 install --no-cache-dir \
-      "litellm!=1.82.7,!=1.82.8" \
-      beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
-      fastmcp redis backoff
+      -r /tmp/requirements-base.txt
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -31,7 +31,7 @@ ENV PYTHONPATH=/src:$PYTHONPATH
 # Install BeeAI Framework and FastMCP
 RUN pip3 install --no-cache-dir \
       "litellm!=1.82.7,!=1.82.8" \
-      beeai-framework[vertexai,mcp,duckduckgo]==0.1.79 \
+      beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
       fastmcp redis backoff
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)

--- a/requirements-agent.txt
+++ b/requirements-agent.txt
@@ -1,0 +1,8 @@
+# Agent container dependencies (c9s, c10s)
+-r requirements-base.txt
+google-cloud-aiplatform
+aiohttp>=3.12.15
+koji
+GitPython>=3.1.0
+unidiff
+sentry-sdk>=2.13.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,0 +1,8 @@
+# Shared pip dependencies for all containers (except MCP)
+# Prevent installation of compromised litellm package versions
+litellm!=1.82.7,!=1.82.8
+beeai-framework[vertexai,mcp,duckduckgo]==0.1.80
+openinference-instrumentation-beeai
+arize-phoenix-otel
+redis>=6.4.0
+specfile>=0.36.0

--- a/requirements-mcp.txt
+++ b/requirements-mcp.txt
@@ -1,0 +1,4 @@
+# Dependencies for the MCP gateway container (beeai[mcp] only, no vertexai/duckduckgo)
+litellm!=1.82.7,!=1.82.8
+beeai-framework[mcp]==0.1.80
+specfile>=0.36.0

--- a/requirements-supervisor.txt
+++ b/requirements-supervisor.txt
@@ -1,0 +1,3 @@
+# Supervisor container dependencies
+-r requirements-base.txt
+google-cloud-aiplatform

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,9 @@
+# c9s test container dependencies
+-r requirements-base.txt
+aiohttp>=3.12.15
+koji
+GitPython>=3.1.0
+pytest
+pytest-asyncio
+flexmock>=0.12.2
+tomli-w

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Dependencies specific to the root ymir package
-ymir-common
-ymir-tools
+# Note: ymir-common and ymir-tools are workspace packages (not on PyPI).
+# They are resolved by uv via [tool.uv.sources] in pyproject.toml.
+# For development setup, use: uv sync
 litellm!=1.82.7,!=1.82.8
 aiohttp>=3.12.15
 arize-phoenix-otel>=0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ litellm!=1.82.7,!=1.82.8
 aiohttp>=3.12.15
 arize-phoenix-otel>=0.13.0
 beautifulsoup4>=4.13.4
-beeai-framework[duckduckgo]
+beeai-framework[duckduckgo]==0.1.80
 copr>=1.129
 fastmcp>=2.11.3
 ogr>=0.55.0


### PR DESCRIPTION
The requirements installed by pip were defined inside container files. Updating them required modification of multiple files at the same time, keeping track of changes to avoid drift. In the worst case scenario, forgetting to update test container, while updating production container, could result in bugs moving undetected into production.

This PR factors out all dependencies into separate requirements files, which are then used across containers.
For example, the Centos 9 test container file, uses `requirements-base.txt`, `requirements-agent.txt` and `requirements-test.txt`. While building the image, both files are copied inside `/tmp` and dependencies are installed using `pip -r`.

When one needs to update agent dependencies across all containers, it is enough to change `requirements-agent.txt`, and all containers will use new dependency list. 

Additional changes:

- beeai-framework versions were synced to 0.1.80 across all containers.
- ymir-tools and ymir-common were removed from requirements, since they can not be installed from PyPi.
