### PR TITLE
Add OpenShift queue/error-list inspection make targets

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -31,6 +31,18 @@ run-jira-issue-fetcher-todo:
 	oc delete job jira-issue-fetcher-todo-manual || true
 	oc create job jira-issue-fetcher-todo-manual --from=cronjob/jira-issue-fetcher-todo
 
+suspend-jira-issue-fetcher:
+	oc patch cronjob jira-issue-fetcher --type merge -p '{"spec":{"suspend":true}}'
+
+unsuspend-jira-issue-fetcher:
+	oc patch cronjob jira-issue-fetcher --type merge -p '{"spec":{"suspend":false}}'
+
+suspend-jira-issue-fetcher-todo:
+	oc patch cronjob jira-issue-fetcher-todo --type merge -p '{"spec":{"suspend":true}}'
+
+unsuspend-jira-issue-fetcher-todo:
+	oc patch cronjob jira-issue-fetcher-todo --type merge -p '{"spec":{"suspend":false}}'
+
 show-triage-queue:
 	$(call show_queue,triage_queue)
 
@@ -98,6 +110,8 @@ logs-otel-collector:
 	oc logs -f deployment/otel-collector
 
 .PHONY: deploy run-jira-issue-fetcher run-jira-issue-fetcher-todo \
+	suspend-jira-issue-fetcher unsuspend-jira-issue-fetcher \
+	suspend-jira-issue-fetcher-todo unsuspend-jira-issue-fetcher-todo \
 	show-triage-queue show-rebase-queue-c9s show-rebase-queue-c10s \
 	show-backport-queue-c9s show-backport-queue-c10s \
 	show-rebuild-queue-c9s show-rebuild-queue-c10s \

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -16,4 +16,37 @@ show-triage-queue:
 	@echo "=== triage_queue (normal) ==="
 	@oc exec deployment/valkey -- valkey-cli LRANGE triage_queue 0 -1 | jq -r .metadata.issue | tac
 
-.PHONY: deploy run-jira-issue-fetcher run-jira-issue-fetcher-todo show-triage-queue
+	oc exec deployment/valkey -- valkey-cli LRANGE triage_queue 0 -1 | jq -r .metadata.issue | tac
+
+show-error-list:
+	@oc exec deployment/valkey -- valkey-cli LRANGE error_list 0 -1 | python3 scripts/error_list.py --file -
+
+logs-triage:
+	oc logs -f deployment/triage-agent
+
+logs-backport-c9s:
+	oc logs -f deployment/backport-agent-c9s
+
+logs-backport-c10s:
+	oc logs -f deployment/backport-agent-c10s
+
+logs-rebase-c9s:
+	oc logs -f deployment/rebase-agent-c9s
+
+logs-rebase-c10s:
+	oc logs -f deployment/rebase-agent-c10s
+
+logs-rebuild-c9s:
+	oc logs -f deployment/rebuild-agent-c9s
+
+logs-rebuild-c10s:
+	oc logs -f deployment/rebuild-agent-c10s
+
+logs-mcp:
+	oc logs -f deployment/mcp-gateway
+
+.PHONY: deploy run-jira-issue-fetcher run-jira-issue-fetcher-todo \
+	show-triage-queue show-error-list \
+	logs-triage logs-backport-c9s logs-backport-c10s \
+	logs-rebase-c9s logs-rebase-c10s logs-rebuild-c9s logs-rebuild-c10s \
+	logs-mcp

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -1,3 +1,25 @@
+# Run recipes under bash with pipefail so a failing `oc exec` in an
+# `oc ... | jq | tac` pipeline aborts the target instead of being masked by the
+# exit status of the trailing command (which would look like an empty queue).
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -c
+
+# Dump an input queue and its ymir_todo priority twin (drained first by the
+# agents' BRPOP), oldest-first to match pop order.
+define show_queue
+@echo "=== $(1)_todo (ymir_todo, priority — popped first) ==="
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1)_todo 0 -1 | jq -r .metadata.issue | tac
+@echo
+@echo "=== $(1) (normal) ==="
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r .metadata.issue | tac
+endef
+
+# Dump a single input queue (one with no priority twin), oldest-first.
+define show_single_queue
+@echo "=== $(1) ==="
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r .metadata.issue | tac
+endef
+
 deploy:
 	./deploy.sh
 
