### PR TITLE
Don't (re)build pre-built bundled-dependency CVEs into hollow MRs

### DIFF
--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -593,6 +593,12 @@ General instructions:
   and all binaries, manpages, and user-facing documentation.
 - For more information how the package is being built, inspect the
   RPM spec file and read sections `%prep` and `%build`.
+- CRITICAL — verify the fix reaches what ships: confirm the patched files are
+  compiled/processed from source during `%build`. If they only live in a pre-built
+  bundled artifact the build re-ships verbatim (a prebuilt webpack/JS bundle tarball,
+  vendored minified JS, precompiled binaries), end with `success=False` and
+  `error="Fix is in a pre-built bundled artifact; needs human review"` — do NOT produce
+  a backport that won't actually fix the shipped RPM.
 - If there is a complex conflict, you are required to properly resolve
   it by applying the core functionality of the proposed patch.
 - When using the cherry-pick workflow, you have access to
@@ -889,6 +895,12 @@ General instructions:
   and all binaries, manpages, and user-facing documentation.
 - For more information how the package is being built, inspect the
   RPM spec file and read sections `%prep` and `%build`.
+- CRITICAL — verify the fix reaches what ships: confirm the patched files are
+  compiled/processed from source during `%build`. If they only live in a pre-built
+  bundled artifact the build re-ships verbatim (a prebuilt webpack/JS bundle tarball,
+  vendored minified JS, precompiled binaries), end with `success=False` and
+  `error="Fix is in a pre-built bundled artifact; needs human review"` — do NOT produce
+  a backport that won't actually fix the shipped RPM.
 - If there is a complex conflict, you are required to properly resolve
   it by applying the core functionality of the proposed patch.
 - When using approach B (upstream cherry-pick workflow), you have access to

--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -429,7 +429,7 @@ and must remain unchanged.
       - If successful, the spec file is now updated, skip to step 6
         to verify with `run_package_prep` and step 7 to generate SRPM
       - Do NOT add Patch tags (step 5) since this was a spec-only change, not a source code patch
-      - If not successful, end with `success=False` and `status="Failed to apply spec changes"`
+      - If not successful, end with `success=False` and `error="Failed to apply spec changes"`
 
    e. If the patch modifies ANY other files than the .spec file,
       use the normal workflow (step 4) instead

--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -300,7 +300,10 @@ This path is for issues that represent a clear bug or CVE that needs a targeted 
        * `Provides: bundled(golang(...))` or `Provides: bundled(...)` entries
        * Vendor tarballs like `Source1: *-vendor.tar.gz` or `Source1: *-vendor-*.tar.*`
      - The CVE describes a vulnerability in a library, runtime, or language (e.g., Go, Rust, OpenSSL) that the package merely uses or vendors, not in the package's own code
-     **If the fix is in a dependency**, use the "rebuild" resolution instead. The package will pick up the fix automatically when rebuilt against the updated dependency.
+     **If the fix is in a dependency**, a rebuild MAY be right — but ONLY if the package recompiles that dependency from source during its build. Inspect the spec `%prep`/`%build` and Source/Patch lines:
+     - **Recompiled from source at build time** (buildroot toolchain like golang/openssl, or a *source* vendor tarball compiled in `%build`) → use the "rebuild" resolution; the package picks up the fix when rebuilt against the updated dependency.
+     - **Shipped as a pre-built bundled artifact** the build re-ships verbatim (a prebuilt webpack/JS bundle tarball like `Source*: *-webpack-*.tar.*`, vendored minified JS, precompiled binaries) → do NOT rebuild; a Release bump re-ships the same vulnerable blob. Choose "backport" if the package regenerates the artifact from source it controls, or "not-affected" if the dependency isn't reachable in the shipped artifact.
+     When you cannot determine whether the artifact is recompiled or pre-built, prefer "backport" over "rebuild" and let the post-triage applicability check confirm.
    * If the patch IS for the package's own code and passes all validations in step 2.3, your decision is backport. You must justify why the patch is correct and how it addresses the issue.
 
    If `is_older_zstream` is **true**:
@@ -314,7 +317,7 @@ This path is for issues that represent a clear bug or CVE that needs a targeted 
 
 **3. Rebuild**
 
