### PR TITLE
Upgrade container images from Fedora 42 to Fedora 43, switch to Python 3.13 venv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,18 +10,20 @@ only need to clone it once; the tests run entirely offline against the local cop
 
 1. Clone the testing-jiras repository somewhere on your machine.
 
-2. Add `JIRA_MOCK_FILES_HOST` to your local `.env` pointing at its `jiras/` directory:
+2. Add these variables to your local `.env` pointing at the testing-jiras checkout:
    ```
    JIRA_MOCK_FILES_HOST=/path/to/testing-jiras/jiras
+   MOCK_REPOS_HOST=/path/to/testing-jiras/mock_data
    ```
-   This makes compose mount that directory into the `mcp-gateway` container at the path
-   where mock Jira files are expected.
+   `JIRA_MOCK_FILES_HOST` mounts mock Jira issue data into the `mcp-gateway` container.
+   `MOCK_REPOS_HOST` mounts mock git repo fixtures into the E2E test containers.
 
-3. Symlink the mock repo fixtures for git operations:
-   ```bash
-   ln -s /path/to/testing-jiras/mock_data/triage ymir/agents/tests/e2e/mock_repos/triage
-   ln -s /path/to/testing-jiras/mock_data/backport ymir/agents/tests/e2e/mock_repos/backport
-   ```
+3. Add `GITLAB_TOKEN` to both `.env` and `.secrets/beeai-agent.env` with a GitLab
+   personal access token that has read access to `gitlab.com/redhat`. It must be in
+   `.env` so the compose `${GITLAB_TOKEN:-}` substitution resolves correctly (otherwise
+   the empty `environment:` value overrides `env_file`). The mock repo setup clones
+   from GitLab to create pre-fix-state bare repos; without it you'll be prompted for
+   credentials.
 
 ### Running
 

--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -31,6 +31,7 @@ RUN dnf -y install --allowerasing \
       rpmlint \
       autoconf \
       automake \
+      gettext-devel \
       libtool \
       libtool-ltdl \
       libtool-ltdl-devel \

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -32,6 +32,7 @@ RUN dnf -y install --allowerasing \
       python3.11-devel \
       autoconf \
       automake \
+      gettext-devel \
       libtool \
       libtool-ltdl \
       libtool-ltdl-devel \

--- a/Containerfile.jira-issue-fetcher
+++ b/Containerfile.jira-issue-fetcher
@@ -1,4 +1,4 @@
-FROM fedora:42
+FROM fedora:43
 
 # Install minimal system dependencies for the issue fetcher
 RUN dnf -y install \

--- a/Containerfile.mcp
+++ b/Containerfile.mcp
@@ -1,4 +1,4 @@
-FROM fedora:42
+FROM fedora:43
 
 # Install RH IT Root CAs for access to internal services
 COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/

--- a/Containerfile.mcp
+++ b/Containerfile.mcp
@@ -15,6 +15,7 @@ RUN dnf -y install \
       python3.13 \
       python3.13-devel \
       python3-rpm \
+      rpm-devel \
       krb5-libs \
       krb5-workstation \
       krb5-devel \
@@ -34,10 +35,8 @@ RUN useradd -m -G wheel mcp
 # Copy required directories
 # Individual directories are mounted as volumes in development
 COPY requirements-global.txt /home/mcp/
