### PR TITLE
Prioritize ymir_todo tasks via a separate priority queue

### DIFF
--- a/jira_label_workflow_routing.md
+++ b/jira_label_workflow_routing.md
@@ -99,7 +99,8 @@ flowchart TD
 
 | Queue | Type | Triggers | Labels Added | Status |
 |-------|------|----------|--------------|--------|
-| `triage_queue` | Input | No labels OR `ymir_retry_needed` OR `ymir_todo` | `ymir_triage_in_progress` (set by fetcher atomic flip for retry/todo, or by agent at triage start for fresh issues) | Active |
+| `triage_queue` | Input | No labels OR `ymir_retry_needed` | `ymir_triage_in_progress` (set by fetcher atomic flip for retry/todo, or by agent at triage start for fresh issues) | Active |
+| `triage_queue_todo` | Input (priority) | `ymir_todo` | Same as `triage_queue`. The triage agent BRPOPs `[triage_queue_todo, triage_queue]`, so ymir_todo tasks jump ahead of fresh/retry tasks. | Active |
 | `rebase_queue_c9s` | Input | Resolution=REBASE, RHEL 8/9 | `ymir_triaged_rebase` | Active (AUTO_CHAIN only) |
 | `rebase_queue_c10s` | Input | Resolution=REBASE, RHEL 10+ | `ymir_triaged_rebase` | Active (AUTO_CHAIN only) |
 | `backport_queue_c9s` | Input | Resolution=BACKPORT, RHEL 8/9 | `ymir_triaged_backport` | Active (AUTO_CHAIN only) |
@@ -170,4 +171,4 @@ JQL no longer restricts `ymir_todo` by assignee — the fetcher instead verifies
 
 ---
 
-**Last Updated:** 2026-06-04
+**Last Updated:** 2026-06-10

--- a/jira_label_workflow_routing.md
+++ b/jira_label_workflow_routing.md
@@ -102,7 +102,9 @@ flowchart TD
 | `triage_queue` | Input | No labels OR `ymir_retry_needed` | `ymir_triage_in_progress` (set by fetcher atomic flip for retry/todo, or by agent at triage start for fresh issues) | Active |
 | `triage_queue_todo` | Input (priority) | `ymir_todo` | Same as `triage_queue`. The triage agent BRPOPs `[triage_queue_todo, triage_queue]`, so ymir_todo tasks jump ahead of fresh/retry tasks. | Active |
 | `rebase_queue_c9s` | Input | Resolution=REBASE, RHEL 8/9 | `ymir_triaged_rebase` | Active (AUTO_CHAIN only) |
+| `rebase_queue_c9s_todo` | Input (priority) | Resolution=REBASE, RHEL 8/9 (ymir_todo) | Same as `rebase_queue_c9s`. The rebase agent BRPOPs `[rebase_queue_c9s_todo, rebase_queue_c9s]`. | Active (AUTO_CHAIN only) |
 | `rebase_queue_c10s` | Input | Resolution=REBASE, RHEL 10+ | `ymir_triaged_rebase` | Active (AUTO_CHAIN only) |
+| `rebase_queue_c10s_todo` | Input (priority) | Resolution=REBASE, RHEL 10+ (ymir_todo) | Same as `rebase_queue_c10s`. The rebase agent BRPOPs `[rebase_queue_c10s_todo, rebase_queue_c10s]`. | Active (AUTO_CHAIN only) |
 | `backport_queue_c9s` | Input | Resolution=BACKPORT, RHEL 8/9 | `ymir_triaged_backport` | Active (AUTO_CHAIN only) |
 | `backport_queue_c10s` | Input | Resolution=BACKPORT, RHEL 10+ | `ymir_triaged_backport` | Active (AUTO_CHAIN only) |
 | `rebase_queue` | Input | (Not actively enqueued) | `ymir_triaged_rebase` | Legacy (checked for deduplication) |

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -9,4 +9,11 @@ run-jira-issue-fetcher-todo:
 	oc delete job jira-issue-fetcher-todo-manual || true
 	oc create job jira-issue-fetcher-todo-manual --from=cronjob/jira-issue-fetcher-todo
 