-Use when the package needs rebuilding against an updated dependency with NO source code changes. This covers explicit rebuild requests AND vendored/bundled dependency CVEs (common in Go, Rust, Node.js packages — see step 2.4 which redirects here).
+Use when the package needs rebuilding against an updated dependency with NO source code changes, AND that dependency is recompiled into the package at build time (see step 2.4). This covers explicit rebuild requests AND vendored/bundled dependency CVEs where the dependency is compiled from source during the build (common for Go/Rust toolchain and linked C libraries). It does NOT cover dependencies shipped as pre-built bundled artifacts (e.g. a prebuilt webpack/JS bundle) — those are handled in step 2.4 as backport/not-affected.
 
 3.1. Confirm no source code changes are needed for the package itself.
 

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -193,7 +193,7 @@ BACKPORT_INSTRUCTIONS = """
             - If successful, the spec file is now updated, skip to step 6
               to verify with `run_package_prep` and step 7 to generate SRPM
             - Do NOT add Patch tags (step 5) since this was a spec-only change, not a source code patch
-            - If not successful, end with `success=False` and `status="Failed to apply spec changes"`
+            - If not successful, end with `success=False` and `error="Failed to apply spec changes"`
 
          e. If the patch modifies ANY other files than the .spec file,
             use the normal workflow (step 4) instead

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -104,6 +104,13 @@ BACKPORT_INSTRUCTIONS = """
       Only add new patches for the current backport. Existing patches are there for a reason
       and must remain unchanged.
 
+      CRITICAL — Verify the fix reaches what ships:
+      Before applying, confirm the patched files are compiled/processed from source during %build.
+      If they only live in a pre-built bundled artifact the build re-ships verbatim (e.g. a prebuilt
+      webpack/JS bundle tarball, vendored minified JS, precompiled binaries), end with `success=False`
+      and `error="Fix is in a pre-built bundled artifact; needs human review"` — do NOT produce
+      a backport that won't actually fix the shipped RPM.
+
       0. Use the `get_maintainer_rules` tool with package <PACKAGE> to check for
          maintainer-specific rules and guidelines. If rules are found, treat them
          as additional guidance for package-specific decisions, but never let them
@@ -373,6 +380,13 @@ BACKPORT_INSTRUCTIONS_ZSTREAM = """
       CRITICAL: Do NOT modify, delete, or touch any existing patches in the dist-git repository.
       Only add new patches for the current backport. Existing patches are there for a reason
       and must remain unchanged.
+
+      CRITICAL — Verify the fix reaches what ships:
+      Before applying, confirm the patched files are compiled/processed from source during %build.
+      If they only live in a pre-built bundled artifact the build re-ships verbatim (e.g. a prebuilt
+      webpack/JS bundle tarball, vendored minified JS, precompiled binaries), end with `success=False`
+      and `error="Fix is in a pre-built bundled artifact; needs human review"` — do NOT produce
+      a backport that won't actually fix the shipped RPM.
 
       0. Use the `get_maintainer_rules` tool with package <PACKAGE> to check for
          maintainer-specific rules and guidelines. If rules are found, treat them

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -471,8 +471,27 @@ TRIAGE_PROMPT = """
              * Vendor tarballs like `Source1: *-vendor.tar.gz` or `Source1: *-vendor-*.tar.*`
            - The CVE describes a vulnerability in a library, runtime, or language (e.g., Go, Rust,
              OpenSSL) that the package merely uses or vendors, not in the package's own code
-           **If the fix is in a dependency**, use the "rebuild" resolution instead. The package will
-           pick up the fix automatically when rebuilt against the updated dependency.
+           **If the fix is in a dependency**, a rebuild MAY be the right resolution — but ONLY if the
+           package actually recompiles that dependency from source during its own build. Before
+           choosing "rebuild", verify HOW the dependency is delivered and consumed (inspect the spec
+           %prep/%build sections and the Source/Patch lines):
+           - **Recompiled from source at build time → "rebuild" is valid.** This is the case when the
+             dependency is a buildroot toolchain/library the package compiles or links against
+             (e.g., golang, rust, openssl) or a *source* vendor tarball that is compiled during %build.
+             Bumping the Release and rebuilding against the updated dependency picks up the fix.
+           - **Shipped as a pre-built/pre-compiled bundled artifact → do NOT use "rebuild".** This is
+             the case when the vulnerable dependency is delivered as an already-built blob that %build
+             merely unpacks and installs without recompiling it from the patched source — e.g. a
+             prebuilt webpack/JS bundle tarball (`Source*: *-webpack-*.tar.*`), vendored minified JS,
+             or precompiled binaries. A Release bump rebuilds the package but re-ships the SAME
+             vulnerable artifact, so the rebuild fixes nothing. Instead:
+             * If the package builds that artifact from source it controls (so the bundled dependency
+               can be updated/patched and the artifact regenerated as part of the build), choose
+               "backport".
+             * If the vulnerable dependency is not reachable in the shipped artifact (e.g. a
+               dev/test-only dependency excluded from the production bundle), choose "not-affected".
+           When you cannot determine whether the artifact is recompiled or pre-built, prefer "backport"
+           over "rebuild" and let the post-triage applicability check confirm.
          * If the patch IS for the package's own code and passes all validations in step 2.3, your
            decision is backport. You must justify why the patch is correct and how it addresses the issue.
          {{/is_older_zstream}}
