### PR TITLE
Implement retries in get_patch_from_url tool when 503 is encountered

### DIFF
--- a/ymir/tools/constants.py
+++ b/ymir/tools/constants.py
@@ -1,4 +1,7 @@
 import aiohttp
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=30)
+AIOHTTP_RETRYABLE_STATUS_CODES = frozenset({503})
+AIOHTTP_MAX_RETRIES = 3
+AIOHTTP_RETRY_BACKOFF_BASE = 2  # seconds; delay = base * 2^attempt
 YMIR_USER_AGENT = "redhat-ymir-agent"

--- a/ymir/tools/http.py
+++ b/ymir/tools/http.py
@@ -1,0 +1,53 @@
+import asyncio
+import logging
+import random
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import aiohttp
+
+from ymir.tools.constants import (
+    AIOHTTP_MAX_RETRIES,
+    AIOHTTP_RETRY_BACKOFF_BASE,
+    AIOHTTP_RETRYABLE_STATUS_CODES,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def aiohttp_get_with_retries(
+    session: aiohttp.ClientSession,
+    url: str,
+    **kwargs,
+) -> AsyncIterator[aiohttp.ClientResponse]:
+    """Drop-in replacement for ``session.get()`` that retries on transient HTTP errors.
+
+    Retries up to ``AIOHTTP_MAX_RETRIES`` times on status codes listed in
+    ``AIOHTTP_RETRYABLE_STATUS_CODES`` using exponential back-off.  Raises
+    ``aiohttp.ClientResponseError`` when all retries are exhausted.
+    """
+    for attempt in range(AIOHTTP_MAX_RETRIES):
+        async with session.get(url, **kwargs) as response:
+            if response.status not in AIOHTTP_RETRYABLE_STATUS_CODES:
+                yield response
+                return
+            if attempt >= AIOHTTP_MAX_RETRIES - 1:
+                raise aiohttp.ClientResponseError(
+                    response.request_info,
+                    response.history,
+                    status=response.status,
+                    message=f"after {AIOHTTP_MAX_RETRIES} retries",
+                )
+            retry_status = response.status
+        # Response context is closed here — sleep without holding the connection
+        delay = AIOHTTP_RETRY_BACKOFF_BASE * (2**attempt) + random.uniform(0, 1)  # noqa: S311
+        logger.warning(
+            "Transient HTTP %d on %s, retrying in %.1fs (attempt %d/%d)",
+            retry_status,
+            url,
+            delay,
+            attempt + 1,
+            AIOHTTP_MAX_RETRIES,
+        )
+        await asyncio.sleep(delay)

--- a/ymir/tools/privileged/aiohttp_client_session_mock.py
+++ b/ymir/tools/privileged/aiohttp_client_session_mock.py
@@ -81,25 +81,27 @@ class aiohttpClientSessionMock:
     async def get(self, *args, **kwargs):
         if match_data := self.issue_get_regex.fullmatch(args[0]):
             yield flexmock(
+                status=200,
                 raise_for_status=lambda: None,
                 json=partial(_read_jira_mock, issue_key=match_data.group(1), remote_link=False),
             )
         elif match_data := self.remote_link_get_regex.fullmatch(args[0]):
             yield flexmock(
+                status=200,
                 raise_for_status=lambda: None,
                 json=partial(_read_jira_mock, issue_key=match_data.group(1)),
                 remote_link=True,
             )
         elif match_data := self.transitions_get_regex.fullmatch(args[0]):
-            yield flexmock(raise_for_status=lambda: None, json=_get_transitions)
+            yield flexmock(status=200, raise_for_status=lambda: None, json=_get_transitions)
         elif match_data := self.user_get_regex.fullmatch(args[0]):
             if (
                 kwargs["params"].get("key") == "verified_user"
                 or kwargs["params"].get("accountId") == "verified_user"
             ):
-                yield flexmock(raise_for_status=lambda: None, json=_get_verified_user)
+                yield flexmock(status=200, raise_for_status=lambda: None, json=_get_verified_user)
             else:
-                yield flexmock(raise_for_status=lambda: None, json=_get_unverified_user)
+                yield flexmock(status=200, raise_for_status=lambda: None, json=_get_unverified_user)
         else:
             raise NotImplementedError()
 

--- a/ymir/tools/privileged/copr.py
+++ b/ymir/tools/privileged/copr.py
@@ -24,6 +24,7 @@ from ymir.common.base_utils import KerberosError, init_kerberos_ticket
 from ymir.common.validators import AbsolutePath
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
+from ymir.tools.http import aiohttp_get_with_retries
 
 COPR_CONFIG = {
     "copr_url": "https://copr.devel.redhat.com",
@@ -310,7 +311,7 @@ class DownloadArtifactsTool(Tool[DownloadArtifactsToolInput, ToolRunOptions, Str
             for url in artifacts_urls:
                 logger.info(f"Downloading build artifact from: {url}")
                 try:
-                    async with session.get(url) as response:
+                    async with aiohttp_get_with_retries(session, url) as response:
                         if response.status < 400:
                             target = Path(Path(urlparse(url).path).name)
                             content = await response.read()
@@ -323,6 +324,8 @@ class DownloadArtifactsTool(Tool[DownloadArtifactsToolInput, ToolRunOptions, Str
                             (target_path / target).write_bytes(content)
                         else:
                             raise ToolError(f"Failed to download {url}: {response.status} {response.reason}")
+                except aiohttp.ClientError as e:
+                    raise ToolError(f"Failed to download {url}: {e}") from e
                 except TimeoutError as e:
                     raise ToolError(f"Failed to download {url}: timed out") from e
         return StringToolOutput(result="Successfully downloaded the specified build artifacts")

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -34,6 +34,7 @@ from ymir.common.models import (
 from ymir.common.validators import AbsolutePath
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
+from ymir.tools.http import aiohttp_get_with_retries
 from ymir.tools.privileged.utils import clean_stale_repositories
 
 logger = logging.getLogger(__name__)
@@ -973,10 +974,15 @@ class GetPatchFromUrlTool(Tool[GetPatchFromUrlToolInput, ToolRunOptions, StringT
         try:
             async with (
                 aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session,
-                session.get(request_url, headers=headers) as response,
+                aiohttp_get_with_retries(session, request_url, headers=headers) as response,
             ):
                 if response.status >= 400:
-                    raise ToolError(f"Failed to fetch patch from {patch_url}: HTTP {response.status}")
+                    # We return Error string instead of ToolError, because status >= 400
+                    # on for example badly formatted URL is not a tool error and
+                    # should not be flagged
+                    return StringToolOutput(
+                        result=f"Error: Failed to fetch patch from {patch_url}: HTTP {response.status}"
+                    )
                 text = await response.text()
         except aiohttp.ClientError as e:
             raise ToolError(f"Failed to fetch patch from {patch_url}: {e}") from e
@@ -1030,7 +1036,8 @@ class FetchGitlabMrNotesTool(Tool[FetchGitlabMrNotesInput, ToolRunOptions, Strin
         try:
             async with (
                 aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session,
-                session.get(
+                aiohttp_get_with_retries(
+                    session,
                     url,
                     headers=headers,
                     params={
@@ -1066,6 +1073,10 @@ class FetchGitlabMrNotesTool(Tool[FetchGitlabMrNotesInput, ToolRunOptions, Strin
 
             return StringToolOutput(result=json.dumps(result, indent=2))
 
+        except aiohttp.ClientError as e:
+            # Here we handle ClientError as ToolError, because client error
+            # signals networking issues which should be flagged (DNS resolution failure, timeouts etc)
+            raise ToolError(f"Failed to fetch MR notes for !{input.mr_iid} in {input.project}: {e}") from e
         except Exception as e:
             logger.error("Error fetching GitLab MR notes: %s", e)
             return StringToolOutput(result=f"Error fetching GitLab MR notes: {e}")
@@ -1124,7 +1135,7 @@ class SearchGitlabProjectMrsTool(
         try:
             async with (
                 aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session,
-                session.get(url, headers=headers, params=params) as response,
+                aiohttp_get_with_retries(session, url, headers=headers, params=params) as response,
             ):
                 response.raise_for_status()
                 data = await response.json()

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -23,6 +23,7 @@ from ymir.common.constants import JIRA_SEARCH_PATH
 from ymir.common.version_utils import get_fix_version_variants, normalize_fix_version
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT
+from ymir.tools.http import aiohttp_get_with_retries
 
 if os.getenv("MOCK_JIRA", "False").lower() == "true":
     from ymir.tools.privileged.aiohttp_client_session_mock import (
@@ -92,7 +93,8 @@ class GetJiraDetailsTool(Tool[GetJiraDetailsToolInput, ToolRunOptions, JSONToolO
 
         async with aiohttpClientSession(timeout=AIOHTTP_TIMEOUT) as session:
             try:
-                async with session.get(
+                async with aiohttp_get_with_retries(
+                    session,
                     jira_url,
                     params={"expand": "comments"},
                     headers=headers,
@@ -103,7 +105,8 @@ class GetJiraDetailsTool(Tool[GetJiraDetailsToolInput, ToolRunOptions, JSONToolO
                 raise ToolError(f"Failed to get details about the specified issue: {e}") from e
 
             try:
-                async with session.get(
+                async with aiohttp_get_with_retries(
+                    session,
                     urljoin(
                         os.getenv("JIRA_URL"),
                         f"rest/api/3/issue/{issue_key}/remotelink",
@@ -171,7 +174,8 @@ class SetJiraFieldsTool(Tool[SetJiraFieldsToolInput, ToolRunOptions, StringToolO
             jira_url = urljoin(os.getenv("JIRA_URL"), f"rest/api/3/issue/{issue_key}")
             logger.info(f"Connecting to JIRA API to set fields for issue: {jira_url}")
             try:
-                async with session.get(
+                async with aiohttp_get_with_retries(
+                    session,
                     jira_url,
                     headers=get_jira_auth_headers(),
                 ) as response:
@@ -419,7 +423,8 @@ class CheckCveTriageEligibilityTool(
 
         async with aiohttpClientSession(timeout=AIOHTTP_TIMEOUT) as session:
             try:
-                async with session.get(
+                async with aiohttp_get_with_retries(
+                    session,
                     jira_url,
                     headers=headers,
                 ) as response:
@@ -647,7 +652,8 @@ class ChangeJiraStatusTool(Tool[ChangeJiraStatusToolInput, ToolRunOptions, Strin
 
         async with aiohttpClientSession(timeout=AIOHTTP_TIMEOUT) as session:
             try:
-                async with session.get(
+                async with aiohttp_get_with_retries(
+                    session,
                     urljoin(os.getenv("JIRA_URL"), f"rest/api/3/issue/{issue_key}"),
                     params={"fields": "status"},
                     headers=headers,
@@ -666,7 +672,7 @@ class ChangeJiraStatusTool(Tool[ChangeJiraStatusToolInput, ToolRunOptions, Strin
                 pass
 
             try:
-                async with session.get(jira_url, headers=headers) as resp:
+                async with aiohttp_get_with_retries(session, jira_url, headers=headers) as resp:
                     resp.raise_for_status()
                     transitions = (await resp.json()).get("transitions", [])
             except aiohttp.ClientError as e:
@@ -794,7 +800,8 @@ class VerifyIssueAuthorTool(Tool[VerifyIssueAuthorToolInput, ToolRunOptions, JSO
 
         async with aiohttpClientSession(timeout=AIOHTTP_TIMEOUT) as session:
             try:
-                async with session.get(
+                async with aiohttp_get_with_retries(
+                    session,
                     jira_url,
                     headers=headers,
                 ) as response:
@@ -818,7 +825,8 @@ class VerifyIssueAuthorTool(Tool[VerifyIssueAuthorToolInput, ToolRunOptions, JSO
                 params["key"] = author_key
 
             try:
-                async with session.get(
+                async with aiohttp_get_with_retries(
+                    session,
                     urljoin(os.getenv("JIRA_URL"), "rest/api/3/user"),
                     params=params,
                     headers=headers,
@@ -926,7 +934,9 @@ async def _fetch_dev_status_details(
     *summary_category* (e.g. ``"repository"`` or ``"pullrequest"``)."""
     issue_url = urljoin(jira_base, f"rest/api/3/issue/{issue_key}")
     try:
-        async with session.get(issue_url, params={"fields": ""}, headers=headers) as response:
+        async with aiohttp_get_with_retries(
+            session, issue_url, params={"fields": ""}, headers=headers
+        ) as response:
             response.raise_for_status()
             issue_data = await response.json()
             issue_id = issue_data["id"]
@@ -935,7 +945,7 @@ async def _fetch_dev_status_details(
 
     summary_url = urljoin(jira_base, f"rest/dev-status/1.0/issue/summary?issueId={issue_id}")
     try:
-        async with session.get(summary_url, headers=headers) as response:
+        async with aiohttp_get_with_retries(session, summary_url, headers=headers) as response:
             response.raise_for_status()
             summary_data = await response.json()
     except aiohttp.ClientError as e:
@@ -953,7 +963,7 @@ async def _fetch_dev_status_details(
             f"&applicationType={app_type}&dataType={data_type}",
         )
         try:
-            async with session.get(detail_url, headers=headers) as response:
+            async with aiohttp_get_with_retries(session, detail_url, headers=headers) as response:
                 response.raise_for_status()
                 dev_data = await response.json()
         except aiohttp.ClientError as e:
@@ -1102,7 +1112,7 @@ class SetPreliminaryTestingTool(Tool[SetPreliminaryTestingToolInput, ToolRunOpti
     async def _resolve_field_id(self, session: Any, headers: dict) -> str:
         jira_base = os.getenv("JIRA_URL")
         url = urljoin(jira_base, "rest/api/3/field")
-        async with session.get(url, headers=headers) as response:
+        async with aiohttp_get_with_retries(session, url, headers=headers) as response:
             response.raise_for_status()
             fields = await response.json()
         for field in fields:
@@ -1321,7 +1331,7 @@ class GetJiraAttachmentTool(Tool[GetJiraAttachmentToolInput, ToolRunOptions, Str
             # Get issue attachments
             issue_url = urljoin(jira_base, f"rest/api/2/issue/{issue_key}?fields=attachment")
             try:
-                async with session.get(issue_url, headers=headers) as response:
+                async with aiohttp_get_with_retries(session, issue_url, headers=headers) as response:
                     response.raise_for_status()
                     issue_data = await response.json()
             except aiohttp.ClientError as e:
@@ -1337,7 +1347,7 @@ class GetJiraAttachmentTool(Tool[GetJiraAttachmentToolInput, ToolRunOptions, Str
 
             content_url = matching[0]["content"]
             try:
-                async with session.get(content_url, headers=headers) as response:
+                async with aiohttp_get_with_retries(session, content_url, headers=headers) as response:
                     response.raise_for_status()
                     content = await response.read()
             except aiohttp.ClientError as e:

--- a/ymir/tools/privileged/maintainer_rules.py
+++ b/ymir/tools/privileged/maintainer_rules.py
@@ -9,6 +9,7 @@ from beeai_framework.tools import StringToolOutput, Tool, ToolError, ToolRunOpti
 from pydantic import BaseModel, Field
 
 from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
+from ymir.tools.http import aiohttp_get_with_retries
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +61,7 @@ class MaintainerRulesTool(Tool[MaintainerRulesInput, ToolRunOptions, StringToolO
         try:
             async with (
                 aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session,
-                session.get(url, headers=headers) as response,
+                aiohttp_get_with_retries(session, url, headers=headers) as response,
             ):
                 if response.status == 200:
                     return StringToolOutput(result=await response.text())

--- a/ymir/tools/privileged/tests/unit/test_http.py
+++ b/ymir/tools/privileged/tests/unit/test_http.py
@@ -1,0 +1,135 @@
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import aiohttp
+import pytest
+from flexmock import flexmock
+
+from ymir.tools.http import aiohttp_get_with_retries
+
+
+def _mock_response(status=200, **kwargs):
+    return flexmock(
+        status=status,
+        request_info=flexmock(),
+        history=(),
+        **kwargs,
+    )
+
+
+def _make_session(responses):
+    """Create a mock session whose .get() yields *responses* in order."""
+    call_count = 0
+
+    @asynccontextmanager
+    async def fake_get(url, **kwargs):
+        nonlocal call_count
+        resp = responses[call_count]
+        call_count += 1
+        yield resp
+
+    session = flexmock(get=fake_get)
+    return session, lambda: call_count
+
+
+@pytest.mark.asyncio
+@patch("ymir.tools.http.asyncio.sleep", return_value=None)
+async def test_success_no_retry(mock_sleep):
+    session, get_count = _make_session([_mock_response(200)])
+
+    async with aiohttp_get_with_retries(session, "http://example.com") as resp:
+        assert resp.status == 200
+
+    assert get_count() == 1
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("ymir.tools.http.asyncio.sleep", return_value=None)
+async def test_non_retryable_error_passes_through(mock_sleep):
+    session, get_count = _make_session([_mock_response(404)])
+
+    async with aiohttp_get_with_retries(session, "http://example.com") as resp:
+        assert resp.status == 404
+
+    assert get_count() == 1
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("ymir.tools.http.asyncio.sleep", return_value=None)
+async def test_retries_on_503_then_succeeds(mock_sleep):
+    session, get_count = _make_session(
+        [
+            _mock_response(503),
+            _mock_response(200),
+        ]
+    )
+
+    async with aiohttp_get_with_retries(session, "http://example.com") as resp:
+        assert resp.status == 200
+
+    assert get_count() == 2
+    mock_sleep.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("ymir.tools.http.asyncio.sleep", return_value=None)
+async def test_exhausted_retries_raises(mock_sleep):
+    session, get_count = _make_session(
+        [
+            _mock_response(503),
+            _mock_response(503),
+            _mock_response(503),
+        ]
+    )
+
+    with pytest.raises(aiohttp.ClientResponseError) as exc_info:
+        async with aiohttp_get_with_retries(session, "http://example.com"):
+            pass
+
+    assert exc_info.value.status == 503
+    assert "after 3 retries" in exc_info.value.message
+    assert get_count() == 3
+    assert mock_sleep.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch("ymir.tools.http.random.uniform", return_value=0.5)
+@patch("ymir.tools.http.asyncio.sleep", return_value=None)
+async def test_backoff_delays_increase(mock_sleep, mock_uniform):
+    session, _ = _make_session(
+        [
+            _mock_response(503),
+            _mock_response(503),
+            _mock_response(503),
+        ]
+    )
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        async with aiohttp_get_with_retries(session, "http://example.com"):
+            pass
+
+    delays = [call.args[0] for call in mock_sleep.call_args_list]
+    assert delays == [2.5, 4.5]  # base=2: 2*1+0.5, 2*2+0.5
+
+
+@pytest.mark.asyncio
+@patch("ymir.tools.http.asyncio.sleep", return_value=None)
+async def test_kwargs_forwarded_to_session_get(mock_sleep):
+    captured_kwargs = {}
+
+    @asynccontextmanager
+    async def fake_get(url, **kwargs):
+        captured_kwargs.update(kwargs)
+        yield _mock_response(200)
+
+    session = flexmock(get=fake_get)
+
+    async with aiohttp_get_with_retries(
+        session, "http://example.com", headers={"X-Test": "1"}, params={"q": "search"}
+    ) as resp:
+        assert resp.status == 200
+
+    assert captured_kwargs["headers"] == {"X-Test": "1"}
+    assert captured_kwargs["params"] == {"q": "search"}

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -75,13 +75,13 @@ async def test_get_jira_details():
             async def json():
                 return issue_data
 
-            yield flexmock(json=json, raise_for_status=lambda: None)
+            yield flexmock(status=200, json=json, raise_for_status=lambda: None)
         elif url.endswith(f"rest/api/3/issue/{issue_key}/remotelink"):
 
             async def json():
                 return remote_links_data
 
-            yield flexmock(json=json, raise_for_status=lambda: None)
+            yield flexmock(status=200, json=json, raise_for_status=lambda: None)
         else:
             raise AssertionError(f"Unexpected URL: {url}")
 
@@ -138,7 +138,7 @@ async def test_set_jira_fields(args, current_fields, expected_fields):
             async def json():
                 return current_fields
 
-            yield flexmock(json=json, raise_for_status=lambda: None)
+            yield flexmock(status=200, json=json, raise_for_status=lambda: None)
         else:
             raise AssertionError(f"Unexpected URL: {url}")
 
@@ -220,13 +220,13 @@ async def test_change_jira_status(transitions, status, expected_transition_id):
             async def json():
                 return current_status_data
 
-            yield flexmock(json=json, raise_for_status=lambda: None)
+            yield flexmock(status=200, json=json, raise_for_status=lambda: None)
         elif url.endswith(f"rest/api/3/issue/{issue_key}/transitions"):
 
             async def json():
                 return {"transitions": transitions}
 
-            yield flexmock(json=json, raise_for_status=lambda: None)
+            yield flexmock(status=200, json=json, raise_for_status=lambda: None)
         else:
             raise AssertionError(f"Unexpected URL: {url}")
 
@@ -338,7 +338,7 @@ async def test_verify_issue_author(user_groups, expected_result, use_account_id)
             async def json():
                 return issue_data
 
-            yield flexmock(json=json, raise_for_status=lambda: None)
+            yield flexmock(status=200, json=json, raise_for_status=lambda: None)
         elif url.endswith("rest/api/3/user"):
             assert params.get(expected_param_key) == expected_param_value
             assert params.get("expand") == "groups"
@@ -346,7 +346,7 @@ async def test_verify_issue_author(user_groups, expected_result, use_account_id)
             async def json():
                 return user_data
 
-            yield flexmock(json=json, raise_for_status=lambda: None)
+            yield flexmock(status=200, json=json, raise_for_status=lambda: None)
         else:
             raise AssertionError(f"Unexpected URL: {url}")
 
@@ -634,7 +634,7 @@ def _mock_jira_get(issue_data):
         async def json():
             return issue_data
 
-        yield flexmock(json=json, raise_for_status=lambda: None)
+        yield flexmock(status=200, json=json, raise_for_status=lambda: None)
 
     return get
 

--- a/ymir/tools/pyproject.toml
+++ b/ymir/tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-tools"
-version = "0.5.1"
+version = "0.5.2"
 description = "Ymir MCP tools for AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]
@@ -36,4 +36,5 @@ packages = []
 "privileged" = "ymir/tools/privileged"
 "unprivileged" = "ymir/tools/unprivileged"
 "constants.py" = "ymir/tools/constants.py"
+"http.py" = "ymir/tools/http.py"
 "base.py" = "ymir/tools/base.py"

--- a/ymir/tools/unprivileged/greenwave.py
+++ b/ymir/tools/unprivileged/greenwave.py
@@ -5,11 +5,12 @@ from urllib.parse import urlparse
 import aiohttp
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
-from beeai_framework.tools import StringToolOutput, ToolRunOptions
+from beeai_framework.tools import StringToolOutput, ToolError, ToolRunOptions
 from pydantic import BaseModel, Field
 
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
+from ymir.tools.http import aiohttp_get_with_retries
 
 TESTING_FARM_ARTIFACTS_URL = "https://artifacts.osci.redhat.com/testing-farm"
 
@@ -57,7 +58,7 @@ class FetchGreenWaveTool(Tool[FetchGreenWaveInput, ToolRunOptions, StringToolOut
                 aiohttp.ClientSession(
                     timeout=AIOHTTP_TIMEOUT, headers={"User-Agent": YMIR_USER_AGENT}
                 ) as session,
-                session.get(url) as response,
+                aiohttp_get_with_retries(session, url) as response,
             ):
                 if response.status == 200:
                     html = await response.text()
@@ -71,6 +72,10 @@ class FetchGreenWaveTool(Tool[FetchGreenWaveInput, ToolRunOptions, StringToolOut
                 return StringToolOutput(
                     result=f"Failed to fetch GreenWave gating status (HTTP {response.status}): {text}"
                 )
+        except aiohttp.ClientError as e:
+            # Here we handle ClientError as ToolError, because it signals
+            # networking issues. Error statuses are handled above by StringToolOutput
+            raise ToolError(f"Failed to fetch GreenWave gating status: {e}") from e
         except Exception as e:
             logger.error("Error fetching GreenWave gating status: %s", e)
             return StringToolOutput(result=f"Error fetching GreenWave gating status: {e}")
@@ -136,7 +141,7 @@ class FetchTestingFarmResultsTool(Tool[FetchTestingFarmResultsInput, ToolRunOpti
             for url in urls_to_try:
                 logger.info("Fetching Testing Farm results from %s", url)
                 try:
-                    async with session.get(url) as response:
+                    async with aiohttp_get_with_retries(session, url) as response:
                         if response.status == 200:
                             # Limit reading to 10MB to prevent OOM on large files
                             content_bytes = await response.content.read(10 * 1024 * 1024)

--- a/ymir/tools/unprivileged/read_logfile.py
+++ b/ymir/tools/unprivileged/read_logfile.py
@@ -3,8 +3,10 @@ import logging
 import aiohttp
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
-from beeai_framework.tools import StringToolOutput, Tool, ToolRunOptions
+from beeai_framework.tools import StringToolOutput, Tool, ToolError, ToolRunOptions
 from pydantic import BaseModel, Field
+
+from ymir.tools.http import aiohttp_get_with_retries
 
 logger = logging.getLogger(__name__)
 
@@ -31,10 +33,16 @@ class ReadLogfileTool(Tool[ReadLogfileInput, ToolRunOptions, StringToolOutput]):
         context: RunContext,
     ) -> StringToolOutput:
         logger.info("Reading logfile from URL: %s", input.logfile_url)
-        async with aiohttp.ClientSession() as session, session.get(input.logfile_url) as response:
-            if response.status == 200:
-                return StringToolOutput(
-                    result=await response.text(),
-                )
+        try:
+            async with (
+                aiohttp.ClientSession() as session,
+                aiohttp_get_with_retries(session, input.logfile_url) as response,
+            ):
+                if response.status == 200:
+                    return StringToolOutput(
+                        result=await response.text(),
+                    )
+        except aiohttp.ClientError as e:
+            raise ToolError(f"Failed to read logfile from {input.logfile_url}: {e}") from e
 
         return StringToolOutput(result=f"Failed to read logfile from {input.logfile_url}")

--- a/ymir/tools/unprivileged/read_readme.py
+++ b/ymir/tools/unprivileged/read_readme.py
@@ -7,6 +7,7 @@ from beeai_framework.tools import StringToolOutput, Tool, ToolRunOptions
 from pydantic import BaseModel, Field
 
 from ymir.tools.constants import YMIR_USER_AGENT
+from ymir.tools.http import aiohttp_get_with_retries
 
 logger = logging.getLogger(__name__)
 
@@ -45,10 +46,13 @@ class ReadReadmeTool(Tool[ReadReadmeInput, ToolRunOptions, StringToolOutput]):
             for prefix, suffix in README_PATTERNS:
                 if input.repo_url.startswith(prefix):
                     url = input.repo_url.removesuffix("/") + suffix
-                    async with session.get(url) as response:
-                        if response.status == 200:
-                            return StringToolOutput(
-                                result=await response.text(),
-                            )
+                    try:
+                        async with aiohttp_get_with_retries(session, url) as response:
+                            if response.status == 200:
+                                return StringToolOutput(
+                                    result=await response.text(),
+                                )
+                    except aiohttp.ClientError:
+                        pass
 
         return StringToolOutput(result=f"Failed to find README.md for {input.repo_url}")

--- a/ymir/tools/unprivileged/search_resultsdb.py
+++ b/ymir/tools/unprivileged/search_resultsdb.py
@@ -10,6 +10,7 @@ from beeai_framework.tools import Tool, ToolError, ToolOutput, ToolRunOptions
 from pydantic import BaseModel, Field
 
 from ymir.tools.constants import YMIR_USER_AGENT
+from ymir.tools.http import aiohttp_get_with_retries
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ async def search_resultsdb(package_nvr: str, name_pattern: str) -> list[ResultsD
     logger.info("Fetching resultsdb data from %s", url)
     async with (
         aiohttp.ClientSession(headers={"User-Agent": YMIR_USER_AGENT}) as session,
-        session.get(url) as response,
+        aiohttp_get_with_retries(session, url) as response,
     ):
         if response.status == 200:
             response_json = await response.json()

--- a/ymir/tools/unprivileged/upstream_search.py
+++ b/ymir/tools/unprivileged/upstream_search.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT
+from ymir.tools.http import aiohttp_get_with_retries
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,8 @@ class UpstreamSearchTool(Tool[UpstreamSearchToolInput, ToolRunOptions, UpstreamS
             repos = []
             commits = []
             async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
-                async with session.get(
+                async with aiohttp_get_with_retries(
+                    session,
                     f"{os.environ['UPSTREAM_SEARCH_API_URL']}/find_repository",
                     params={"name": tool_input.project},
                 ) as response:

--- a/ymir/tools/unprivileged/upstream_tools.py
+++ b/ymir/tools/unprivileged/upstream_tools.py
@@ -18,6 +18,7 @@ from ymir.common.base_utils import run_subprocess
 from ymir.common.validators import AbsolutePath
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
+from ymir.tools.http import aiohttp_get_with_retries
 
 
 class ExtractUpstreamRepositoryInput(BaseModel):
@@ -123,7 +124,7 @@ class ExtractUpstreamRepositoryTool(
                 try:
                     async with (
                         aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session,
-                        session.get(api_url, headers=headers) as response,
+                        aiohttp_get_with_retries(session, api_url, headers=headers) as response,
                     ):
                         response.raise_for_status()
                         data = await response.json()
@@ -180,7 +181,9 @@ class ExtractUpstreamRepositoryTool(
                                 f"https://api.github.com/repos/{project_path}/compare/"
                                 f"{quote(base_ref, safe='')}...{quote(target_ref, safe='')}"
                             )
-                            async with session.get(api_url, headers=headers) as response:
+                            async with aiohttp_get_with_retries(
+                                session, api_url, headers=headers
+                            ) as response:
                                 response.raise_for_status()
                                 data = await response.json()
                                 # GitHub: commits are in 'commits' array (oldest first)
@@ -192,7 +195,9 @@ class ExtractUpstreamRepositoryTool(
                                 f"{quote(project_path, safe='')}/repository/compare"
                             )
                             params = {"from": base_ref, "to": target_ref}
-                            async with session.get(api_url, params=params, headers=headers) as response:
+                            async with aiohttp_get_with_retries(
+                                session, api_url, params=params, headers=headers
+                            ) as response:
                                 response.raise_for_status()
                                 data = await response.json()
                                 # GitLab: commits are in 'commits' array (newest first)


### PR DESCRIPTION
Github is starting to throttle our requests, thus we can add token in the future but still should be able to retry when this happens.