-.PHONY: deploy run-jira-issue-fetcher run-jira-issue-fetcher-todo
+show-triage-queue:
+	@echo "=== triage_queue_todo (ymir_todo, priority — popped first) ==="
+	@oc exec deployment/valkey -- valkey-cli LRANGE triage_queue_todo 0 -1 | jq -r .metadata.issue | tac
+	@echo
+	@echo "=== triage_queue (normal) ==="
+	@oc exec deployment/valkey -- valkey-cli LRANGE triage_queue 0 -1 | jq -r .metadata.issue | tac
+
+.PHONY: deploy run-jira-issue-fetcher run-jira-issue-fetcher-todo show-triage-queue

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -818,13 +818,18 @@ async def main() -> None:
             if container_version == "c9s"
             else RedisQueues.BACKPORT_QUEUE_C10S.value
         )
+        # Priority twin: ymir_todo-triggered tasks are served before normal ones.
+        backport_queue_todo = RedisQueues.priority_twin(backport_queue)
         redis_logger.info(
-            f"Connected to Redis, max retries set to {max_retries}, listening to queue: {backport_queue}"
+            f"Connected to Redis, max retries set to {max_retries}, "
+            f"listening to queues: [{backport_queue_todo}, {backport_queue}]"
         )
 
         while True:
-            redis_logger.info(f"Waiting for tasks from {backport_queue} (timeout: 30s)...")
-            element = await fix_await(redis.brpop([backport_queue], timeout=30))
+            redis_logger.info(
+                f"Waiting for tasks from [{backport_queue_todo}, {backport_queue}] (timeout: 30s)..."
+            )
+            element = await fix_await(redis.brpop([backport_queue_todo, backport_queue], timeout=30))
             if element is None:
                 redis_logger.info("No tasks received, continuing to wait...")
                 continue
@@ -851,7 +856,8 @@ async def main() -> None:
                         f"Task failed (attempt {task.attempts}/{max_retries}), "
                         f"re-queuing for retry: {backport_data.jira_issue}"
                     )
-                    await fix_await(redis.lpush(backport_queue, task.model_dump_json()))
+                    retry_queue = backport_queue_todo if task.user_triggered else backport_queue
+                    await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
                     logger.error(
                         f"Task failed after {max_retries} attempts, "

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -437,13 +437,18 @@ async def main() -> None:
             if container_version == "c9s"
             else RedisQueues.REBASE_QUEUE_C10S.value
         )
+        # Priority twin: ymir_todo-triggered tasks are served before normal ones.
+        rebase_queue_todo = RedisQueues.priority_twin(rebase_queue)
         redis_logger.info(
-            f"Connected to Redis, max retries set to {max_retries}, listening to queue: {rebase_queue}"
+            f"Connected to Redis, max retries set to {max_retries}, "
+            f"listening to queues: [{rebase_queue_todo}, {rebase_queue}]"
         )
 
         while True:
-            redis_logger.info(f"Waiting for tasks from {rebase_queue} (timeout: 30s)...")
-            element = await fix_await(redis.brpop([rebase_queue], timeout=30))
+            redis_logger.info(
+                f"Waiting for tasks from [{rebase_queue_todo}, {rebase_queue}] (timeout: 30s)..."
+            )
+            element = await fix_await(redis.brpop([rebase_queue_todo, rebase_queue], timeout=30))
             if element is None:
                 redis_logger.info("No tasks received, continuing to wait...")
                 continue
@@ -470,7 +475,8 @@ async def main() -> None:
                         f"Task failed (attempt {task.attempts}/{max_retries}), "
                         f"re-queuing for retry: {rebase_data.jira_issue}"
                     )
-                    await fix_await(redis.lpush(rebase_queue, task.model_dump_json()))
+                    retry_queue = rebase_queue_todo if task.user_triggered else rebase_queue
+                    await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
                     logger.error(
                         f"Task failed after {max_retries} attempts, "

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -340,13 +340,18 @@ async def main() -> None:
             if container_version == "c9s"
             else RedisQueues.REBUILD_QUEUE_C10S.value
         )
+        # Priority twin: ymir_todo-triggered tasks are served before normal ones.
+        rebuild_queue_todo = RedisQueues.priority_twin(rebuild_queue)
         redis_logger.info(
-            f"Connected to Redis, max retries set to {max_retries}, listening to queue: {rebuild_queue}"
+            f"Connected to Redis, max retries set to {max_retries}, "
+            f"listening to queues: [{rebuild_queue_todo}, {rebuild_queue}]"
         )
 
         while True:
-            redis_logger.info(f"Waiting for tasks from {rebuild_queue} (timeout: 30s)...")
-            element = await fix_await(redis.brpop([rebuild_queue], timeout=30))
+            redis_logger.info(
+                f"Waiting for tasks from [{rebuild_queue_todo}, {rebuild_queue}] (timeout: 30s)..."
+            )
+            element = await fix_await(redis.brpop([rebuild_queue_todo, rebuild_queue], timeout=30))
             if element is None:
                 redis_logger.info("No tasks received, continuing to wait...")
                 continue
