### PR TITLE
Add run_package_prep tool to prevent stale state after prep failure

### DIFF
--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -85,6 +85,7 @@ This skill uses the following tools. Do not restrict tool usage — use any tool
 - `apply_downstream_patches` — Apply existing dist-git patches to an upstream clone
 - `cherry_pick_commit` — Cherry-pick a single commit in a git repository
 - `cherry_pick_continue` — Continue a cherry-pick after conflict resolution
+- `run_package_prep` — Run the %prep section of a spec file, with automatic build directory cleanup on failure
 
 **Other:**
 - Web search via DuckDuckGo or equivalent
@@ -383,7 +384,7 @@ and must remain unchanged.
       - Only apply relevant changes that address the logic of the patch,
         do not modify the Release field or changelog section.
       - If successful, the spec file is now updated, skip to step 6
-        to verify with `<PKG_TOOL> prep` and step 7 to generate SRPM
+        to verify with `run_package_prep` and step 7 to generate SRPM
       - Do NOT add Patch tags (step 5) since this was a spec-only change, not a source code patch
       - If not successful, end with `success=False` and `status="Failed to apply spec changes"`
 
@@ -481,10 +482,10 @@ and must remain unchanged.
             existing patches in the dist-git repository
 
       4h. The cherry-pick workflow is complete! Continue with steps 5-7 below to add
-          the patch(es) to the spec file, verify with `<PKG_TOOL> prep`, and build the SRPM.
+          the patch(es) to the spec file, verify with `run_package_prep`, and build the SRPM.
 
           Note: You do NOT need to apply patches to <UNPACKED_SOURCES>. The patch files
-          will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
+          will be automatically applied during the RPM build process when you run `run_package_prep`.
 
    B. GIT AM WORKFLOW (Fallback approach):
 
@@ -520,12 +521,11 @@ and must remain unchanged.
    the `Patch:` tag(s) - these URLs reference the related upstream commits or pull/merge requests.
    IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order.
 
-6. Run
-   `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
-   to see if the new patch applies cleanly. When `prep` command
-   finishes with "exit 0", it's a success. Ignore errors from
-   libtoolize that warn about newer files: "use '--force' to overwrite".
-   Note: <PKG_TOOL> is the package tool command provided in the prompt.
+6. Use the `run_package_prep` tool to verify that the new patch applies cleanly.
+   When prep succeeds, it's safe to proceed. If it fails, the build directory
+   is automatically cleaned up — do NOT inspect the source tree after a prep
+   failure, fix the patch instead. Ignore errors from libtoolize that warn
+   about newer files: "use '--force' to overwrite".
 
 7. Generate a SRPM using
    `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
@@ -742,10 +742,10 @@ and must remain unchanged.
             existing patches in the dist-git repository
 
       3l. The cherry-pick workflow is complete! Continue with steps 4-6 below to add
-          the patch(es) to the spec file, verify with `<PKG_TOOL> prep`, and build the SRPM.
+          the patch(es) to the spec file, verify with `run_package_prep`, and build the SRPM.
 
           Note: You do NOT need to apply patches to <UNPACKED_SOURCES>. The patch files
-          will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
+          will be automatically applied during the RPM build process when you run `run_package_prep`.
 
    C. GIT AM WORKFLOW (Fallback approach):
 
@@ -785,12 +785,11 @@ and must remain unchanged.
    IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order. Do NOT
    add or change any changelog entries. Do NOT change the Release field.
 
-5. Run
-   `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
-   to see if the new patch applies cleanly. When `prep` command
-   finishes with "exit 0", it's a success. Ignore errors from
-   libtoolize that warn about newer files: "use '--force' to overwrite".
-   Note: <PKG_TOOL> is the package tool command provided in the prompt.
+5. Use the `run_package_prep` tool to verify that the new patch applies cleanly.
+   When prep succeeds, it's safe to proceed. If it fails, the build directory
+   is automatically cleaned up — do NOT inspect the source tree after a prep
+   failure, fix the patch instead. Ignore errors from libtoolize that warn
+   about newer files: "use '--force' to overwrite".
 
 6. Generate a SRPM using
    `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
@@ -882,7 +881,7 @@ SPECIAL CONSIDERATIONS FOR TEST FAILURES:
    - patch_file_path: the path to each patch file in <LOCAL_CLONE>/
 
 5. Test the build:
