### PR TITLE
Ignore xorg-x11-server(-Xwayland) in the fetcher

### DIFF
--- a/openshift/configmap-jira-issue-fetcher-env.yml
+++ b/openshift/configmap-jira-issue-fetcher-env.yml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  IGNORED_COMPONENTS: "firefox,thunderbird,firefox-flatpak-container,thunderbird-flatpak-container,webkit2gtk3,openjdk,postfix"
+  IGNORED_COMPONENTS: "firefox,thunderbird,firefox-flatpak-container,thunderbird-flatpak-container,webkit2gtk3,openjdk,postfix,xorg-x11-server,xorg-x11-server-Xwayland"
   MAX_ISSUES: "20"
   LOGLEVEL: "INFO"
 immutable: false


### PR DESCRIPTION
Add `xorg-x11-server` and `xorg-x11-server-Xwayland` to `IGNORED_COMPONENTS` so the fetcher skips them.

These ship **multi-CVE "various flaws" trackers** (one Jira issue covering many CVEs — e.g. [RHEL-182445](https://issues.redhat.com/browse/RHEL-182445) lists 9: CVE-2026-50256 … 50264). The pipeline can't handle a single tracker with many distinct fixes without backport consolidation (PACKIT-5060 / PACKIT-5045), so triaging/backporting them produces incorrect MRs. Skipping at fetch time avoids that until consolidation lands.

`IGNORED_COMPONENTS` matching is exact (lowercased set intersection), so both component names are listed explicitly. Other `xorg-x11-server-*` subpackages are not covered.

Relates: https://redhat.atlassian.net/browse/PACKIT-5092

🤖 Generated with [Claude Code](https://claude.com/claude-code)