-COPY ymir/common/*.py ymir/common/pyproject.toml ymir/common/requirements.txt /home/mcp/ymir/common/
-COPY ymir/tools/*.py ymir/tools/pyproject.toml ymir/tools/requirements.txt /home/mcp/ymir/tools/
-COPY ymir/tools/privileged/*.py /home/mcp/ymir/tools/privileged/
-COPY ymir/tools/unprivileged/*.py /home/mcp/ymir/tools/unprivileged/
+COPY ymir/common/ /home/mcp/ymir/common/
+COPY ymir/tools/ /home/mcp/ymir/tools/
 
 # Install dependencies via pyproject.toml; litellm pinned separately to exclude compromised versions
 RUN pip install --no-cache-dir "litellm!=1.82.7,!=1.82.8" /home/mcp/ymir/common/ /home/mcp/ymir/tools/

--- a/Containerfile.mcp
+++ b/Containerfile.mcp
@@ -12,34 +12,43 @@ RUN if [ -n "$INTERNAL_REPO_URL" ]; then \
 ARG EXTRA_PACKAGES=""
 # Install system dependencies
 RUN dnf -y install \
-      python3 \
-      python3-aiofiles \
-      python3-aiohttp \
-      python3-copr \
-      python3-ogr \
-      python3-pip \
-      python3-redis \
-      python3-requests \
-      python3-GitPython \
-      python3-flexmock \
-      python3-koji \
+      python3.13 \
+      python3.13-devel \
+      python3-rpm \
       krb5-libs \
       krb5-workstation \
+      krb5-devel \
       centpkg \
       git \
+      gcc \
       ${EXTRA_PACKAGES} \
     && dnf clean all
 
-# Install beeai mcp server
-RUN pip3 install --no-cache-dir "litellm!=1.82.7,!=1.82.8" beeai-framework[mcp]==0.1.80 "specfile>=0.36.0"
+RUN python3.13 -m venv --system-site-packages /opt/beeai-venv
+ENV PATH=/opt/beeai-venv/bin:$PATH
+RUN pip install --upgrade pip
 
 # Create user
 RUN useradd -m -G wheel mcp
 
 # Copy required directories
 # Individual directories are mounted as volumes in development
-COPY ymir/tools/ /home/mcp/ymir/tools/
-COPY ymir/common/ /home/mcp/ymir/common/
+COPY requirements-global.txt /home/mcp/
+COPY ymir/common/*.py ymir/common/pyproject.toml ymir/common/requirements.txt /home/mcp/ymir/common/
+COPY ymir/tools/*.py ymir/tools/pyproject.toml ymir/tools/requirements.txt /home/mcp/ymir/tools/
+COPY ymir/tools/privileged/*.py /home/mcp/ymir/tools/privileged/
+COPY ymir/tools/unprivileged/*.py /home/mcp/ymir/tools/unprivileged/
+
+# Install dependencies via pyproject.toml; litellm pinned separately to exclude compromised versions
+RUN pip install --no-cache-dir "litellm!=1.82.7,!=1.82.8" /home/mcp/ymir/common/ /home/mcp/ymir/tools/
+
+# Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
+RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \
+    if [ -n "$MALICIOUS" ]; then \
+      echo "SECURITY ALERT: malicious litellm_init.pth detected: $MALICIOUS"; \
+      exit 1; \
+    fi
+
 COPY files/ipa_redhat_com /etc/krb5.conf.d/ipa_redhat_com
 RUN chgrp -R root /home/mcp && chmod -R g+rwX /home/mcp
 

--- a/Containerfile.mcp.containerignore
+++ b/Containerfile.mcp.containerignore
@@ -1,0 +1,2 @@
+**/tests
+**/__pycache__

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -30,6 +30,7 @@ RUN pip install --no-cache-dir \
       redis \
       backoff \
       requests \
+      requests-gssapi \
       GitPython \
       copr \
       flexmock \

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -4,23 +4,17 @@ FROM fedora:43
 RUN dnf -y install \
       gcc \
       gcc-c++ \
+      git-core \
       make \
       krb5-devel \
-      python3 \
-      python3-devel \
-      python3-copr \
-      python3-flexmock \
-      python3-koji \
-      python3-ogr \
-      python3-pip \
-      python3-pytest \
-      python3-pytest-asyncio \
-      python3-specfile \
-      python3-redis \
-      python3-requests \
-      python3-backoff \
-      python3-GitPython \
+      python3.13 \
+      python3.13-devel \
+      python3-rpm \
     && dnf clean all
+
+RUN python3.13 -m venv --system-site-packages /opt/beeai-venv
+ENV PATH=/opt/beeai-venv/bin:$PATH
+RUN pip install --upgrade pip
 
 RUN git config --global user.email "ymir-tests@example.com" \
       && git config --global user.name "Ymir Tests"
@@ -29,10 +23,21 @@ RUN git config --global user.email "ymir-tests@example.com" \
 ENV PYTHONPATH=/src:$PYTHONPATH
 
 # Install BeeAI Framework and FastMCP
-RUN pip3 install --no-cache-dir \
+RUN pip install --no-cache-dir \
       "litellm!=1.82.7,!=1.82.8" \
       beeai-framework[vertexai,mcp,duckduckgo]==0.1.79 \
-      fastmcp redis backoff
+      fastmcp \
+      redis \
+      backoff \
+      requests \
+      GitPython \
+      copr \
+      flexmock \
+      koji \
+      ogr \
+      pytest \
+      pytest-asyncio \
+      specfile
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -1,4 +1,4 @@
-FROM fedora:42
+FROM fedora:43
 
 # Install system dependencies
 RUN dnf -y install \

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -10,6 +10,7 @@ RUN dnf -y install \
       python3.13 \
       python3.13-devel \
       python3-rpm \