-   - `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
+   - Use the `run_package_prep` tool to verify patches apply cleanly
    - `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`
    - Call `build_package` with the SRPM path, dist_git_branch, and jira_issue
    - If build fails: use `download_artifacts` to get logs and identify the new error

--- a/agents_as_skills/rebase/SKILL.md
+++ b/agents_as_skills/rebase/SKILL.md
@@ -72,6 +72,7 @@ This skill uses the following tools. Do not restrict tool usage — use any tool
 - `get_cwd` — Get the current working directory
 - `remove` — Delete files
 - `run_shell_command` — Execute shell commands (use as last resort; prefer native tools)
+- `run_package_prep` — Run the %prep section of a spec file, with automatic build directory cleanup on failure
 - `add_changelog_entry` — Add a changelog entry to an RPM spec file
 - `update_release` — Bump the Release field in a spec file
 
@@ -321,14 +322,12 @@ To rebase package <PACKAGE> to version <VERSION> in dist-git branch <DIST_GIT_BR
 4. Use `rpmlint <PACKAGE>.spec` to validate your changes and fix any new issues.
 
 5. Download upstream sources using `spectool -g -S <PACKAGE>.spec`.
-   Run `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
-   to see if everything is in order. It is possible that some *.patch files will fail to apply now
+   Use the `run_package_prep` tool to see if everything is in order.
+   It is possible that some *.patch files will fail to apply now
    that the spec file has been updated. Don't jump to conclusions -
    if one patch fails to apply, it doesn't mean all other patches fail
    to apply as well. Go through the errors one by one, fix them and
-   verify the changes by running
-   `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
-   again.
+   use `run_package_prep` again to verify.
    Repeat as necessary. Do not remove any patches unless all their hunks have been already applied
    to the upstream sources.
    Note: <PKG_TOOL> is `centpkg` for CentOS Stream branches (c9s, c10s) and `rhpkg` for RHEL branches.

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -86,6 +86,7 @@ from ymir.tools.unprivileged.wicked_git import (
     GitPatchApplyTool,
     GitPatchCreationTool,
     GitPreparePackageSources,
+    RunPackagePrepTool,
 )
 
 logger = logging.getLogger(__name__)
@@ -153,7 +154,7 @@ BACKPORT_INSTRUCTIONS = """
             - Only apply relevant changes that address the logic of the patch,
               do not modify the Release field or changelog section.
             - If successful, the spec file is now updated, skip to step 6
-              to verify with `<PKG_TOOL> prep` and step 7 to generate SRPM
+              to verify with `run_package_prep` and step 7 to generate SRPM
             - Do NOT add Patch tags (step 5) since this was a spec-only change, not a source code patch
             - If not successful, end with `success=False` and `status="Failed to apply spec changes"`
 
@@ -251,10 +252,10 @@ BACKPORT_INSTRUCTIONS = """
                   existing patches in the dist-git repository
 
             4h. The cherry-pick workflow is complete! Continue with steps 5-7 below to add
-                the patch(es) to the spec file, verify with `<PKG_TOOL> prep`, and build the SRPM.
+                the patch(es) to the spec file, verify with `run_package_prep`, and build the SRPM.
 
                 Note: You do NOT need to apply patches to <UNPACKED_SOURCES>. The patch files
-                will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
+                will be automatically applied during the RPM build process when you run `run_package_prep`.
 
          B. GIT AM WORKFLOW (Fallback approach):
 
@@ -290,12 +291,11 @@ BACKPORT_INSTRUCTIONS = """
          the `Patch:` tag(s) - these URLs reference the related upstream commits or pull/merge requests.
          IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order.
 
-      6. Run
-         `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
-         to see if the new patch applies cleanly. When `prep` command
-         finishes with "exit 0", it's a success. Ignore errors from
-         libtoolize that warn about newer files: "use '--force' to overwrite".
-         Note: <PKG_TOOL> is the package tool command provided in the prompt.
+      6. Use the `run_package_prep` tool to verify that the new patch applies cleanly.
+         When prep succeeds, it's safe to proceed. If it fails, the build directory
+         is automatically cleaned up — do NOT inspect the source tree after a prep
+         failure, fix the patch instead. Ignore errors from libtoolize that warn
+         about newer files: "use '--force' to overwrite".
 
       7. Generate a SRPM using
          `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
@@ -511,10 +511,10 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
                   existing patches in the dist-git repository
 
             3l. The cherry-pick workflow is complete! Continue with steps 4-6 below to add
-                the patch(es) to the spec file, verify with `<PKG_TOOL> prep`, and build the SRPM.
+                the patch(es) to the spec file, verify with `run_package_prep`, and build the SRPM.
 
                 Note: You do NOT need to apply patches to <UNPACKED_SOURCES>. The patch files
-                will be automatically applied during the RPM build process when you run `<PKG_TOOL> prep`.
+                will be automatically applied during the RPM build process when you run `run_package_prep`.
 
          C. GIT AM WORKFLOW (Fallback approach):
 
@@ -554,12 +554,11 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
          IMPORTANT: Only ADD new patches. Do NOT modify existing Patch tags or their order. Do NOT
          add or change any changelog entries. Do NOT change the Release field.
 
-      5. Run
-         `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
-         to see if the new patch applies cleanly. When `prep` command
-         finishes with "exit 0", it's a success. Ignore errors from
-         libtoolize that warn about newer files: "use '--force' to overwrite".
-         Note: <PKG_TOOL> is the package tool command provided in the prompt.
+      5. Use the `run_package_prep` tool to verify that the new patch applies cleanly.
+         When prep succeeds, it's safe to proceed. If it fails, the build directory
+         is automatically cleaned up — do NOT inspect the source tree after a prep
+         failure, fix the patch instead. Ignore errors from libtoolize that warn
+         about newer files: "use '--force' to overwrite".
 
       6. Generate a SRPM using
          `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> srpm`.