@@ -10,16 +32,31 @@ run-jira-issue-fetcher-todo:
 	oc create job jira-issue-fetcher-todo-manual --from=cronjob/jira-issue-fetcher-todo
 
 show-triage-queue:
-	@echo "=== triage_queue_todo (ymir_todo, priority — popped first) ==="
-	@oc exec deployment/valkey -- valkey-cli LRANGE triage_queue_todo 0 -1 | jq -r .metadata.issue | tac
-	@echo
-	@echo "=== triage_queue (normal) ==="
-	@oc exec deployment/valkey -- valkey-cli LRANGE triage_queue 0 -1 | jq -r .metadata.issue | tac
+	$(call show_queue,triage_queue)
 
-	oc exec deployment/valkey -- valkey-cli LRANGE triage_queue 0 -1 | jq -r .metadata.issue | tac
+show-rebase-queue-c9s:
+	$(call show_queue,rebase_queue_c9s)
+
+show-rebase-queue-c10s:
+	$(call show_queue,rebase_queue_c10s)
+
+show-backport-queue-c9s:
+	$(call show_queue,backport_queue_c9s)
+
+show-backport-queue-c10s:
+	$(call show_queue,backport_queue_c10s)
+
+show-rebuild-queue-c9s:
+	$(call show_queue,rebuild_queue_c9s)
+
+show-rebuild-queue-c10s:
+	$(call show_queue,rebuild_queue_c10s)
+
+show-clarification-queue:
+	$(call show_single_queue,clarification_needed_queue)
 
 show-error-list:
-	@oc exec deployment/valkey -- valkey-cli LRANGE error_list 0 -1 | python3 scripts/error_list.py --file -
+	@oc exec deployment/valkey -- valkey-cli --no-raw LRANGE error_list 0 -1 | python3 scripts/error_list.py --file -
 
 logs-triage:
 	oc logs -f deployment/triage-agent
@@ -45,8 +82,27 @@ logs-rebuild-c10s:
 logs-mcp:
 	oc logs -f deployment/mcp-gateway
 
+logs-supervisor:
+	oc logs -f deployment/supervisor-processor
+
+logs-valkey:
+	oc logs -f deployment/valkey
+
+logs-phoenix:
+	oc logs -f deployment/phoenix
+
+logs-redis-commander:
+	oc logs -f deployment/redis-commander
+
+logs-otel-collector:
+	oc logs -f deployment/otel-collector
+
 .PHONY: deploy run-jira-issue-fetcher run-jira-issue-fetcher-todo \
-	show-triage-queue show-error-list \
+	show-triage-queue show-rebase-queue-c9s show-rebase-queue-c10s \
+	show-backport-queue-c9s show-backport-queue-c10s \
+	show-rebuild-queue-c9s show-rebuild-queue-c10s \
+	show-clarification-queue show-error-list \
 	logs-triage logs-backport-c9s logs-backport-c10s \
 	logs-rebase-c9s logs-rebase-c10s logs-rebuild-c9s logs-rebuild-c10s \
-	logs-mcp
+	logs-mcp logs-supervisor logs-valkey logs-phoenix \
+	logs-redis-commander logs-otel-collector

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -4,20 +4,24 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -c
 
+# Reverse to oldest-first (next-to-pop) order. tac is GNU-only; fall back to
+# `tail -r` on macOS/BSD where tac is absent.
+TAC := $(shell command -v tac 2>/dev/null || echo "tail -r")
+
 # Dump an input queue and its ymir_todo priority twin (drained first by the
 # agents' BRPOP), oldest-first to match pop order.
 define show_queue
 @echo "=== $(1)_todo (ymir_todo, priority — popped first) ==="
-@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1)_todo 0 -1 | jq -r .metadata.issue | tac
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1)_todo 0 -1 | jq -r '.metadata.issue // empty' | $(TAC)
 @echo
 @echo "=== $(1) (normal) ==="
-@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r .metadata.issue | tac
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '.metadata.issue // empty' | $(TAC)
 endef
 
 # Dump a single input queue (one with no priority twin), oldest-first.
 define show_single_queue
 @echo "=== $(1) ==="
