### PR TITLE
Add triage_summary field and collapsible MR description sections

### DIFF
--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -32,7 +32,7 @@ from ymir.agents.package_update_steps import PackageUpdateState, PackageUpdateSt
 from ymir.agents.reasoning_agent import ReasoningAgent
 from ymir.agents.utils import (
     check_subprocess,
-    format_mr_justification,
+    format_mr_triage_details,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -42,6 +42,7 @@ from ymir.agents.utils import (
     render_prompt,
     resolve_chat_model_override,
     run_tool,
+    wrap_details,
 )
 from ymir.common.base_utils import fix_await, is_cs_branch, redis_client
 from ymir.common.constants import JiraLabels, RedisQueues
@@ -614,6 +615,13 @@ def get_prompt() -> str:
       Your working directory is {{local_clone}}, a clone of dist-git repository of package {{package}}.
       {{dist_git_branch}} dist-git branch has been checked out. You are working on Jira issue {{jira_issue}}
       {{#cve_id}}(a.k.a. {{.}}){{/cve_id}}.
+      {{#triage_summary}}
+      Triage context (from the triage agent that selected these patches):
+      {{.}}
+      Apply all provided patches as-is unless the triage context above explicitly
+      states that only specific parts of the patches are relevant. Only then should
+      you selectively apply the indicated changes.
+      {{/triage_summary}}
       {{^build_error}}
       Backport upstream patches:
       {{#upstream_patches}}
@@ -637,6 +645,13 @@ BACKPORT_FIX_BUILD_ERROR_PROMPT = """
       Your working directory is {{local_clone}}, a clone of dist-git repository of package {{package}}.
       {{dist_git_branch}} dist-git branch has been checked out. You are working on Jira issue {{jira_issue}}
       {{#cve_id}}(a.k.a. {{.}}){{/cve_id}}.
+      {{#triage_summary}}
+      Triage context (from the triage agent that selected these patches):
+      {{.}}
+      Apply all provided patches as-is unless the triage context above explicitly
+      states that only specific parts of the patches are relevant. Only then should
+      you selectively apply the indicated changes.
+      {{/triage_summary}}
 
       Upstream patches that were backported:
       {{#upstream_patches}}
@@ -881,6 +896,7 @@ class BackportState(PackageUpdateState):
     upstream_patches: list[str]
     cve_id: str | None
     justification: str | None = Field(default=None)
+    triage_summary: str | None = Field(default=None)
     unpacked_sources: Path | None = Field(default=None)
     backport_log: list[str] = Field(default_factory=list)
     backport_result: BackportOutputSchema | None = Field(default=None)
@@ -898,6 +914,7 @@ async def run_workflow(
     jira_issue,
     cve_id,
     justification=None,
+    triage_summary=None,
     fix_version=None,
     redis_conn=None,
     dry_run=False,
@@ -1009,6 +1026,7 @@ async def run_workflow(
                         upstream_patches=state.upstream_patches,
                         build_error=state.build_error,
                         pkg_tool=pkg_tool,
+                        triage_summary=state.triage_summary,
                     ),
                 ),
                 expected_output=BackportOutputSchema,
@@ -1100,6 +1118,7 @@ async def run_workflow(
                             upstream_patches=state.upstream_patches,
                             build_error=state.build_error,
                             pkg_tool=pkg_tool,
+                            triage_summary=state.triage_summary,
                         ),
                     ),
                     expected_output=BackportOutputSchema,
@@ -1271,7 +1290,7 @@ async def run_workflow(
         async def commit_push_and_open_mr(state):
             try:
                 formatted_patches = "\n".join(f" - {p}" for p in state.upstream_patches)
-                justification_text = format_mr_justification(state.justification)
+                triage_details_text = format_mr_triage_details(state.justification, state.triage_summary)
                 (
                     state.merge_request_url,
                     state.merge_request_newly_created,
@@ -1295,9 +1314,9 @@ async def run_workflow(
                     mr_description=(
                         f"{state.log_result.description}\n\n"
                         f"Upstream patches:\n{formatted_patches}\n\n"
-                        f"{justification_text}"
+                        f"{triage_details_text}"
                         f"Resolves: {state.jira_issue}\n\n"
-                        f"Backporting steps:\n\n{state.backport_log[-1]}"
+                        f"{wrap_details('Backporting steps', state.backport_log[-1])}"
                         f"\n\n{mr_description_footer(state.package)}"
                     ),
                     available_tools=gateway_tools,
@@ -1361,6 +1380,7 @@ async def run_workflow(
                 jira_issue=jira_issue,
                 cve_id=cve_id,
                 justification=justification,
+                triage_summary=triage_summary,
                 fix_version=fix_version,
                 attempts_remaining=max_build_attempts,
             ),
@@ -1396,6 +1416,7 @@ async def main() -> None:
                 jira_issue=jira_issue,
                 cve_id=os.getenv("CVE_ID", None),
                 justification=os.getenv("JUSTIFICATION", None),
+                triage_summary=os.getenv("TRIAGE_SUMMARY", None),
                 fix_version=branch,
                 redis_conn=None,
                 dry_run=dry_run,
@@ -1473,6 +1494,7 @@ async def main() -> None:
                         jira_issue=backport_data.jira_issue,
                         cve_id=backport_data.cve_id,
                         justification=backport_data.justification,
+                        triage_summary=backport_data.triage_summary,
                         fix_version=backport_data.fix_version,
                         redis_conn=redis,
                         dry_run=dry_run,

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -28,7 +28,7 @@ from ymir.agents.observability import setup_observability
 from ymir.agents.package_update_steps import PackageUpdateState, PackageUpdateStep
 from ymir.agents.reasoning_agent import ReasoningAgent
 from ymir.agents.utils import (
-    format_mr_justification,
+    format_mr_triage_details,
     get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
@@ -37,6 +37,7 @@ from ymir.agents.utils import (
     mcp_tools,
     render_prompt,
     resolve_chat_model_override,
+    wrap_details,
 )
 from ymir.common.base_utils import fix_await, is_cs_branch, redis_client
 from ymir.common.constants import JiraLabels, RedisQueues
@@ -167,6 +168,10 @@ def get_prompt() -> str:
       to do so.
       {{/fedora_clone}}
 
+      {{#triage_summary}}
+      Triage context (from the triage agent that selected this rebase):
+      {{.}}
+      {{/triage_summary}}
       {{^build_error}}
       Rebase the package to version {{version}}.
       {{/build_error}}
@@ -234,6 +239,7 @@ async def main() -> None:
     class State(PackageUpdateState):
         version: str
         justification: str | None = Field(default=None)
+        triage_summary: str | None = Field(default=None)
         fedora_clone: Path | None = Field(default=None)
         rebase_log: list[str] = Field(default_factory=list)
         rebase_result: RebaseOutputSchema | None = Field(default=None)
@@ -247,6 +253,7 @@ async def main() -> None:
         version,
         jira_issue,
         justification=None,
+        triage_summary=None,
         redis_conn=None,
         user_triggered=False,
     ):
@@ -309,6 +316,7 @@ async def main() -> None:
                             jira_issue=state.jira_issue,
                             build_error=state.build_error,
                             pkg_tool=pkg_tool,
+                            triage_summary=state.triage_summary,
                         ),
                     ),
                     expected_output=RebaseOutputSchema,
@@ -420,7 +428,7 @@ async def main() -> None:
 
             async def commit_push_and_open_mr(state):
                 try:
-                    justification_text = format_mr_justification(state.justification)
+                    triage_details_text = format_mr_triage_details(state.justification, state.triage_summary)
                     (
                         state.merge_request_url,
                         state.merge_request_newly_created,
@@ -439,9 +447,9 @@ async def main() -> None:
                         mr_title=state.log_result.title,
                         mr_description=(
                             f"{state.log_result.description}\n\n"
-                            f"{justification_text}"
+                            f"{triage_details_text}"
                             f"Resolves: {state.jira_issue}\n\n"
-                            f"Status of the rebase:\n\n{state.rebase_log[-1]}"
+                            f"{wrap_details('Rebase status', state.rebase_log[-1])}"
                             f"\n\n{mr_description_footer(state.package)}"
                         ),
                         available_tools=gateway_tools,
@@ -502,6 +510,7 @@ async def main() -> None:
                     version=version,
                     jira_issue=jira_issue,
                     justification=justification,
+                    triage_summary=triage_summary,
                 ),
             )
             return response.state
@@ -520,6 +529,7 @@ async def main() -> None:
                 version=version,
                 jira_issue=jira_issue,
                 justification=os.getenv("JUSTIFICATION", None),
+                triage_summary=os.getenv("TRIAGE_SUMMARY", None),
                 redis_conn=None,
             )
             logger.info(f"Direct run completed: {state.rebase_result.model_dump_json(indent=4)}")
@@ -592,6 +602,7 @@ async def main() -> None:
                         version=rebase_data.version,
                         jira_issue=rebase_data.jira_issue,
                         justification=rebase_data.justification,
+                        triage_summary=rebase_data.triage_summary,
                         redis_conn=redis,
                         user_triggered=user_triggered,
                     )

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -16,7 +16,7 @@ from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
 from ymir.agents.package_update_steps import PackageUpdateState
 from ymir.agents.utils import (
-    format_mr_justification,
+    format_mr_triage_details,
     get_agent_execution_config,
     init_sentry,
     mcp_tools,
@@ -58,6 +58,7 @@ async def main() -> None:
         rebuild_success: bool = Field(default=False)
         rebuild_error: str | None = Field(default=None)
         justification: str | None = Field(default=None)
+        triage_summary: str | None = Field(default=None)
         dependency_issue: str | None = Field(default=None)
         dependency_component: str | None = Field(default=None)
         consolidated_issues: list[ConsolidatedIssue] = Field(default_factory=list)
@@ -68,6 +69,7 @@ async def main() -> None:
         dist_git_branch,
         jira_issue,
         justification=None,
+        triage_summary=None,
         dependency_issue=None,
         dependency_component=None,
         consolidated_issues=None,
@@ -210,7 +212,7 @@ async def main() -> None:
                             f"\nSibling consolidation analysis:\n{state.consolidation_summary}\n"
                         )
 
-                    justification_text = format_mr_justification(state.justification)
+                    triage_details_text = format_mr_triage_details(state.justification, state.triage_summary)
 
                     (
                         state.merge_request_url,
@@ -231,7 +233,7 @@ async def main() -> None:
                         mr_title=state.log_result.title,
                         mr_description=(
                             f"{state.log_result.description}\n\n"
-                            f"{justification_text}"
+                            f"{triage_details_text}"
                             f"{dep_text}"
                             f"{dep_issues_text}"
                             f"{resolves_text}\n"
@@ -294,6 +296,7 @@ async def main() -> None:
                     dist_git_branch=dist_git_branch,
                     jira_issue=jira_issue,
                     justification=justification,
+                    triage_summary=triage_summary,
                     dependency_issue=dependency_issue,
                     dependency_component=dependency_component,
                     consolidated_issues=consolidated_issues or [],
@@ -319,6 +322,7 @@ async def main() -> None:
                 dist_git_branch=branch,
                 jira_issue=jira_issue,
                 justification=os.getenv("JUSTIFICATION", None),
+                triage_summary=os.getenv("TRIAGE_SUMMARY", None),
                 dependency_issue=dependency_issue,
                 dependency_component=dependency_component,
                 consolidated_issues=consolidated_issues,
@@ -408,6 +412,7 @@ async def main() -> None:
                         dist_git_branch=dist_git_branch,
                         jira_issue=rebuild_data.jira_issue,
                         justification=rebuild_data.justification,
+                        triage_summary=rebuild_data.triage_summary,
                         dependency_issue=rebuild_data.dependency_issue,
                         dependency_component=rebuild_data.dependency_component,
                         consolidated_issues=rebuild_data.consolidated_issues,

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -545,6 +545,30 @@ TRIAGE_PROMPT = """
          * The package mentioned in the issue cannot be found or identified
          * The issue cannot be accessed
 
+      **Triage Summary vs Justification**
+
+      For rebase, backport, and rebuild decisions, you MUST include both a
+      `justification` and a `triage_summary` field. These serve different
+      audiences and MUST NOT overlap:
+
+      `justification` — reviewer-facing rationale. Explain *why this fix is
+      correct*: what vulnerability/bug it addresses, why the downstream version
+      is affected, and why the chosen patch/version resolves it. Do NOT include
+      investigation narrative ("I searched…", "I found…") here.
+
+      `triage_summary` — investigation log and downstream-agent handoff.
+      Explain *how you arrived at this conclusion and what the downstream agent
+      needs to know*. Cover:
+      - What you searched (upstream repos, advisories, Fedora, git history)
+      - What you ruled out and why
+      - Any caveats, uncertainties, or limitations in your analysis
+      - For backports: the downstream agent applies all provided patches
+        in full by default. Only mention patch handling when something
+        non-standard is needed (e.g. only part of a patch is relevant,
+        or the downstream code structure differs from upstream so the
+        agent must adapt the patch manually). Do NOT add redundant
+        instructions like "apply the full patch".
+
       **Final Step: Set JIRA Fields
       (for Rebase, Backport, and Rebuild decisions only)**
 
@@ -795,7 +819,8 @@ async def run_workflow(
                         "data": {{
                         "package": "some-package",
                         "patch_urls": ["https://github.com/example-org/example-repo/commit/abc123def456.patch"],
-                        "justification": "This patch fixes the bug by doing X, Y, and Z.",
+                        "justification": "Patch adds input validation to parse_input().",
+                        "triage_summary": "Searched upstream git for CVE ID; no match. Found via Fedora.",
                         "jira_issue": "RHEL-12345",
                         "cve_id": "CVE-1234-98765",
                         "fix_version": "rhel-X.Y.Z"
@@ -810,7 +835,8 @@ async def run_workflow(
                         "data": {{
                         "package": "some-package",
                         "version": "2.4.1",
-                        "justification": "The issue is fixed in upstream version 2.4.1 available in Fedora.",
+                        "justification": "Version 2.4.1 includes the fix for the crash in parse_uri().",
+                        "triage_summary": "Fedora already rebased to 2.4.1 for this bug. Verified changelog.",
                         "jira_issue": "RHEL-12345",
                         "fix_version": "rhel-X.Y.Z"
                         }}
@@ -825,7 +851,8 @@ async def run_workflow(
                         "package": "some-package",
                         "jira_issue": "RHEL-12345",
                         "cve_id": "CVE-1234-98765",
-                        "justification": "Rebuild needed, links against golang which received security fix.",
+                        "justification": "Package links against golang which got a CVE-1234-98765 fix.",
+                        "triage_summary": "Confirmed package vendors Go deps via spec BuildRequires.",
                         "dependency_issue": "RHEL-67890",
                         "dependency_component": "golang",
                         "fix_version": "rhel-X.Y.Z"

--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -156,18 +156,27 @@ def build_agent_factory_with_mock_repos(
     return agent_factory
 
 
-def format_mr_justification(justification: str | None) -> str:
-    """Format justification text for MR descriptions.
+def wrap_details(summary: str, body: str) -> str:
+    """Wrap content in a collapsible HTML <details> block for GitLab MR descriptions."""
+    return f"<details>\n<summary>{summary}</summary>\n\n{body}\n\n</details>"
 
-    Args:
-        justification: Optional justification text from triage agent
 
-    Returns:
-        Formatted string with "Justification:" header and trailing newlines,
-        or empty string if justification is None
+def format_mr_triage_details(
+    justification: str | None,
+    triage_summary: str | None = None,
+) -> str:
+    """Format justification and triage summary for MR descriptions.
+
+    Wraps content in a collapsible <details> block.
     """
-    if justification:
-        return f"Triage Decision Justification:\n{justification}\n\n"
+    parts = []
+    if triage_summary and triage_summary.strip():
+        parts.append(f"**Reasoning:**\n{triage_summary.strip()}")
+    if justification and justification.strip():
+        parts.append(f"**Justification:**\n{justification.strip()}")
+    if parts:
+        body = "\n\n".join(parts)
+        return wrap_details("Triage Details", body) + "\n\n"
     return ""
 
 

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -105,6 +105,10 @@ class RebaseInputSchema(BaseModel):
     version: str = Field(description="Version to update to")
     jira_issue: str = Field(description="Jira issue to reference as resolved")
     build_error: str | None = Field(description="Error encountered during package build")
+    triage_summary: str | None = Field(
+        default=None,
+        description="Triage context: what was investigated and guidance on how the rebase should be done",
+    )
 
 
 class RebaseOutputSchema(BaseModel):
@@ -143,6 +147,10 @@ class BackportInputSchema(BaseModel):
     )
     build_error: str | None = Field(description="Error encountered during package build")
     pkg_tool: str = Field(default="centpkg", description="Package tool command with arguments")
+    triage_summary: str | None = Field(
+        default=None,
+        description="Triage context: what was investigated and guidance on how the backport should be done",
+    )
 
 
 class BackportOutputSchema(BaseModel):
@@ -193,7 +201,15 @@ class RebaseData(BaseModel):
     package: str = Field(description="Package name")
     version: str = Field(description="Target upstream package version to rebase to (e.g., '2.4.1')")
     justification: str | None = Field(
-        default=None, description="Clear explanation of why this version fixes the issue"
+        default=None,
+        description="Reviewer-facing rationale: why this version fixes the issue. "
+        "Do NOT include investigation narrative here.",
+    )
+    triage_summary: str | None = Field(
+        default=None,
+        description="Investigation log and downstream-agent handoff: what was searched, "
+        "what was ruled out, caveats, and operational guidance. "
+        "Do NOT repeat the justification rationale here.",
     )
     jira_issue: str = Field(description="Jira issue identifier")
     fix_version: str | None = Field(description="Fix version in Jira (e.g., 'rhel-9.8')", default=None)
@@ -212,10 +228,18 @@ class BackportData(BaseModel):
     )
     justification: str = Field(
         description=(
-            "Clear explanation of why this patch fixes the issue, linking it to the root cause. "
+            "Reviewer-facing rationale: why this patch fixes the issue, linking it to the root cause. "
             "For CVE issues: explicitly state whether the patch mentions the CVE ID, and if not, "
-            "explain how you verified the patch addresses the specific vulnerability described in the CVE."
+            "explain how the patch addresses the specific vulnerability. "
+            "Do NOT include investigation narrative here."
         )
+    )
+    triage_summary: str | None = Field(
+        default=None,
+        description="Investigation log and downstream-agent handoff: what was searched, "
+        "what was ruled out, caveats, and operational guidance "
+        "(e.g. which part of a broad patch is the actual fix). "
+        "Do NOT repeat the justification rationale here.",
     )
     jira_issue: str = Field(description="Jira issue identifier")
     cve_id: str | None = Field(description="CVE identifier", default=None)
@@ -244,7 +268,14 @@ class RebuildData(BaseModel):
     cve_id: str | None = Field(description="CVE identifier", default=None)
     justification: str | None = Field(
         default=None,
-        description="Clear explanation of why a rebuild is needed and how it addresses the issue",
+        description="Reviewer-facing rationale: why a rebuild is needed and how it addresses the issue. "
+        "Do NOT include investigation narrative here.",
+    )
+    triage_summary: str | None = Field(
+        default=None,
+        description="Investigation log and downstream-agent handoff: what was searched, "
+        "what was ruled out, caveats, and operational guidance. "
+        "Do NOT repeat the justification rationale here.",
     )
     dependency_issue: str | None = Field(
         description="Key of the dependency Jira issue that triggered the rebuild",
@@ -413,10 +444,16 @@ class TriageOutputSchema(BaseModel):
                 patch_urls_text = "\n".join(
                     [f"*Patch URL {i + 1}*: {url}" for i, url in enumerate(self.data.patch_urls)]
                 )
+                triage_summary_text = (
+                    f"\n*Triage Reasoning*: {self.data.triage_summary.strip()}"
+                    if self.data.triage_summary and self.data.triage_summary.strip()
+                    else ""
+                )
                 return (
                     f"{resolution}"
                     f"{patch_urls_text}\n"
                     f"*Justification*: {self.data.justification}"
+                    f"{triage_summary_text}"
                     f"{fix_version_text}"
                     f"{follow_up_note}"
                     f"{TRIAGE_DISCLAIMER}"
@@ -429,12 +466,17 @@ class TriageOutputSchema(BaseModel):
                 justification_text = (
                     f"\n*Justification*: {self.data.justification}" if self.data.justification else ""
                 )
+                triage_summary_text = (
+                    f"\n*Triage Reasoning*: {self.data.triage_summary.strip()}"
+                    if self.data.triage_summary and self.data.triage_summary.strip()
+                    else ""
+                )
 
                 return (
                     f"{resolution}"
                     f"*Package*: {self.data.package}\n"
                     f"*Version*: {self.data.version}"
-                    f"{justification_text}{fix_version_text}"
+                    f"{justification_text}{triage_summary_text}{fix_version_text}"
                     f"{follow_up_note}"
                     f"{TRIAGE_DISCLAIMER}"
                 )
@@ -445,6 +487,11 @@ class TriageOutputSchema(BaseModel):
                 )
                 justification_text = (
                     f"\n*Justification*: {self.data.justification}" if self.data.justification else ""
+                )
+                triage_summary_text = (
+                    f"\n*Triage Reasoning*: {self.data.triage_summary.strip()}"
+                    if self.data.triage_summary and self.data.triage_summary.strip()
+                    else ""
                 )
                 dep_text = (
                     f"\n*Dependency Issue*: {self.data.dependency_issue}"
@@ -467,6 +514,7 @@ class TriageOutputSchema(BaseModel):
                     f"{resolution}"
                     f"*Package*: {self.data.package}"
                     f"{justification_text}"
+                    f"{triage_summary_text}"
                     f"{dep_comp_text}"
                     f"{dep_text}"
                     f"{fix_version_text}"

--- a/ymir/common/tests/unit/test_models.py
+++ b/ymir/common/tests/unit/test_models.py
@@ -384,3 +384,65 @@ def test_rebuild_data_without_justification():
     comment = result.format_for_comment()
     assert "*Justification*" not in comment
     assert "*Package*: git-lfs" in comment
+
+
+# --- triage_summary in format_for_comment ---
+
+
+def test_backport_formatting_with_triage_summary():
+    data = BackportData(
+        package="readline",
+        patch_urls=["https://example.com/patch.patch"],
+        justification="Fixes the bug in bind.c",
+        triage_summary="Investigated CVE-2024-1234. Found fix in upstream commit abc123.",
+        jira_issue="RHEL-12345",
+        cve_id="CVE-2024-1234",
+        fix_version="rhel-10.0",
+    )
+    result = TriageOutputSchema(resolution=Resolution.BACKPORT, data=data)
+    comment = result.format_for_comment()
+    assert "*Triage Reasoning*: Investigated CVE-2024-1234" in comment
+    assert "*Justification*: Fixes the bug in bind.c" in comment
+
+
+def test_rebase_formatting_with_triage_summary():
+    data = RebaseData(
+        package="httpd",
+        version="2.4.55",
+        jira_issue="RHEL-67890",
+        fix_version="rhel-9.5",
+        justification="Update to upstream version 2.4.55 to fix the issue",
+        triage_summary="Checked upstream release notes. Bug fixed in 2.4.55.",
+    )
+    result = TriageOutputSchema(resolution=Resolution.REBASE, data=data)
+    comment = result.format_for_comment()
+    assert "*Triage Reasoning*: Checked upstream release notes" in comment
+    assert "*Justification*: Update to upstream version 2.4.55" in comment
+
+
+def test_rebuild_formatting_with_triage_summary():
+    data = RebuildData(
+        package="git-lfs",
+        jira_issue="RHEL-100",
+        fix_version="rhel-9.8",
+        justification="Rebuild needed against updated dependency",
+        triage_summary="CVE is in golang standard library. Package vendors Go deps.",
+    )
+    result = TriageOutputSchema(resolution=Resolution.REBUILD, data=data)
+    comment = result.format_for_comment()
+    assert "*Triage Reasoning*: CVE is in golang standard library" in comment
+    assert "*Justification*: Rebuild needed against updated dependency" in comment
+
+
+def test_backport_formatting_without_triage_summary():
+    """Backward compat: triage_summary absent should not affect output."""
+    data = BackportData(
+        package="readline",
+        patch_urls=["https://example.com/patch.patch"],
+        justification="Fixes the bug in bind.c",
+        jira_issue="RHEL-12345",
+    )
+    result = TriageOutputSchema(resolution=Resolution.BACKPORT, data=data)
+    comment = result.format_for_comment()
+    assert "*Triage Reasoning*" not in comment
+    assert "*Justification*: Fixes the bug in bind.c" in comment


### PR DESCRIPTION
Add a triage_summary field to BackportData, RebaseData, RebuildData and their input schemas so the triage agent can communicate its reasoning and operational guidance to downstream agents and human reviewers.

- Render triage summary in Jira comments and MR descriptions
- Wrap triage details and operational logs (backporting steps, rebase status) in collapsible <details> blocks to reduce MR description noise
- Pass triage context to all three agent prompts (backport, rebase, rebuild) including the fix-build-error retry path
- Instruct the triage agent to produce triage_summary in its output
- Default to applying patches as-is unless triage explicitly says otherwise, preserving existing downstream agent behavior

Fixes: https://redhat.atlassian.net/browse/PACKIT-5026
Relates: https://redhat.atlassian.net/browse/PACKIT-5044

Assisted-by: Claude Opus 4.6