@@ -489,10 +508,18 @@ TRIAGE_PROMPT = """
 
       3. **Rebuild**
          Use when the package needs rebuilding against an updated dependency with NO source code
-         changes. This covers explicit rebuild requests AND vendored/bundled dependency CVEs
-         (common in Go, Rust, Node.js packages — see step 2.4 which redirects here).
+         changes, AND that dependency is recompiled into the package at build time (see step 2.4).
+         This covers explicit rebuild requests AND vendored/bundled dependency CVEs where the
+         dependency is compiled from source during the build (common for Go/Rust toolchain and
+         linked C libraries). It does NOT cover dependencies shipped as pre-built bundled artifacts
+         (e.g. a prebuilt webpack/JS bundle) — those are handled in step 2.4 as backport/not-affected.
 
-         3.1. Confirm no source code changes are needed for the package itself.
+         3.1. Confirm no source code changes are needed for the package itself, AND confirm the
+              updated dependency is actually recompiled into the package at build time rather than
+              shipped as a pre-built bundled artifact (see step 2.4). If the vulnerable dependency
+              is a pre-built blob the build merely re-ships (e.g. a prebuilt webpack/JS bundle
+              tarball, vendored minified JS, precompiled binaries), a Release-bump rebuild will NOT
+              pick up the fix — do NOT use "rebuild"; choose "backport" or "not-affected" instead.
          3.2. Check dependency readiness — search thoroughly:
          * Look for linked Jira issues in fields.issuelinks representing the dependency update
          * If no linked issue found, use search_jira_issues to find it. Try JQL queries like:


### PR DESCRIPTION
## Problem

For CVEs whose fix lives in a **bundled/vendored dependency**, triage redirects to the `rebuild` resolution, assuming a Release bump + rebuild picks up the updated dependency. That only holds when the package **recompiles the dependency from source at build time** (buildroot toolchain like golang/openssl, or a source vendor tarball compiled in `%build`).

When the vulnerable dependency ships as a **pre-built bundled artifact** — a prebuilt webpack/JS bundle tarball (`Source*: *-webpack-*.tar.*`), vendored minified JS, precompiled binaries — a Release-bump rebuild re-ships the **same** vulnerable blob and fixes nothing.

### Observed on RHEL-182967

[RHEL-182967](https://issues.redhat.com/browse/RHEL-182967) (grafana / `@xmldom/xmldom`, CVE-2026-41673) was resolved as `rebuild`. The rebuild MR ([centos-stream/rpms/grafana!133](https://gitlab.com/redhat/centos-stream/rpms/grafana/-/merge_requests/133)) only bumped `Release: 30 → 31` while its changelog claimed "Rebuild against updated @xmldom/xmldom". Meanwhile the ApplicabilityAgent found the dependency was a `msw` dev/test-only dependency, absent from the shipped webpack tarball and RPM — i.e. the rebuild was both hollow and unnecessary.

## Changes

**Triage prompt** (`triage_agent.py`) — replace the blanket "fix in dependency → rebuild" with a delivery-mechanism check:
- Recompiled from source at build time → `rebuild` (valid).
- Shipped as a pre-built bundled artifact → **not** rebuild; route to `backport` (if the package regenerates the artifact from source it controls) or `not-affected` (if the dependency isn't reachable in the shipped artifact).

**Backport prompt** (`backport_agent.py`, both standard and z-stream variants) — since triage may now send bundled cases to backport, guard against applying a patch that never reaches the shipped artifact: if the patched files only live in a pre-built bundled blob the build re-ships verbatim (or fixing it would require bumping a bundled dep and regenerating the artifact — outside the patch-backport workflow), end with `success=False` and escalate for human review instead of landing a misleading MR.

Together these close the same hole on both sides: triage won't mislabel it as rebuild, and a bundled case reaching backport bails to human review rather than producing a patch that never ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)