@@ -386,7 +391,8 @@ async def main() -> None:
                         f"Task failed (attempt {task.attempts}/{max_retries}), "
                         f"re-queuing for retry: {rebuild_data.jira_issue}"
                     )
-                    await fix_await(redis.lpush(rebuild_queue, task.model_dump_json()))
+                    retry_queue = rebuild_queue_todo if task.user_triggered else rebuild_queue
+                    await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
                     logger.error(
                         f"Task failed after {max_retries} attempts, "

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -913,8 +913,18 @@ async def main() -> None:
         redis_logger.info(f"Connected to Redis, max retries set to {max_retries}")
 
         while True:
-            redis_logger.info("Waiting for tasks from triage_queue (timeout: 30s)...")
-            element = await fix_await(redis.brpop([RedisQueues.TRIAGE_QUEUE.value], timeout=30))
+            redis_logger.info(
+                "Waiting for tasks from triage_queue_todo (priority) and triage_queue (timeout: 30s)..."
+            )
+            # Multi-key BRPOP serves the first non-empty list in order, so
+            # ymir_todo-triggered tasks (TRIAGE_QUEUE_TODO) jump ahead of
+            # normal-flow tasks (TRIAGE_QUEUE).
+            element = await fix_await(
+                redis.brpop(
+                    [RedisQueues.TRIAGE_QUEUE_TODO.value, RedisQueues.TRIAGE_QUEUE.value],
+                    timeout=30,
+                )
+            )
             if element is None:
                 redis_logger.info("No tasks received, continuing to wait...")
                 continue
@@ -963,7 +973,17 @@ async def main() -> None:
                         f"Task failed (attempt {task.attempts}/{max_retries}), "
                         f"re-queuing for retry: {input.issue}"
                     )