+      rpm-devel \
     && dnf clean all
 
 RUN python3.13 -m venv --system-site-packages /opt/beeai-venv
@@ -38,6 +39,7 @@ RUN pip install --no-cache-dir \
       ogr \
       pytest \
       pytest-asyncio \
+      rpm \
       specfile
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)

--- a/compose.yaml
+++ b/compose.yaml
@@ -202,6 +202,13 @@ services:
     <<: *beeai-agent-c10s
     environment:
       <<: *beeai-env
+      MOCK_REPOS_DIR: /home/beeai/mock_repos/triage
+    volumes:  # YAML doesn't support list concatenation
+      - ./ymir:/home/beeai/ymir:ro,z
+      - git-repos:/git-repos:rw,U
+      - .secrets/rhel-config.json:/home/beeai/rhel-config.json:ro,z,U
+      - .secrets/jotnar-vertex-dev.json:/home/beeai/jotnar-vertex-dev.json:ro,z,U
+      - ${MOCK_REPOS_HOST:-./ymir/agents/tests/e2e/mock_repos}:/home/beeai/mock_repos:ro,z
     # the option about default loop is here because of litellm issue
     # https://github.com/BerriAI/litellm/issues/14521
     command: ["pytest", "ymir/agents/tests/e2e/test_triage.py", "-o", "asyncio_default_test_loop_scope=session"]
@@ -212,6 +219,13 @@ services:
     <<: *beeai-agent-c10s
     environment:
       <<: *beeai-env
+      BACKPORT_MOCK_REPOS_DIR: /home/beeai/mock_repos/backport
+    volumes:
+      - ./ymir:/home/beeai/ymir:ro,z
+      - git-repos:/git-repos:rw,U
+      - .secrets/rhel-config.json:/home/beeai/rhel-config.json:ro,z,U
+      - .secrets/jotnar-vertex-dev.json:/home/beeai/jotnar-vertex-dev.json:ro,z,U
+      - ${MOCK_REPOS_HOST:-./ymir/agents/tests/e2e/mock_repos}:/home/beeai/mock_repos:ro,z
     command: ["pytest", "ymir/agents/tests/e2e/backport_agent/test_backport.py", "-o", "asyncio_default_test_loop_scope=session"]
     restart: "no"
     profiles: ["e2e-test"]

--- a/ymir/agents/tests/e2e/mock_repos/README.md
+++ b/ymir/agents/tests/e2e/mock_repos/README.md
@@ -4,12 +4,15 @@ This directory contains mock repo fixture files organized by agent type.
 The fixtures come from `git@gitlab.cee.redhat.com:jotnar-project/testing-jiras.git`
 if you have access.
 
-Clone the repository and symlink its `mock_data/` subdirectories here:
+Clone the repository and set `MOCK_REPOS_HOST` in your `.env`:
 
-```bash
-ln -s /path/to/testing-jiras/mock_data/triage ymir/agents/tests/e2e/mock_repos/triage
-ln -s /path/to/testing-jiras/mock_data/backport ymir/agents/tests/e2e/mock_repos/backport
 ```