-@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r .metadata.issue | tac
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '.metadata.issue // empty' | $(TAC)
 endef
 
 deploy:

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -141,6 +141,46 @@ oc rsh deployment/valkey redis-cli LPUSH triage_queue '{"metadata": {"issue": "R
 
 Set `force_cve_triage` to `false` for a normal triage run. This mirrors the `make trigger-pipeline` target used locally.
 
+## Inspecting queues and following logs
+
+Run these from the `openshift/` directory (they shell into the `valkey` pod via `oc exec`, so an active `oc login` to the project is required).
+
+### Queue contents
+
+Each `show-*-queue` target lists the Jira issue keys currently waiting in a queue, oldest-first (next to be popped). Every input queue has a priority twin (`<queue>_todo`) that the agents drain first for `ymir_todo`-triggered tasks, so those targets print the `_todo` queue before the normal one.
+
+```bash
+make show-triage-queue          # triage_queue_todo + triage_queue
+make show-rebase-queue-c9s      # rebase_queue_c9s_todo + rebase_queue_c9s
+make show-rebase-queue-c10s     # rebase_queue_c10s_todo + rebase_queue_c10s
+make show-backport-queue-c9s    # backport_queue_c9s_todo + backport_queue_c9s
+make show-backport-queue-c10s   # backport_queue_c10s_todo + backport_queue_c10s
+make show-rebuild-queue-c9s     # rebuild_queue_c9s_todo + rebuild_queue_c9s
+make show-rebuild-queue-c10s    # rebuild_queue_c10s_todo + rebuild_queue_c10s
+make show-clarification-queue   # clarification_needed_queue (no priority twin)
+make show-error-list            # per-issue / per-tool-error breakdown via scripts/error_list.py
+```
+
+### Following pod logs
+
+Each `logs-*` target follows (`oc logs -f`) the corresponding deployment's pod:
+
+```bash
+make logs-triage           # triage-agent
+make logs-backport-c9s     # backport-agent-c9s
+make logs-backport-c10s    # backport-agent-c10s
+make logs-rebase-c9s       # rebase-agent-c9s
+make logs-rebase-c10s      # rebase-agent-c10s
+make logs-rebuild-c9s      # rebuild-agent-c9s
+make logs-rebuild-c10s     # rebuild-agent-c10s
+make logs-mcp              # mcp-gateway
+make logs-supervisor       # supervisor-processor
+make logs-valkey           # valkey
+make logs-phoenix          # phoenix
+make logs-redis-commander  # redis-commander
+make logs-otel-collector   # otel-collector
+```
+
 ## Image rebuilds of MCP Gateway and agent images
 
 They are built internally. If you need a rebuild right now, head over

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -118,6 +118,17 @@ make run-jira-issue-fetcher       # generic batch filter
 make run-jira-issue-fetcher-todo  # ymir_todo sweep
 ```
 
+Both CronJobs ship with `suspend: true`, so they never fire on their schedule until resumed. Enable or pause each one's schedule:
+
+```bash
+make unsuspend-jira-issue-fetcher        # resume the generic batch fetcher
+make unsuspend-jira-issue-fetcher-todo   # resume the ymir_todo sweep
+make suspend-jira-issue-fetcher          # pause it again
+make suspend-jira-issue-fetcher-todo     # pause it again
+```
+
+These patch the live CronJob (`oc patch ... suspend`). Re-applying the manifests (`./deploy.sh`) resets both back to suspended, so to enable a fetcher permanently set `suspend: false` in its `cronjob-jira-issue-fetcher*.yml` as well.
+
 ## Agent runtime knobs (`agents-env` ConfigMap)
 
 | Key | Default | Effect |

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -118,7 +118,7 @@ make run-jira-issue-fetcher       # generic batch filter
 make run-jira-issue-fetcher-todo  # ymir_todo sweep
 ```
 
-Both CronJobs ship with `suspend: true`, so they never fire on their schedule until resumed. Enable or pause each one's schedule:
+`jira-issue-fetcher-todo` ships with `suspend: false` (it runs on its schedule out of the box); `jira-issue-fetcher` ships with `suspend: true` and must be resumed before it fires. Enable or pause each one's schedule:
 
 ```bash
 make unsuspend-jira-issue-fetcher        # resume the generic batch fetcher
@@ -127,7 +127,7 @@ make suspend-jira-issue-fetcher          # pause it again
 make suspend-jira-issue-fetcher-todo     # pause it again
 ```
 