-                    await fix_await(redis.lpush(RedisQueues.TRIAGE_QUEUE.value, task.model_dump_json()))
+                    # Preserve priority on retries: ymir_todo tasks go back to
+                    # the priority queue, normal tasks to the standard one.
+                    # Read from `task.user_triggered` (not the closure-captured
+                    # variable) so we're robust to anything that might rebind
+                    # the local in a future refactor.
+                    retry_queue = (
+                        RedisQueues.TRIAGE_QUEUE_TODO.value
+                        if task.user_triggered
+                        else RedisQueues.TRIAGE_QUEUE.value
+                    )
+                    await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
                     logger.error(
                         f"Task failed after {max_retries} attempts, moving to error list: {input.issue}"

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1141,11 +1141,17 @@ async def main() -> None:
                             task = Task(metadata=state.model_dump(), user_triggered=user_triggered)
                             payload = task.model_dump_json()
                             if output.resolution == Resolution.REBASE:
-                                queue = RedisQueues.get_rebase_queue_for_branch(state.target_branch)
+                                queue = RedisQueues.get_rebase_queue_for_branch(
+                                    state.target_branch, user_triggered
+                                )
                             elif output.resolution == Resolution.BACKPORT:
-                                queue = RedisQueues.get_backport_queue_for_branch(state.target_branch)
+                                queue = RedisQueues.get_backport_queue_for_branch(
+                                    state.target_branch, user_triggered
+                                )
                             elif output.resolution == Resolution.REBUILD:
-                                queue = RedisQueues.get_rebuild_queue_for_branch(state.target_branch)
+                                queue = RedisQueues.get_rebuild_queue_for_branch(
+                                    state.target_branch, user_triggered
+                                )
                             else:
                                 queue = RedisQueues.CLARIFICATION_NEEDED_QUEUE.value
                         await fix_await(redis.lpush(queue, payload))

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1142,15 +1142,15 @@ async def main() -> None:
                             payload = task.model_dump_json()
                             if output.resolution == Resolution.REBASE:
                                 queue = RedisQueues.get_rebase_queue_for_branch(
-                                    state.target_branch, user_triggered
+                                    state.target_branch, task.user_triggered
                                 )
                             elif output.resolution == Resolution.BACKPORT:
                                 queue = RedisQueues.get_backport_queue_for_branch(
-                                    state.target_branch, user_triggered
+                                    state.target_branch, task.user_triggered
                                 )
                             elif output.resolution == Resolution.REBUILD:
                                 queue = RedisQueues.get_rebuild_queue_for_branch(
-                                    state.target_branch, user_triggered
+                                    state.target_branch, task.user_triggered
                                 )
                             else:
                                 queue = RedisQueues.CLARIFICATION_NEEDED_QUEUE.value

--- a/ymir/common/constants.py
+++ b/ymir/common/constants.py
@@ -19,6 +19,10 @@ class RedisQueues(Enum):
     """Constants for Redis queue names used by Ymir agents"""
 
     TRIAGE_QUEUE = "triage_queue"
+    # Priority twin of TRIAGE_QUEUE for ymir_todo-triggered tasks. The triage
+    # agent BRPOPs from [TRIAGE_QUEUE_TODO, TRIAGE_QUEUE] so Redis serves the
+    # priority queue first whenever it has anything.
+    TRIAGE_QUEUE_TODO = "triage_queue_todo"
     REBASE_QUEUE_C9S = "rebase_queue_c9s"
     REBASE_QUEUE_C10S = "rebase_queue_c10s"
     BACKPORT_QUEUE_C9S = "backport_queue_c9s"
@@ -45,6 +49,7 @@ class RedisQueues(Enum):
         """Return input queue names that contain Task objects with metadata"""
         return {
             cls.TRIAGE_QUEUE.value,
+            cls.TRIAGE_QUEUE_TODO.value,
             cls.REBASE_QUEUE_C9S.value,
             cls.REBASE_QUEUE_C10S.value,
             cls.BACKPORT_QUEUE_C9S.value,

--- a/ymir/common/constants.py
+++ b/ymir/common/constants.py
@@ -27,6 +27,13 @@ class RedisQueues(Enum):
     REBASE_QUEUE_C10S = "rebase_queue_c10s"
     BACKPORT_QUEUE_C9S = "backport_queue_c9s"
     BACKPORT_QUEUE_C10S = "backport_queue_c10s"
+    # Priority twins of the downstream queues for ymir_todo-triggered tasks. Each
+    # downstream agent BRPOPs from [<queue>_todo, <queue>] so Redis serves the
+    # priority queue first whenever it has anything.
+    REBASE_QUEUE_C9S_TODO = "rebase_queue_c9s_todo"
+    REBASE_QUEUE_C10S_TODO = "rebase_queue_c10s_todo"
+    BACKPORT_QUEUE_C9S_TODO = "backport_queue_c9s_todo"
+    BACKPORT_QUEUE_C10S_TODO = "backport_queue_c10s_todo"
     CLARIFICATION_NEEDED_QUEUE = "clarification_needed_queue"
     ERROR_LIST = "error_list"
     OPEN_ENDED_ANALYSIS_LIST = "open_ended_analysis_list"
@@ -34,6 +41,8 @@ class RedisQueues(Enum):
     COMPLETED_BACKPORT_LIST = "completed_backport_list"
     REBUILD_QUEUE_C9S = "rebuild_queue_c9s"
     REBUILD_QUEUE_C10S = "rebuild_queue_c10s"
+    REBUILD_QUEUE_C9S_TODO = "rebuild_queue_c9s_todo"
+    REBUILD_QUEUE_C10S_TODO = "rebuild_queue_c10s_todo"
     COMPLETED_REBUILD_LIST = "completed_rebuild_list"
     REBASE_QUEUE = "rebase_queue"
     BACKPORT_QUEUE = "backport_queue"
@@ -56,6 +65,12 @@ class RedisQueues(Enum):
             cls.BACKPORT_QUEUE_C10S.value,
             cls.REBUILD_QUEUE_C9S.value,
             cls.REBUILD_QUEUE_C10S.value,
+            cls.REBASE_QUEUE_C9S_TODO.value,
+            cls.REBASE_QUEUE_C10S_TODO.value,
+            cls.BACKPORT_QUEUE_C9S_TODO.value,
+            cls.BACKPORT_QUEUE_C10S_TODO.value,
+            cls.REBUILD_QUEUE_C9S_TODO.value,
+            cls.REBUILD_QUEUE_C10S_TODO.value,
             cls.CLARIFICATION_NEEDED_QUEUE.value,
             cls.REBASE_QUEUE.value,
             cls.BACKPORT_QUEUE.value,
@@ -74,25 +89,39 @@ class RedisQueues(Enum):
         }
 
     @classmethod
-    def get_rebase_queue_for_branch(cls, target_branch: str | None) -> str:
-        """Return appropriate rebase queue based on target branch"""
-        if target_branch and cls._use_c9s_branch(target_branch):
-            return cls.REBASE_QUEUE_C9S.value
-        return cls.REBASE_QUEUE_C10S.value
+    def priority_twin(cls, queue: str) -> str:
+        """Return the priority (_todo) twin for an input queue (ymir_todo tasks)."""
+        return f"{queue}_todo"
 
     @classmethod
-    def get_backport_queue_for_branch(cls, target_branch: str | None) -> str:
-        """Return appropriate backport queue based on target branch"""
-        if target_branch and cls._use_c9s_branch(target_branch):
-            return cls.BACKPORT_QUEUE_C9S.value
-        return cls.BACKPORT_QUEUE_C10S.value
+    def get_rebase_queue_for_branch(cls, target_branch: str | None, user_triggered: bool = False) -> str:
+        """Return rebase queue for the branch; the priority twin if user-triggered."""
+        base = (
+            cls.REBASE_QUEUE_C9S.value
+            if target_branch and cls._use_c9s_branch(target_branch)
+            else cls.REBASE_QUEUE_C10S.value
+        )
+        return cls.priority_twin(base) if user_triggered else base
 
     @classmethod
-    def get_rebuild_queue_for_branch(cls, target_branch: str | None) -> str:
-        """Return appropriate rebuild queue based on target branch"""
-        if target_branch and cls._use_c9s_branch(target_branch):
-            return cls.REBUILD_QUEUE_C9S.value
-        return cls.REBUILD_QUEUE_C10S.value
+    def get_backport_queue_for_branch(cls, target_branch: str | None, user_triggered: bool = False) -> str:
+        """Return backport queue for the branch; the priority twin if user-triggered."""
+        base = (
+            cls.BACKPORT_QUEUE_C9S.value
+            if target_branch and cls._use_c9s_branch(target_branch)
+            else cls.BACKPORT_QUEUE_C10S.value
+        )
+        return cls.priority_twin(base) if user_triggered else base
+
+    @classmethod
+    def get_rebuild_queue_for_branch(cls, target_branch: str | None, user_triggered: bool = False) -> str:
+        """Return rebuild queue for the branch; the priority twin if user-triggered."""
+        base = (
+            cls.REBUILD_QUEUE_C9S.value
+            if target_branch and cls._use_c9s_branch(target_branch)
+            else cls.REBUILD_QUEUE_C10S.value
+        )
+        return cls.priority_twin(base) if user_triggered else base
 
     @classmethod
     def _use_c9s_branch(cls, branch: str) -> bool:

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -340,7 +340,10 @@ class JiraIssueFetcher:
                                 task = Task.model_validate_json(item)
                                 if task.metadata:
                                     match queue_name:
-                                        case RedisQueues.TRIAGE_QUEUE.value:
+                                        case (
+                                            RedisQueues.TRIAGE_QUEUE.value
+                                            | RedisQueues.TRIAGE_QUEUE_TODO.value
+                                        ):
                                             schema = TriageInputSchema.model_validate(task.metadata)
                                             issue_key = schema.issue.upper()
                                         case (
@@ -573,13 +576,20 @@ class JiraIssueFetcher:
                     # Create task using shared Pydantic model
                     task = Task.from_issue(issue_key, user_triggered=user_triggered)
 
-                    await fix_await(redis_conn.lpush(RedisQueues.TRIAGE_QUEUE.value, task.to_json()))
+                    # ymir_todo-triggered tasks go to the priority queue so the
+                    # triage agent pops them before normal-flow tasks.
+                    target_queue = (
+                        RedisQueues.TRIAGE_QUEUE_TODO.value
+                        if user_triggered
+                        else RedisQueues.TRIAGE_QUEUE.value
+                    )
+                    await fix_await(redis_conn.lpush(target_queue, task.to_json()))
                     pushed_count += 1
 
                     # Add to existing_keys to avoid duplicates within this batch
                     existing_keys.add(issue_key)
 
-                    logger.debug(f"Pushed issue {issue_key} to triage_queue")
+                    logger.debug(f"Pushed issue {issue_key} to {target_queue}")
 
                 except Exception as e:
                     logger.error(f"Error pushing issue {issue.get('key', 'unknown')} to queue: {e}")

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -351,6 +351,14 @@ class JiraIssueFetcher:
                                             | RedisQueues.REBASE_QUEUE_C10S.value
                                             | RedisQueues.BACKPORT_QUEUE_C9S.value
                                             | RedisQueues.BACKPORT_QUEUE_C10S.value
+                                            | RedisQueues.REBUILD_QUEUE_C9S.value
+                                            | RedisQueues.REBUILD_QUEUE_C10S.value
+                                            | RedisQueues.REBASE_QUEUE_C9S_TODO.value
+                                            | RedisQueues.REBASE_QUEUE_C10S_TODO.value
+                                            | RedisQueues.BACKPORT_QUEUE_C9S_TODO.value
+                                            | RedisQueues.BACKPORT_QUEUE_C10S_TODO.value
+                                            | RedisQueues.REBUILD_QUEUE_C9S_TODO.value
+                                            | RedisQueues.REBUILD_QUEUE_C10S_TODO.value
                                             | RedisQueues.CLARIFICATION_NEEDED_QUEUE.value
                                             | RedisQueues.BACKPORT_QUEUE.value
                                             | RedisQueues.REBASE_QUEUE.value

--- a/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -217,28 +217,22 @@ async def test_get_existing_issue_keys(fetcher, mock_redis_context):
     )
 
     mock_redis, _ = mock_redis_context
-    mock_redis.should_receive("lrange").with_args(RedisQueues.TRIAGE_QUEUE.value, 0, -1).and_return(
-        create_async_mock_return_value([triage_task_json])
-    )
-    mock_redis.should_receive("lrange").with_args(RedisQueues.TRIAGE_QUEUE_TODO.value, 0, -1).and_return(
-        create_async_mock_return_value([todo_task_json])
-    )
-
-    # Mock other queues as empty
-    for queue in [
-        RedisQueues.REBASE_QUEUE_C9S.value,
-        RedisQueues.REBASE_QUEUE_C10S.value,
-        RedisQueues.BACKPORT_QUEUE_C9S.value,
-        RedisQueues.BACKPORT_QUEUE_C10S.value,
-        RedisQueues.CLARIFICATION_NEEDED_QUEUE.value,
-        RedisQueues.ERROR_LIST.value,
-        RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value,
-        RedisQueues.COMPLETED_REBASE_LIST.value,
-        RedisQueues.COMPLETED_BACKPORT_LIST.value,
-    ]:
-        mock_redis.should_receive("lrange").with_args(queue, 0, -1).and_return(
-            create_async_mock_return_value([])
-        )
+    # Dynamically mock every queue so the test stays robust against future
+    # additions to RedisQueues. The two triage queues return seeded tasks;
+    # everything else is empty.
+    for queue in RedisQueues.all_queues():
+        if queue == RedisQueues.TRIAGE_QUEUE.value:
+            mock_redis.should_receive("lrange").with_args(queue, 0, -1).and_return(
+                create_async_mock_return_value([triage_task_json])
+            )
+        elif queue == RedisQueues.TRIAGE_QUEUE_TODO.value:
+            mock_redis.should_receive("lrange").with_args(queue, 0, -1).and_return(
+                create_async_mock_return_value([todo_task_json])
+            )
+        else:
+            mock_redis.should_receive("lrange").with_args(queue, 0, -1).and_return(
+                create_async_mock_return_value([])
+            )
 
     result = await fetcher._get_existing_issue_keys(mock_redis)
 
@@ -717,16 +711,8 @@ async def test_run_full_workflow_with_labeled_issues(fetcher, mock_redis_context
         create_async_mock_return_value([existing_issues["ISSUE-2"]])
     )
 
-    mock_redis.should_receive("lrange").with_args(RedisQueues.REBASE_QUEUE_C10S.value, 0, -1).and_return(
-        create_async_mock_return_value([])
-    )
-
     mock_redis.should_receive("lrange").with_args(RedisQueues.BACKPORT_QUEUE_C9S.value, 0, -1).and_return(
         create_async_mock_return_value([existing_issues["ISSUE-3"]])
-    )
-
-    mock_redis.should_receive("lrange").with_args(RedisQueues.BACKPORT_QUEUE_C10S.value, 0, -1).and_return(
-        create_async_mock_return_value([])
     )
 
     mock_redis.should_receive("lrange").with_args(
@@ -737,16 +723,20 @@ async def test_run_full_workflow_with_labeled_issues(fetcher, mock_redis_context
         create_async_mock_return_value([existing_issues["ISSUE-6"]])
     )
 
-    # Mock other queues as empty to avoid flexmock errors
-    mock_redis.should_receive("lrange").with_args(RedisQueues.TRIAGE_QUEUE.value, 0, -1).and_return(
-        create_async_mock_return_value([])
-    )
-    mock_redis.should_receive("lrange").with_args(RedisQueues.COMPLETED_REBASE_LIST.value, 0, -1).and_return(
-        create_async_mock_return_value([])
-    )
-    mock_redis.should_receive("lrange").with_args(
-        RedisQueues.COMPLETED_BACKPORT_LIST.value, 0, -1
-    ).and_return(create_async_mock_return_value([]))
+    # Mock every other queue as empty so the test stays robust against
+    # future additions to RedisQueues (e.g. the _todo and rebuild queues).
+    seeded_queues = {
+        RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value,
+        RedisQueues.REBASE_QUEUE_C9S.value,
+        RedisQueues.BACKPORT_QUEUE_C9S.value,
+        RedisQueues.CLARIFICATION_NEEDED_QUEUE.value,
+        RedisQueues.ERROR_LIST.value,
+    }
+    for queue in RedisQueues.all_queues():
+        if queue not in seeded_queues:
+            mock_redis.should_receive("lrange").with_args(queue, 0, -1).and_return(
+                create_async_mock_return_value([])
+            )
 
     # ISSUE-4 has ymir_retry_needed → atomic label flip before enqueue.
     flexmock(fetcher).should_receive("_edit_jira_labels").with_args(

--- a/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -204,15 +204,24 @@ async def test_search_issues_multiple_pages(fetcher):
 
 @pytest.mark.asyncio
 async def test_get_existing_issue_keys(fetcher, mock_redis_context):
-    """Test getting existing issue keys from Redis queues."""
-    # Mock the Task and schema imports
+    """Test getting existing issue keys from Redis queues.
+
+    Both triage_queue and triage_queue_todo must contribute to the
+    dedup set — otherwise priority-queue items would be invisible and
+    the fetcher would re-push them on every sweep.
+    """
     # Create actual Task and TriageInputSchema instances
-    task_data = {"metadata": {"issue": "EXISTING-1"}, "attempts": 0}
-    task_json = json.dumps(task_data)
+    triage_task_json = json.dumps({"metadata": {"issue": "EXISTING-1"}, "attempts": 0})
+    todo_task_json = json.dumps(
+        {"metadata": {"issue": "EXISTING-TODO-1"}, "attempts": 0, "user_triggered": True}
+    )
 
     mock_redis, _ = mock_redis_context
     mock_redis.should_receive("lrange").with_args(RedisQueues.TRIAGE_QUEUE.value, 0, -1).and_return(
-        create_async_mock_return_value([task_json])
+        create_async_mock_return_value([triage_task_json])
+    )
+    mock_redis.should_receive("lrange").with_args(RedisQueues.TRIAGE_QUEUE_TODO.value, 0, -1).and_return(
+        create_async_mock_return_value([todo_task_json])
     )
 
     # Mock other queues as empty
@@ -234,6 +243,7 @@ async def test_get_existing_issue_keys(fetcher, mock_redis_context):
     result = await fetcher._get_existing_issue_keys(mock_redis)
 
     assert "EXISTING-1" in result
+    assert "EXISTING-TODO-1" in result
 
 
 @pytest.mark.asyncio
@@ -531,20 +541,28 @@ async def test_retry_needed_skip_when_label_flip_fails(fetcher, mock_redis_conte
 
 
 @pytest.mark.parametrize(
-    ("trigger_label", "user_triggered", "issue_key"),
+    ("trigger_label", "user_triggered", "issue_key", "expected_queue"),
     [
-        (JiraLabels.TODO.value, True, "TODO-DRY"),
-        (JiraLabels.RETRY_NEEDED.value, False, "RETRY-DRY"),
+        (JiraLabels.TODO.value, True, "TODO-DRY", RedisQueues.TRIAGE_QUEUE_TODO.value),
+        (JiraLabels.RETRY_NEEDED.value, False, "RETRY-DRY", RedisQueues.TRIAGE_QUEUE.value),
     ],
 )
 @pytest.mark.asyncio
 async def test_dry_run_skips_flip_but_still_pushes(
-    monkeypatch, mock_env_vars, mock_redis_context, trigger_label, user_triggered, issue_key
+    monkeypatch,
+    mock_env_vars,
+    mock_redis_context,
+    trigger_label,
+    user_triggered,
+    issue_key,
+    expected_queue,
 ):
     """DRY_RUN=true: skip the Jira atomic flip for trigger labels, but still push to Redis.
 
     The pushed Task preserves user_triggered so the agent (also presumably in
-    DRY_RUN) sees the same dry-mode flow as it would for a real trigger.
+    DRY_RUN) sees the same dry-mode flow as it would for a real trigger. The
+    queue selection still respects priority: ymir_todo tasks go to
+    triage_queue_todo, retry/normal tasks to triage_queue.
     """
     monkeypatch.setenv("DRY_RUN", "true")
     fetcher = JiraIssueFetcher()
@@ -562,9 +580,9 @@ async def test_dry_run_skips_flip_but_still_pushes(
     flexmock(fetcher).should_receive("_edit_jira_labels").never()
 
     expected_task = Task.from_issue(issue_key, user_triggered=user_triggered)
-    mock_redis.should_receive("lpush").with_args(
-        RedisQueues.TRIAGE_QUEUE.value, expected_task.to_json()
-    ).and_return(create_async_mock_return_value(1)).once()
+    mock_redis.should_receive("lpush").with_args(expected_queue, expected_task.to_json()).and_return(
+        create_async_mock_return_value(1)
+    ).once()
 
     result = await fetcher.push_issues_to_queue(issues)
 
@@ -757,6 +775,55 @@ async def test_run_full_workflow_with_labeled_issues(fetcher, mock_redis_context
     await fetcher.run()
 
 
+@pytest.mark.parametrize(
+    ("labels", "user_triggered", "expected_queue", "label_to_remove"),
+    [
+        # Fresh issue with no labels → normal queue
+        ([], False, RedisQueues.TRIAGE_QUEUE.value, None),
+        # ymir_todo trigger → priority queue
+        ([JiraLabels.TODO.value], True, RedisQueues.TRIAGE_QUEUE_TODO.value, JiraLabels.TODO.value),
+        # ymir_retry_needed trigger → normal queue (not priority)
+        (
+            [JiraLabels.RETRY_NEEDED.value],
+            False,
+            RedisQueues.TRIAGE_QUEUE.value,
+            JiraLabels.RETRY_NEEDED.value,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_push_routes_to_priority_queue_for_user_triggered(
+    fetcher, mock_redis_context, labels, user_triggered, expected_queue, label_to_remove
+):
+    """Queue routing: ymir_todo → triage_queue_todo (priority); others → triage_queue."""
+    mock_redis, _ = mock_redis_context
+    issue_key = "ROUTE-1"
+
+    issues = [{"key": issue_key, "fields": {"labels": labels}}]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+    flexmock(fetcher).should_receive("_label_added_by_rh_employee").and_return(True)
+    if label_to_remove:
+        flexmock(fetcher).should_receive("_edit_jira_labels").with_args(
+            issue_key,
+            add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+            remove=[label_to_remove],
+        ).once()
+    else:
+        flexmock(fetcher).should_receive("_edit_jira_labels").never()
+
+    expected_task = Task.from_issue(issue_key, user_triggered=user_triggered)
+    mock_redis.should_receive("lpush").with_args(expected_queue, expected_task.to_json()).and_return(
+        create_async_mock_return_value(1)
+    ).once()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 1
+
+
 @pytest.mark.asyncio
 async def test_push_user_triggered_issue(fetcher, mock_redis_context):
     """ymir_todo on an otherwise clean issue: enqueue as user_triggered, flip the label."""
@@ -780,8 +847,10 @@ async def test_push_user_triggered_issue(fetcher, mock_redis_context):
     ).once()
 
     expected_task = Task.from_issue("TODO-1", user_triggered=True)
+    # ymir_todo-triggered tasks go to the priority queue so they jump ahead of
+    # normal-flow tasks in the triage agent's BRPOP order.
     mock_redis.should_receive("lpush").with_args(
-        RedisQueues.TRIAGE_QUEUE.value, expected_task.to_json()
+        RedisQueues.TRIAGE_QUEUE_TODO.value, expected_task.to_json()
     ).and_return(create_async_mock_return_value(1)).once()
 
     result = await fetcher.push_issues_to_queue(issues)


### PR DESCRIPTION
Make `ymir_todo` (maintainer-triggered) runs jump ahead of normal-flow tasks at every stage via Redis priority "twin" queues. The triage agent and each downstream agent (rebase/backport/rebuild) `BRPOP [<queue>_todo, <queue>]`, so Redis serves the priority list first; the `user_triggered` bit is propagated end-to-end so a single `ymir_todo` stays prioritized through triage and its downstream backport/rebase/rebuild, and `retry()` re-queues to the priority twin too.

The fetcher routes user-triggered tasks to the `_todo` queues and recognizes them in its existing-issue dedup (`input_queues()` plus `_get_existing_issue_keys`, which now also covers the rebuild queues that were previously unhandled). `make show-triage-queue` shows both queues and `jira_label_workflow_routing.md` documents the behavior.

Priority is strict argument-order — a sustained `ymir_todo` stream on a branch is served before normal-flow tasks there, which is fine in practice (downstream queues are typically short); a fairness cap can be added later if a backlog ever forms.