@@ -687,7 +686,7 @@ BACKPORT_FIX_BUILD_ERROR_PROMPT = """
          - patch_file_path: the path to each patch file in {{local_clone}}/
 
       5. Test the build:
-         - `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} prep`
+         - Use the `run_package_prep` tool to verify patches apply cleanly
          - `{{pkg_tool}} --name={{package}} --namespace=rpms --release={{dist_git_branch}} srpm`
          - Call `build_package` with the SRPM path, dist_git_branch, and jira_issue
          - If build fails: use `download_artifacts` to get logs and identify the new error
@@ -754,6 +753,7 @@ async def create_backport_agent(
         ApplyDownstreamPatchesTool(options=local_tool_options),
         CherryPickCommitTool(options=local_tool_options),
         CherryPickContinueTool(options=local_tool_options),
+        RunPackagePrepTool(options=local_tool_options),
     ]
 
     base_tools.extend([t for t in mcp_tools if t.name == "get_maintainer_rules"])

--- a/ymir/agents/merge_request_agent.py
+++ b/ymir/agents/merge_request_agent.py
@@ -52,6 +52,7 @@ from ymir.tools.unprivileged.text import (
     StrReplaceTool,
     ViewTool,
 )
+from ymir.tools.unprivileged.wicked_git import RunPackagePrepTool
 
 logger = logging.getLogger(__name__)
 
@@ -69,8 +70,7 @@ def get_instructions() -> str:
       2. If you updated the spec file, use `rpmlint <PACKAGE>.spec` to validate
          your changes and fix any new issues.
 
-      3. Verify any changes to patches by running
-         `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`.
+      3. Verify any changes to patches by using the `run_package_prep` tool.
          Repeat as necessary. Do not remove any patches unless all their hunks have been already applied
          to the upstream sources.
          Note: <PKG_TOOL> is `centpkg` for CentOS Stream branches (c9s, c10s) and `rhpkg` for RHEL branches.
@@ -153,6 +153,7 @@ def create_merge_request_agent(mcp_tools: list[Tool], local_tool_options: dict[s
             SearchTextTool(options=local_tool_options),
             GetCWDTool(options=local_tool_options),
             RemoveTool(options=local_tool_options),
+            RunPackagePrepTool(options=local_tool_options),
         ]
         + [t for t in mcp_tools if t.name == "upload_sources"],
         memory=UnconstrainedMemory(),

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -63,6 +63,7 @@ from ymir.tools.unprivileged.text import (
     StrReplaceTool,
     ViewTool,
 )
+from ymir.tools.unprivileged.wicked_git import RunPackagePrepTool
 
 logger = logging.getLogger(__name__)
 redis_logger = logging.getLogger("agent.redis")
@@ -109,14 +110,12 @@ def get_instructions() -> str:
       4. Use `rpmlint <PACKAGE>.spec` to validate your changes and fix any new issues.
 
       5. Download upstream sources using `spectool -g -S <PACKAGE>.spec`.
-         Run `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
-         to see if everything is in order. It is possible that some *.patch files will fail to apply now
+         Use the `run_package_prep` tool to see if everything is in order.
+         It is possible that some *.patch files will fail to apply now
          that the spec file has been updated. Don't jump to conclusions -
          if one patch fails to apply, it doesn't mean all other patches fail
          to apply as well. Go through the errors one by one, fix them and
-         verify the changes by running
-         `<PKG_TOOL> --name=<PACKAGE> --namespace=rpms --release=<DIST_GIT_BRANCH> prep`
-         again.
+         use `run_package_prep` again to verify.
          Repeat as necessary. Do not remove any patches unless all their hunks have been already applied
          to the upstream sources.
          Note: <PKG_TOOL> is `centpkg` for CentOS Stream branches (c9s, c10s) and `rhpkg` for RHEL branches.
@@ -200,6 +199,7 @@ def create_rebase_agent(mcp_tools: list[Tool], local_tool_options: dict[str, Any
             SearchTextTool(options=local_tool_options),
             GetCWDTool(options=local_tool_options),
             RemoveTool(options=local_tool_options),
+            RunPackagePrepTool(options=local_tool_options),
         ]
         + [t for t in mcp_tools if t.name in ["upload_sources", "get_maintainer_rules"]],
         memory=UnconstrainedMemory(),

--- a/ymir/tools/unprivileged/tests/unit/test_wicked_git.py
+++ b/ymir/tools/unprivileged/tests/unit/test_wicked_git.py
@@ -13,6 +13,8 @@ from ymir.tools.unprivileged.wicked_git import (
     GitPatchApplyToolInput,
     GitPatchCreationTool,
     GitPatchCreationToolInput,
+    RunPackagePrepInput,
+    RunPackagePrepTool,
     discover_patch_p,
     find_rej_files,
 )
@@ -254,3 +256,104 @@ async def test_find_rej_files(git_repo):
     (git_repo / "foo-bar.rej").write_text("rej content 2")
     result = await find_rej_files(git_repo)
     assert sorted(result) == sorted(["file.txt.rej", "foo-bar.rej"])
+
+
+@pytest.fixture
+def dist_git_dir(tmp_path):
+    """Simulate a dist-git directory with a fake package tool script."""
+    dist_git = tmp_path / "dist-git"
+    dist_git.mkdir()
+    return dist_git
+
+
+@pytest.mark.asyncio
+async def test_run_package_prep_success(dist_git_dir, tmp_path):
+    # Create a fake pkg_tool script that succeeds with known output
+    fake_tool = tmp_path / "fake-centpkg"
+    fake_tool.write_text(
+        "#!/bin/bash\necho 'Executing(%prep): /bin/sh'\necho 'prep done successfully'\nexit 0\n"
+    )
+    fake_tool.chmod(0o755)
+
+    tool = RunPackagePrepTool()
+    output = await tool.run(
+        input=RunPackagePrepInput(
+            dist_git_path=str(dist_git_dir),
+            package="ruby",
+            namespace="rpms",
+            dist_git_branch="rhel-10.2.z",
+            pkg_tool=str(fake_tool),
+        ),
+    )
+    assert "Prep succeeded" in output.result
+    assert "prep done successfully" in output.result
+
+
+@pytest.mark.asyncio
+async def test_run_package_prep_failure_cleans_build_dir(dist_git_dir, tmp_path):
+    # Create a fake pkg_tool script that fails
+    fake_tool = tmp_path / "fake-centpkg"
+    fake_tool.write_text("#!/bin/bash\necho 'patch failed to apply' >&2\nexit 1\n")
+    fake_tool.chmod(0o755)
+
+    # Simulate a partially-patched build subdirectory left behind by rpmbuild
+    build_dir = dist_git_dir / "ruby-3.3.10"
+    build_dir.mkdir()
+    (build_dir / "patched_file.rb").write_text("partially applied content")
+
+    tool = RunPackagePrepTool()
+    output = await tool.run(
+        input=RunPackagePrepInput(
+            dist_git_path=str(dist_git_dir),
+            package="ruby",
+            namespace="rpms",
+            dist_git_branch="rhel-10.2.z",
+            pkg_tool=str(fake_tool),
+        ),
+    )
+    assert "Prep FAILED" in output.result
+    assert "cleaned up" in output.result
+    assert not build_dir.exists(), "Build directory should have been removed on failure"
+
+
+@pytest.mark.asyncio
+async def test_run_package_prep_failure_preserves_non_matching_dirs(dist_git_dir, tmp_path):
+    # Create a fake pkg_tool script that fails
+    fake_tool = tmp_path / "fake-centpkg"
+    fake_tool.write_text("#!/bin/bash\nexit 1\n")
+    fake_tool.chmod(0o755)
+
+    # Create directories: one matching the package name, one not
+    build_dir = dist_git_dir / "ruby-3.3.10"
+    build_dir.mkdir()
+    other_dir = dist_git_dir / "some-other-dir"
+    other_dir.mkdir()
+
+    tool = RunPackagePrepTool()
+    await tool.run(
+        input=RunPackagePrepInput(
+            dist_git_path=str(dist_git_dir),
+            package="ruby",
+            namespace="rpms",
+            dist_git_branch="rhel-10.2.z",
+            pkg_tool=str(fake_tool),
+        ),
+    )
+    assert not build_dir.exists(), "Build directory should have been removed"
+    assert other_dir.exists(), "Non-matching directory should be preserved"
+
+
+@pytest.mark.asyncio
+async def test_run_package_prep_nonexistent_path(tmp_path):
+    tool = RunPackagePrepTool()
+    with pytest.raises(ToolError) as e:
+        await tool.run(
+            input=RunPackagePrepInput(
+                dist_git_path=str(tmp_path / "nonexistent"),
+                package="ruby",
+                namespace="rpms",
+                dist_git_branch="rhel-10.2.z",
+                pkg_tool="centpkg",
+            ),
+        )
+    assert "does not exist" in e.value.message

--- a/ymir/tools/unprivileged/wicked_git.py
+++ b/ymir/tools/unprivileged/wicked_git.py
@@ -1,3 +1,5 @@
+import shutil
+
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
 from beeai_framework.tools import StringToolOutput, ToolError, ToolRunOptions
@@ -81,6 +83,71 @@ class GitPreparePackageSources(Tool[GitPreparePackageSourcesInput, ToolRunOption
             raise
         except Exception as e:
             raise ToolError(f"ERROR: {e}") from e
+
+
+class RunPackagePrepInput(BaseModel):
+    dist_git_path: AbsolutePath = Field(
+        description="Absolute path to the cloned dist-git repository",
+    )
+    package: str = Field(description="Package name")
+    namespace: str = Field(default="rpms", description="Package namespace")
+    dist_git_branch: str = Field(description="Dist-git branch")
+    pkg_tool: str = Field(
+        description="Package tool command (e.g. 'centpkg' or 'rhpkg --offline --released')",
+    )
+
+
+class RunPackagePrepTool(Tool[RunPackagePrepInput, ToolRunOptions, StringToolOutput]):
+    name = "run_package_prep"
+    description = """
+    Runs the package prep step (source extraction + patch application) to verify
+    that all patches apply cleanly. If prep fails, the build subdirectory is
+    removed to prevent inspection of a partially-patched source tree.
+    """
+    input_schema = RunPackagePrepInput
+
+    def _create_emitter(self) -> Emitter:
+        return Emitter.root().child(
+            namespace=["tool", "package", self.name],
+            creator=self,
+        )
+
+    async def _run(
+        self,
+        tool_input: RunPackagePrepInput,
+        options: ToolRunOptions | None,
+        context: RunContext,
+    ) -> StringToolOutput:
+        dist_git = tool_input.dist_git_path
+        if not dist_git.exists():
+            raise ToolError(f"Dist-git path does not exist: {dist_git}")
+
+        pkg_tool_parts = tool_input.pkg_tool.split()
+
+        cmd = [
+            *pkg_tool_parts,
+            f"--name={tool_input.package}",
+            f"--namespace={tool_input.namespace}",
+            f"--release={tool_input.dist_git_branch}",
+            "prep",
+        ]
+
+        exit_code, stdout, stderr = await run_subprocess(cmd, cwd=dist_git)
+
+        if exit_code == 0:
+            return StringToolOutput(result=f"Prep succeeded.\n{stdout}")
+
+        # Prep failed — remove build subdirectories to prevent stale state.
+        # rpmbuild creates directories like <package>-<version>/ under the dist-git root.
+        for child in dist_git.iterdir():
+            if child.is_dir() and child.name.startswith(tool_input.package + "-"):
+                shutil.rmtree(child, ignore_errors=True)
+
+        return StringToolOutput(
+            result=f"Prep FAILED (exit code {exit_code}). "
+            "Build directory has been cleaned up to prevent stale state.\n"
+            f"stdout: {stdout}\nstderr: {stderr}"
+        )
 
 
 def ensure_git_repository(repository_path: AbsolutePath) -> None:


### PR DESCRIPTION
## Summary
- Adds a new `run_package_prep` tool that wraps `rhpkg prep` / `centpkg prep` and removes the build subdirectory on failure, preventing agents from inspecting a partially-patched source tree
- Replaces raw `run_shell_command` prep calls in the backport, rebase, and merge-request agent prompts with the new tool
- Motivated by RHEL-181797 where the backport agent saw its own partially-applied patch in the source tree after a prep failure and incorrectly concluded "backport already applied"