-These patch the live CronJob (`oc patch ... suspend`). Re-applying the manifests (`./deploy.sh`) resets both back to suspended, so to enable a fetcher permanently set `suspend: false` in its `cronjob-jira-issue-fetcher*.yml` as well.
+These patch the live CronJob (`oc patch ... suspend`). Re-applying the manifests (`./deploy.sh`) resets each CronJob to whatever `suspend` value its `cronjob-jira-issue-fetcher*.yml` declares (`jira-issue-fetcher-todo` → running, `jira-issue-fetcher` → suspended), so to change a fetcher's default permanently edit `suspend` in its manifest.
 
 ## Agent runtime knobs (`agents-env` ConfigMap)
 

--- a/openshift/cronjob-jira-issue-fetcher-todo.yml
+++ b/openshift/cronjob-jira-issue-fetcher-todo.yml
@@ -10,7 +10,7 @@ spec:
   concurrencyPolicy: Forbid  # Prevent overlapping runs
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
-  suspend: true
+  suspend: false
   jobTemplate:
     metadata:
       labels:

--- a/openshift/scripts/error_list.py
+++ b/openshift/scripts/error_list.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Parse and summarize the Ymir `error_list` (or any Valkey list).
+
+Intended to be fed by the `make show-error-list` target, which pipes
+`oc exec deployment/valkey -- valkey-cli --no-raw LRANGE error_list 0 -1` into
+it. It can also fetch the list itself, or read a saved dump.
+
+The list is awkward to read with `jq` because:
+  * valkey-cli/redis-cli framing (`1) "<C-escaped value>"` with `--no-raw` or a
+    TTY, or raw newline-separated values when piped) wraps each element, and
+  * error payloads are double-JSON-encoded, with the real tool error buried in a
+    `details` traceback or a `{"type":"text","text":"Error executing tool ..."}`
+    object.
+
+This script strips the framing, decodes the payloads, extracts the issue key and
+the tool error, and prints a per-issue summary plus a per-tool-error breakdown
+(the list is cumulative across runs, so the breakdown is the useful signal).
+
+Usage:
+    make show-error-list                               # from openshift/ (preferred)
+    python3 scripts/error_list.py                       # fetch via oc directly
+    python3 scripts/error_list.py --queue triage_queue  # any list
+    python3 scripts/error_list.py --json                # machine-readable
+    oc exec deployment/valkey -- valkey-cli --no-raw LRANGE error_list 0 -1 \
+        | python3 scripts/error_list.py --file -
+    python3 scripts/error_list.py --file dump.txt       # parse a saved dump
+
+Read-only: it never mutates the queue.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+
+RHEL_RE = re.compile(r"RHEL-\d+")
+RC_LINE = re.compile(r'^\s*\d+\)\s+"(.*)"\s*$')  # valkey-cli interactive line
+TOOL_ERR_RE = re.compile(r"Error executing tool ([\w.]+): (.+?)(?:\\n|\n|\"|$)")
+AGENT_ERR_RE = re.compile(r"(AgentError: [^\"\\\n]+)")
+REASON_FIELDS = ("details", "error", "message", "status", "traceback", "reason", "text")
+
+
+def fetch_via_oc(queue: str, deployment: str) -> str:
+    # --no-raw forces the `N) "<C-escaped>"` framing: each element on one
+    # physical line with newlines escaped, which to_elements parses unambiguously
+    # (raw output can't be split reliably when an element spans multiple lines).
+    cmd = [
+        "oc",
+        "exec",
+        f"deployment/{deployment}",
+        "--",
+        "valkey-cli",
+        "--no-raw",
+        "LRANGE",
+        queue,
+        "0",
+        "-1",
+    ]
+    print(f"Running: {' '.join(cmd)}", file=sys.stderr)
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)  # noqa: S603
+    except FileNotFoundError:
+        sys.exit("error: `oc` not found on PATH. Pipe a dump in via `--file -` instead.")
+    except subprocess.TimeoutExpired:
+        sys.exit("error: `oc exec` timed out. Check cluster connectivity / VPN.")
+    if proc.returncode != 0:
+        sys.exit(
+            f"error: oc exec failed (exit {proc.returncode}). "
+            f"Are you logged in (`oc whoami`) and is the `{deployment}` deployment present?\n"
+            f"{proc.stderr.strip()[:300]}"
+        )
+    return proc.stdout
+
+
+def _unescape_rediscli(s: str) -> str:
+    """Undo valkey-cli/redis-cli C-style escaping of a quoted bulk string.
+
+    redis-cli emits each non-ASCII byte as its own ``\\xNN`` escape, so a
+    multibyte UTF-8 character arrives as several escapes. Rebuild a byte buffer
+    and decode it as UTF-8 at the end to recover such characters intact rather
+    than turning each byte into a separate code point.
+    """
+    out, i, n = bytearray(), 0, len(s)
+    simple = {"n": b"\n", "t": b"\t", "r": b"\r", "a": b"\a", "b": b"\b", '"': b'"', "\\": b"\\"}
+    while i < n:
+        c = s[i]
+        if c == "\\" and i + 1 < n:
+            nxt = s[i + 1]
+            if nxt == "x" and i + 3 < n:
+                try:
+                    out.append(int(s[i + 2 : i + 4], 16))
+                    i += 4
+                    continue
+                except ValueError:
+                    pass
+            out.extend(simple.get(nxt, nxt.encode("utf-8", "replace")))
+            i += 2
+        else:
+            out.extend(c.encode("utf-8", "replace"))
+            i += 1
+    return out.decode("utf-8", errors="replace")
+
+
+def to_elements(blob: str) -> list[str]:
+    """Split the LRANGE dump into raw element strings.
+
+    Prefers the `N) "..."` framing (from `--no-raw`, or an interactive TTY),
+    which puts each element on one physical line and is unambiguous. Falls back
+    to a best-effort scan for raw/piped output: concatenated JSON objects are
+    decoded individually, and any other text is taken one line per element
+    (valkey-cli `--raw` separates elements with newlines). A raw element that
+    itself spans multiple lines cannot be reassembled here — prefer `--no-raw`.
+    """
+    lines = blob.splitlines()
+    if any(RC_LINE.match(line) for line in lines):
+        return [_unescape_rediscli(m.group(1)) for line in lines if (m := RC_LINE.match(line))]
+    elems, dec, i, n = [], json.JSONDecoder(), 0, len(blob)
+    while i < n:
+        while i < n and blob[i] in " \t\r\n":
+            i += 1
+        if i >= n:
+            break
+        if blob[i] == "{":
+            try:
+                obj, end = dec.raw_decode(blob, i)
+                elems.append(json.dumps(obj))
+                i = end
+                continue
+            except json.JSONDecodeError:
+                pass
+        nl = blob.find("\n", i)
+        end = n if nl == -1 else nl
+        chunk = blob[i:end].strip()
+        if chunk:
+            elems.append(chunk)
+        i = end
+    return elems
+
+
+def _try_json(s: str):
+    v = s
+    for _ in range(3):
+        try:
+            v = json.loads(v)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if isinstance(v, dict):
+            return v
+        if not isinstance(v, str):
+            return None
+    return None
+
+
+def issue_of(obj, raw: str) -> str:
+    if isinstance(obj, dict):
+        meta = obj.get("metadata")
+        if isinstance(meta, dict) and meta.get("issue"):
+            return meta["issue"]
+        for key in ("jira_issue", "issue", "issue_key"):
+            if obj.get(key):
+                return obj[key]
+    m = RHEL_RE.search(raw)
+    return m.group(0) if m else "?"
+
+
+def reason_of(obj, raw: str) -> str:
+    m = TOOL_ERR_RE.search(raw)
+    if m:
+        return f"{m.group(1)}: {m.group(2).strip()[:90]}"
+    a = AGENT_ERR_RE.search(raw)
+    if a:
+        return a.group(1)[:100]
+    if isinstance(obj, dict):
+        for f in REASON_FIELDS:
+            v = obj.get(f)
+            if v:
+                first = str(v).splitlines()[0] if isinstance(v, str) else str(v)
+                if first.strip():
+                    return first[:100]
+        if "attempts" in obj or "metadata" in obj:
+            return f"(Task, attempts={obj.get('attempts', '?')}, no error field)"
+    line = next((ln for ln in raw.splitlines() if ln.strip()), "")
+    return line[:100] or "(empty)"
+
+
+def signature(reason: str) -> str:
+    m = re.match(r"([\w.]+):", reason)
+    return m.group(1) if m else reason[:40]
+
+
+def analyze(blob: str) -> list[dict]:
+    out = []
+    for elem in to_elements(blob):
+        obj = _try_json(elem)
+        out.append({"issue": issue_of(obj, elem), "reason": reason_of(obj, elem), "parsed": obj is not None})
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--queue", default="error_list", help="Valkey list name (default: error_list)")
+    ap.add_argument(
+        "--deployment", default="valkey", help="OpenShift deployment running valkey (default: valkey)"
+    )
+    ap.add_argument("--file", help="Parse a saved `LRANGE ... 0 -1` dump; use '-' to read stdin")
+    ap.add_argument("--json", action="store_true", help="Emit JSON instead of a table")
+    args = ap.parse_args()
+
+    if args.file == "-":
+        # Decode as UTF-8 regardless of locale: dumps carry non-ASCII tracebacks
+        # and the default stdin encoding is the C locale (ASCII) in cron/CI pods.
+        blob = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+    elif args.file:
+        with open(args.file, encoding="utf-8", errors="replace") as fh:
+            blob = fh.read()
+    else:
+        blob = fetch_via_oc(args.queue, args.deployment)
+
+    entries = analyze(blob)
+    total = len(entries)
+    parsed = sum(1 for e in entries if e["parsed"])
+    by_sig = Counter(signature(e["reason"]) for e in entries)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "queue": args.queue,
+                    "total": total,
+                    "parsed": parsed,
+                    "by_issue": dict(Counter(e["issue"] for e in entries).most_common()),
+                    "by_error": dict(by_sig.most_common()),
+                    "entries": entries,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    print(f"\n{args.queue}: {total} entr{'y' if total == 1 else 'ies'} ({parsed} parsed)\n")
+    print("By issue:")
+    grouped: dict[str, Counter] = {}
+    for e in entries:
+        grouped.setdefault(e["issue"], Counter())[e["reason"]] += 1
+    width = max((len(k) for k in grouped), default=4)
+    for issue, reasons in sorted(grouped.items(), key=lambda kv: -sum(kv[1].values())):
+        n = sum(reasons.values())
+        tag = f" (x{n})" if n > 1 else ""
+        print(f"  {issue:<{width}}{tag}  {reasons.most_common(1)[0][0][:90]}")
+    print("\nBy error type:")
+    for sig, n in by_sig.most_common():
+        print(f"  {n:>3}x  {sig}")
+
+
+if __name__ == "__main__":
+    main()