+MOCK_REPOS_HOST=/path/to/testing-jiras/mock_data
+```
+
+This mounts the fixture data into E2E test containers at `/home/beeai/mock_repos/`.
+The compose services set `MOCK_REPOS_DIR` and `BACKPORT_MOCK_REPOS_DIR` to point
+at the `triage/` and `backport/` subdirectories respectively.
 
 ## Expected layout
 

--- a/ymir/tools/pyproject.toml
+++ b/ymir/tools/pyproject.toml
@@ -26,15 +26,42 @@ test = [
 
 [tool.hatch.build]
 dev-mode-dirs = ["../.."]
-
 [tool.hatch.build.targets.wheel]
 packages = []
 
 [tool.hatch.build.targets.wheel.force-include]
 "__init__.py" = "ymir/tools/__init__.py"
 "gateway_utils.py" = "ymir/tools/gateway_utils.py"
-"privileged" = "ymir/tools/privileged"
-"unprivileged" = "ymir/tools/unprivileged"
 "constants.py" = "ymir/tools/constants.py"
 "http.py" = "ymir/tools/http.py"
 "base.py" = "ymir/tools/base.py"
+"privileged/__init__.py" = "ymir/tools/privileged/__init__.py"
+"privileged/aiohttp_client_session_mock.py" = "ymir/tools/privileged/aiohttp_client_session_mock.py"
+"privileged/copr.py" = "ymir/tools/privileged/copr.py"
+"privileged/distgit.py" = "ymir/tools/privileged/distgit.py"
+"privileged/errata.py" = "ymir/tools/privileged/errata.py"
+"privileged/gateway.py" = "ymir/tools/privileged/gateway.py"
+"privileged/gitlab.py" = "ymir/tools/privileged/gitlab.py"
+"privileged/jira.py" = "ymir/tools/privileged/jira.py"
+"privileged/logdetective.py" = "ymir/tools/privileged/logdetective.py"
+"privileged/lookaside.py" = "ymir/tools/privileged/lookaside.py"
+"privileged/maintainer_rules.py" = "ymir/tools/privileged/maintainer_rules.py"
+"privileged/testing_farm.py" = "ymir/tools/privileged/testing_farm.py"
+"privileged/utils.py" = "ymir/tools/privileged/utils.py"
+"privileged/zstream_search.py" = "ymir/tools/privileged/zstream_search.py"
+"unprivileged/__init__.py" = "ymir/tools/unprivileged/__init__.py"
+"unprivileged/analyze_ewa_testrun.py" = "ymir/tools/unprivileged/analyze_ewa_testrun.py"
+"unprivileged/commands.py" = "ymir/tools/unprivileged/commands.py"
+"unprivileged/distgit_detector.py" = "ymir/tools/unprivileged/distgit_detector.py"
+"unprivileged/filesystem.py" = "ymir/tools/unprivileged/filesystem.py"
+"unprivileged/gateway.py" = "ymir/tools/unprivileged/gateway.py"
+"unprivileged/greenwave.py" = "ymir/tools/unprivileged/greenwave.py"
+"unprivileged/read_logfile.py" = "ymir/tools/unprivileged/read_logfile.py"
+"unprivileged/read_readme.py" = "ymir/tools/unprivileged/read_readme.py"
+"unprivileged/search_resultsdb.py" = "ymir/tools/unprivileged/search_resultsdb.py"
+"unprivileged/specfile.py" = "ymir/tools/unprivileged/specfile.py"
+"unprivileged/text.py" = "ymir/tools/unprivileged/text.py"
+"unprivileged/upstream_search.py" = "ymir/tools/unprivileged/upstream_search.py"
+"unprivileged/upstream_tools.py" = "ymir/tools/unprivileged/upstream_tools.py"
+"unprivileged/version_mapper.py" = "ymir/tools/unprivileged/version_mapper.py"
+"unprivileged/wicked_git.py" = "ymir/tools/unprivileged/wicked_git.py"

--- a/ymir/tools/requirements.txt
+++ b/ymir/tools/requirements.txt
@@ -5,5 +5,7 @@ copr>=1.129
 flexmock>=0.12.2
 GitPython>=3.1.0
 ogr>=0.55.0
+requests>=2.32.0
+requests-gssapi>=1.3.0
 rpm>=0.4.0
 specfile>=0.36.0


### PR DESCRIPTION
## Summary

- Bump `Containerfile.tests`, `Containerfile.mcp`, and `Containerfile.jira-issue-fetcher` from `fedora:42` to `fedora:43`
- Replace `python3`/`pip3` with Python 3.13 venv (`/opt/beeai-venv --system-site-packages`) in `tests` and `mcp` images, matching the pattern already used in `Containerfile.c9s`
- Drop `python3-*` dnf packages that install into Python 3.14 (the F43 default); install PyPI equivalents via the venv pip instead
- `Containerfile.mcp`: install from `ymir/tools/pyproject.toml` instead of an explicit package list
- Add `requests` and `requests-gssapi` to `ymir/tools/requirements.txt` (were missing, used by `privileged/testing_farm.py` and `privileged/errata.py`)
- Exclude `tests/` directories from the wheel build (`pyproject.toml`) and from the container image (targeted `COPY` using globs)
- Add `python3-rpm` (system package, accessible via `--system-site-packages`) to both images
- Add `pip install --upgrade pip` and the `litellm_init.pth` security check to both images

## Test plan

- [ ] CI builds `Containerfile.mcp` and `Containerfile.tests` successfully on Fedora 43
- [ ] `pip install` from `pyproject.toml` resolves all deps without errors
- [ ] `python3-rpm` is importable inside the venv
- [ ] litellm security check passes
- [ ] No test data lands in the final image layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)