### PR TITLE
Install python3-devel in the c9s agent image

### DIFF
--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -22,6 +22,7 @@ RUN dnf -y install --allowerasing \
       git \
       krb5-devel \
       python3-rpm \
+      python3-devel \
       rpm-build \
       rpmdevtools \
       rpmautospec-rpm-macros \


### PR DESCRIPTION
## Problem

`centpkg prep` fails in the **c9s** backport agent for packages whose `%prep` runs `%py3_shebang_fix`, because that macro calls `pathfix.py` — shipped by base **`python3-devel`**, which the c9s image was missing (it installed only `python3.11-devel`). `%prep` aborts before any patch work, so the backport dies immediately.

Observed yesterday on libinput (CVE-2026-50265):
- [RHEL-182361](https://issues.redhat.com/browse/RHEL-182361) (c8s)
- [RHEL-182366](https://issues.redhat.com/browse/RHEL-182366) (c9s)

Both: `fork`/`clone`/`download_sources` OK and all 9 existing downstream patches apply cleanly, then:

```
+ pathfix.py -i /usr/bin/python3 -p -n .gitlab-ci.yml … tools/*.py
/var/tmp/rpm-tmp.XXXXXX: line 103: pathfix.py: command not found
error: Bad exit status from /var/tmp/rpm-tmp.XXXXXX (%prep)
```

## Fix

Add `python3-devel` to `Containerfile.c9s`. `Containerfile.c10s` already installs it — which is exactly why the equivalent c10s libinput backport (RHEL-182371) succeeded — so this just brings c9s in line.

This unblocks the whole class of packages whose `%prep` uses `pathfix.py`, not only libinput. After the image is rebuilt/rolled out, RHEL-182361 and RHEL-182366 can be re-triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)