--- a/openshift/scripts/error_list.py
+++ b/openshift/scripts/error_list.py
@@ -61,18 +61,23 @@ def fetch_via_oc(queue: str, deployment: str) -> str:
     ]
     print(f"Running: {' '.join(cmd)}", file=sys.stderr)
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=60)  # noqa: S603
-    except FileNotFoundError:
-        sys.exit("error: `oc` not found on PATH. Pipe a dump in via `--file -` instead.")
+        # Capture bytes and decode as UTF-8 explicitly: text=True would use the
+        # locale encoding (US-ASCII under a C/POSIX locale, common in containers)
+        # and crash on non-ASCII output. Matches how the --file paths decode.
+        proc = subprocess.run(cmd, capture_output=True, timeout=60)  # noqa: S603
+    except OSError as e:
+        sys.exit(f"error: failed to run `oc` ({e}). Pipe a dump in via `--file -` instead.")
     except subprocess.TimeoutExpired:
         sys.exit("error: `oc exec` timed out. Check cluster connectivity / VPN.")
+    stdout = proc.stdout.decode("utf-8", errors="replace")
     if proc.returncode != 0:
+        stderr = proc.stderr.decode("utf-8", errors="replace")
         sys.exit(
             f"error: oc exec failed (exit {proc.returncode}). "
             f"Are you logged in (`oc whoami`) and is the `{deployment}` deployment present?\n"
-            f"{proc.stderr.strip()[:300]}"
+            f"{stderr.strip()[:300]}"
         )
-    return proc.stdout
+    return stdout
 
 
 def _unescape_rediscli(s: str) -> str:
@@ -84,7 +89,18 @@ def _unescape_rediscli(s: str) -> str:
     than turning each byte into a separate code point.
     """
     out, i, n = bytearray(), 0, len(s)
-    simple = {"n": b"\n", "t": b"\t", "r": b"\r", "a": b"\a", "b": b"\b", '"': b'"', "\\": b"\\"}
+    # Mirror redis-cli's sdscatrepr escapes: \n \r \t \a \b \v \f plus " and \.
+    simple = {
+        "n": b"\n",
+        "t": b"\t",
+        "r": b"\r",
+        "a": b"\a",
+        "b": b"\b",
+        "v": b"\v",
+        "f": b"\f",
+        '"': b'"',
+        "\\": b"\\",
+    }
     while i < n:
         c = s[i]
         if c == "\\" and i + 1 < n:
@@ -115,7 +131,11 @@ def to_elements(blob: str) -> list[str]:
     itself spans multiple lines cannot be reassembled here — prefer `--no-raw`.
     """
     lines = blob.splitlines()
-    if any(RC_LINE.match(line) for line in lines):
+    # --no-raw always prefixes the first element with `1) "..."`, so detect the
+    # framing from the first non-empty line only. Probing every line with any()
+    # would misfire on a raw traceback line that happens to look like `N) "..."`.
+    first_line = next((ln for ln in lines if ln.strip()), None)
+    if first_line and RC_LINE.match(first_line):
         return [_unescape_rediscli(m.group(1)) for line in lines if (m := RC_LINE.match(line))]
     elems, dec, i, n = [], json.JSONDecoder(), 0, len(blob)
     while i < n:
@@ -154,14 +174,21 @@ def _try_json(s: str):
     return None
 
 
+def _issue_str(val) -> str:
+    """Coerce an issue value to a string key (Jira sometimes nests it as {"key": ...})."""
+    if isinstance(val, dict) and "key" in val:
+        return str(val["key"])
+    return str(val)
+
+
 def issue_of(obj, raw: str) -> str:
     if isinstance(obj, dict):
         meta = obj.get("metadata")
         if isinstance(meta, dict) and meta.get("issue"):
-            return meta["issue"]
+            return _issue_str(meta["issue"])
         for key in ("jira_issue", "issue", "issue_key"):
             if obj.get(key):
-                return obj[key]
+                return _issue_str(obj[key])
     m = RHEL_RE.search(raw)
     return m.group(0) if m else "?"
 
@@ -177,7 +204,8 @@ def reason_of(obj, raw: str) -> str:
         for f in REASON_FIELDS:
             v = obj.get(f)
             if v:
-                first = str(v).splitlines()[0] if isinstance(v, str) else str(v)
+                lines = str(v).splitlines()
+                first = lines[0] if lines else ""
                 if first.strip():
                     return first[:100]
         if "attempts" in obj or "metadata" in obj:
@@ -214,8 +242,11 @@ def main() -> None:
         # and the default stdin encoding is the C locale (ASCII) in cron/CI pods.
         blob = sys.stdin.buffer.read().decode("utf-8", errors="replace")
     elif args.file:
-        with open(args.file, encoding="utf-8", errors="replace") as fh:
-            blob = fh.read()
+        try:
+            with open(args.file, encoding="utf-8", errors="replace") as fh:
+                blob = fh.read()
+        except OSError as e:
+            sys.exit(f"error: failed to read file '{args.file}': {e}")
     else:
         blob = fetch_via_oc(args.queue, args.deployment)
 


### PR DESCRIPTION
Adds `make` targets in `openshift/` for inspecting the live Ymir pipeline on OpenShift, so common debugging doesn't need hand-typed `oc exec` / `oc logs` commands.

## What's included
- **`show-triage-queue`** — list issue keys queued for triage.
- **`show-error-list`** — parse and summarize `error_list` via `openshift/scripts/error_list.py`. `error_list` can't be read with `jq` (valkey-cli framing + double-JSON-encoded payloads), so the script strips the framing, decodes the payloads, and prints a **per-issue** and **per-tool-error** breakdown (the list is cumulative, so the breakdown is the useful signal).
- **`logs-*`** — follow logs for each agent / mcp-gateway.

## Usage
```bash
cd openshift
make show-triage-queue
make show-error-list
make logs-triage          # logs-backport-c9s, logs-mcp, ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)