### PR TITLE
skills: comply with agentskills.io standard, make client-generic

### DIFF
--- a/.github/workflows/check-in-container.yml
+++ b/.github/workflows/check-in-container.yml
@@ -11,6 +11,18 @@ permissions:
   contents: read
 
 jobs:
+  validate-skills:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - name: Validate agent skills
+      run: |
+        pip install skills-ref==0.1.1
+        for skill_dir in agents_as_skills/*/; do
+          agentskills validate "$skill_dir"
+        done
+
   check-in-container:
     runs-on: ubuntu-latest
     strategy:

--- a/agents_as_skills/README.md
+++ b/agents_as_skills/README.md
@@ -1,6 +1,8 @@
 # Agents as Skills
 
-This directory contains Ymir workflows packaged as **AI coding assistant skills** for [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) and [Cursor](https://www.cursor.com/). The goal is to give individual contributors an easy way to run Ymir workflows directly in their own development environment — helping them with day-to-day package maintenance tasks and potentially surfacing areas for improvement in the workflows themselves.
+This directory contains Ymir workflows packaged as **AI agent skills** compatible with any client that implements the [Agent Skills standard](https://agentskills.io/home). The goal is to give individual contributors an easy way to run Ymir workflows directly in their own development environment — helping them with day-to-day package maintenance tasks and potentially surfacing areas for improvement in the workflows themselves.
+
+Supported clients include [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview), [opencode](https://opencode.ai), [Cursor](https://www.cursor.com/), and any other [skills-compatible agent](https://agentskills.io/clients).
 
 ## Available skills
 
@@ -10,12 +12,14 @@ This directory contains Ymir workflows packaged as **AI coding assistant skills*
 | **Backport** | [`backport/`](backport/) | Cherry-pick or git-am upstream patches, verify builds, and create merge requests |
 | **Rebase** | [`rebase/`](rebase/) | Rebase a package to a new upstream version |
 | **Rebuild** | [`rebuild/`](rebuild/) | Rebuild a package in the build system |
-| **Preliminary Testing** | [`preliminary_testing/`](preliminary_testing/) | Analyze gating and OSCI results to determine preliminary testing status |
-| **Issue Verification** | [`issue_verification/`](issue_verification/) | Issue verification agent (post-fix lifecycle management) |
+| **Preliminary Testing** | [`preliminary-testing/`](preliminary-testing/) | Analyze gating and OSCI results to determine preliminary testing status |
+| **Issue Verification** | [`issue-verification/`](issue-verification/) | Post-fix lifecycle management through errata creation and testing |
+
+Each skill is a directory containing a `SKILL.md` file that follows the [Agent Skills specification](https://agentskills.io/specification).
 
 ## Installation
 
-For installation instructions (skill setup and MCP tool configuration), see the [Skills Installation Guide](https://github.com/packit/ai-workflows/blob/main/skills_installation.md).
+For per-client installation instructions (skill placement paths, MCP tool configuration), see the [Skills Installation Guide](../skills_installation.md).
 
 ## How to use
 
@@ -35,10 +39,11 @@ Set the `DRY_RUN` environment variable or add `dry_run=true` to your prompt to a
 
 ## How to build
 
+To convert a Ymir BeeAI workflow into a new skill:
+
 ```bash
-claude --model claude-opus-4-6 --effort high "Take a look at the BeeAI workflows implemented in agents directory. Convert Workflow in {workflow_file} to Claude skill and save that skill to agents_as_skills directory.
-Restrictions:
+opencode "Please take a look at the BeeAI workflows implemented in the agents directory. Please convert the workflow in {workflow_file} to an Agent Skill (https://agentskills.io/specification) and save it to agents_as_skills/. Restrictions:
  - Pay attention to tools used by the workflow and do not omit them
  - Do not restrict tools that the skill can use
- - Specify arguments the skill uses as an input"
+ - Include a name: field in the frontmatter that matches the directory name"
 ```

--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -1,33 +1,6 @@
 ---
+name: backport
 description: Backport upstream patches to packages in the RHEL ecosystem — cherry-pick or git-am workflow, build verification, changelog, and merge request creation.
-arguments:
-  - name: package
-    description: "Name of the package to backport to (e.g., 'curl')"
-    required: true
-  - name: dist_git_branch
-    description: "Dist-git branch to update (e.g., 'c10s', 'rhel-9.6.0')"
-    required: true
-  - name: upstream_patches
-    description: "Comma-separated list of upstream patch URLs to backport (commit URLs, PR/MR URLs, or .patch URLs)"
-    required: true
-  - name: jira_issue
-    description: "JIRA issue key (e.g., RHEL-12345)"
-    required: true
-  - name: cve_id
-    description: "CVE identifier if the JIRA issue is a CVE (e.g., CVE-2025-12345). Default: null"
-    required: false
-  - name: justification
-    description: "Justification text from triage explaining why this backport fixes the issue. Default: null"
-    required: false
-  - name: fix_version
-    description: "Fix version string for z-stream detection (e.g., 'rhel-9.6.0.z'). Default: null"
-    required: false
-  - name: dry_run
-    description: "If true, skip JIRA status changes, MR creation, and label updates. Default: false"
-    required: false
-  - name: max_build_attempts
-    description: "Maximum number of build retry attempts. Default: 10"
-    required: false
 ---
 
 # Backport Skill

--- a/agents_as_skills/issue-verification/SKILL.md
+++ b/agents_as_skills/issue-verification/SKILL.md
@@ -1,17 +1,8 @@
 ---
+name: issue-verification
 description: >
   Runs the Issue Verification workflow for a JIRA issue, managing the lifecycle
   from merged MR through errata creation, testing analysis, and status transitions.
-arguments:
-  - name: jira_issue
-    description: "JIRA issue key (e.g. RHEL-12345)"
-    required: true
-  - name: dry_run
-    description: "If true, skip all JIRA modifications (label changes, comments, status transitions). Default: false"
-    required: false
-  - name: ignore_needs_attention
-    description: "If true, process the issue even if it has the ymir_needs_attention label. Default: false"
-    required: false
 ---
 
 # Issue Verification Skill

--- a/agents_as_skills/preliminary-testing/SKILL.md
+++ b/agents_as_skills/preliminary-testing/SKILL.md
@@ -1,15 +1,6 @@
 ---
+name: preliminary-testing
 description: Analyze GreenWave gating and MR OSCI results for a RHEL JIRA issue to determine preliminary testing status, then update JIRA fields or flag attention accordingly.
-arguments:
-  - name: jira_issue
-    description: "JIRA issue key (e.g., RHEL-12345)"
-    required: true
-  - name: dry_run
-    description: "If true, skip JIRA updates (label changes, comments, field changes). Default: false"
-    required: false
-  - name: ignore_needs_attention
-    description: "If true, process the issue even if it has the ymir_needs_attention label. Default: false"
-    required: false
 ---
 
 # Preliminary Testing Skill

--- a/agents_as_skills/rebase/SKILL.md
+++ b/agents_as_skills/rebase/SKILL.md
@@ -1,30 +1,6 @@
 ---
+name: rebase
 description: Rebase packages to newer upstream versions in the RHEL ecosystem — version update, spec file modification, patch fixing, build verification, changelog, and merge request creation.
-arguments:
-  - name: package
-    description: "Name of the package to rebase (e.g., 'openssl')"
-    required: true
-  - name: dist_git_branch
-    description: "Dist-git branch to update (e.g., 'c10s', 'rhel-9.6.0')"
-    required: true
-  - name: version
-    description: "Target upstream version to rebase to (e.g., '2.4.1')"
-    required: true
-  - name: jira_issue
-    description: "JIRA issue key (e.g., RHEL-12345)"
-    required: true
-  - name: cve_id
-    description: "CVE identifier if the JIRA issue is a CVE (e.g., CVE-2025-12345). Default: null"
-    required: false
-  - name: justification
-    description: "Justification text from triage explaining why this rebase fixes the issue. Default: null"
-    required: false
-  - name: dry_run
-    description: "If true, skip JIRA status changes, MR creation, and label updates. Default: false"
-    required: false
-  - name: max_build_attempts
-    description: "Maximum number of build retry attempts. Default: 10"
-    required: false
 ---
 
 # Rebase Skill

--- a/agents_as_skills/rebuild/SKILL.md
+++ b/agents_as_skills/rebuild/SKILL.md
@@ -1,30 +1,6 @@
 ---
+name: rebuild
 description: Rebuild packages against updated dependencies in the RHEL ecosystem — release bump, changelog, and merge request creation with no source code changes. Supports consolidating multiple sibling Jira issues into a single rebuild MR.
-arguments:
-  - name: package
-    description: "Name of the package to rebuild (e.g., 'openssl')"
-    required: true
-  - name: dist_git_branch
-    description: "Dist-git branch to update (e.g., 'c10s', 'rhel-9.6.0')"
-    required: true
-  - name: jira_issue
-    description: "Primary JIRA issue key (e.g., RHEL-12345)"
-    required: true
-  - name: dependency_issue
-    description: "JIRA issue key of the dependency that was updated (e.g., RHEL-67890). Default: null"
-    required: false
-  - name: dependency_component
-    description: "Name of the dependency component that was updated (e.g., 'golang'). Default: null"
-    required: false
-  - name: consolidated_issues
-    description: "JSON list of sibling issues consolidated into this rebuild. Each item has 'issue_key' and optional 'dependency_component'. Example: [{\"issue_key\": \"RHEL-67890\", \"dependency_component\": \"golang\"}]. Default: []"
-    required: false
-  - name: consolidation_summary
-    description: "Summary text of the sibling consolidation analysis from triage. Default: null"
-    required: false
-  - name: dry_run
-    description: "If true, skip JIRA status changes and MR creation (commit only). Default: false"
-    required: false
 ---
 
 # Rebuild Skill

--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -1,18 +1,6 @@
 ---
+name: triage
 description: Triage Jira issues for RHEL packages — analyze bugs and CVEs to determine whether to rebase, backport a patch, rebuild, or request clarification, check CVE applicability against package source, consolidate rebuild siblings, and post the result as a Jira comment.
-arguments:
-  - name: jira_issue
-    description: "JIRA issue key to triage (e.g., RHEL-12345)"
-    required: true
-  - name: dry_run
-    description: "If true, skip JIRA comment posting and label updates. Default: false"
-    required: false
-  - name: auto_chain
-    description: "If true, omit the follow-up note in JIRA comments (indicates automated downstream processing is enabled). Default: true"
-    required: false
-  - name: force_cve_triage
-    description: "If true, force triage of CVE issues that would normally be deferred or rejected (eligibility=PENDING_DEPENDENCIES or NEVER). Default: false"
-    required: false
 ---
 
 # Triage Skill

--- a/scripts/sync-agent-skills.py
+++ b/scripts/sync-agent-skills.py
@@ -2,9 +2,9 @@
 """Pre-push hook: ensure agents_as_skills/ stays in sync with ymir/agents/.
 
 Compares the net diff of the current branch against its remote tracking branch.
-Fails the push when a *_agent.py file or its prompt templates were changed but
-the corresponding SKILL.md under agents_as_skills/ was not.  Prints the exact
-claude command the developer should run to regenerate the skill.
+Fails the push when a *_agent.py file or its prompt templates were
+changed but their corresponding SKILL.md under agents_as_skills/ was not.
+Prints the exact command the developer should run to regenerate the skill.
 
 Set SKIP_SKILL_SYNC=1 to bypass this check.
 """
@@ -19,23 +19,29 @@ AGENTS_DIR = Path("ymir/agents")
 PROMPTS_DIR = Path("ymir/agents/prompts")
 SKILLS_DIR = Path("agents_as_skills")
 
-CLAUDE_CMD_TEMPLATE = (
+REGEN_CMD_TEMPLATE = (
     "claude --model claude-opus-4-6 --effort high"
+    "  # any AI agent works; adjust command for your tool"
     ' "Please take a look at the BeeAI workflows implemented in agents'
-    " directory. Please convert Workflow in {workflow_file} to Claude skill and"
-    f" save that skill to {SKILLS_DIR} directory.\n"
+    " directory. Please convert Workflow in {workflow_file} to an Agent Skill"
+    f" (https://agentskills.io/specification) and save it to {SKILLS_DIR}/.\n"
     "Restrictions:\n"
     " - Pay attention to tools used by the workflow and do not omit them\n"
     " - Do not restrict tools that the skill can use\n"
-    ' - Specify arguments the skill uses as an input"'
+    ' - The skill name must match the directory name (lowercase, hyphens only)"'
 )
 
 
 def skill_name_for(agent_path: Path) -> str | None:
-    """Derive the skill directory name from an agent filename."""
+    """Derive the skill directory name from an agent filename.
+
+    Agent filenames use underscores (e.g. preliminary_testing_agent.py) but
+    skill directories use hyphens per the agentskills.io spec, so underscores
+    are replaced with hyphens.
+    """
     if agent_path.suffix != ".py" or not agent_path.stem.endswith("_agent"):
         return None
-    return agent_path.stem.removesuffix("_agent")
+    return agent_path.stem.removesuffix("_agent").replace("_", "-")
 
 
 def skill_name_for_prompt(prompt_path: Path) -> str | None:
@@ -122,7 +128,7 @@ def main() -> int:
     print("\nPlease regenerate the skill(s) before pushing:\n")
     for name in sorted(affected_skills):
         workflow_file = AGENTS_DIR / f"{name}_agent.py"
-        print(f"  {CLAUDE_CMD_TEMPLATE.format(workflow_file=workflow_file)}\n")
+        print(f"  {REGEN_CMD_TEMPLATE.format(workflow_file=workflow_file)}\n")
 
     print(
         "If the change does not affect the skill (e.g. comments only), bypass with:\n"

--- a/skills_installation.md
+++ b/skills_installation.md
@@ -3,75 +3,43 @@
 This guide covers two things:
 
 1. **Installing skills** from the `agents_as_skills/` directory so your AI
-   coding assistant (Claude Code or Cursor) can use them.
+   agent can use them.
 2. **Installing the MCP tools** (`ymir-common` and `ymir-tools`) that the
-   skills depend on, and configuring Claude Code to start both the
+   skills depend on, and configuring your agent to start both the
    **privileged** and **unprivileged** MCP gateways automatically.
+
+The skills follow the [Agent Skills standard](https://agentskills.io/home) and
+work with any [compatible client](https://agentskills.io/clients), including
+[Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview),
+[opencode](https://opencode.ai), and
+[Cursor](https://www.cursor.com/).
 
 ---
 
 ## Installing skills
 
-The `agents_as_skills/` directory in this repository contains ready-to-use
-skills. Each sub-directory (e.g. `backport/`, `rebase/`, `triage/`) holds a
-`SKILL.md` file that your editor picks up once it is placed in the correct
-location.
+The skills in `agents_as_skills/` follow the [Agent Skills standard](https://agentskills.io/specification)
+and work with any compatible client. Consult your client's documentation for
+where to place skill directories:
 
-### Available skills
+- **Claude Code** — [Skills documentation](https://docs.anthropic.com/en/docs/claude-code/skills)
+- **opencode** — [Skills documentation](https://opencode.ai/docs/skills/)
+- **Other clients** — see the [Agent Skills client list](https://agentskills.io/clients)
 
-| Skill | Directory | Description |
-|-------|-----------|-------------|
-| Backport | `agents_as_skills/backport/` | Cherry-pick or git-am upstream patches, verify builds, and create merge requests |
-| Rebase | `agents_as_skills/rebase/` | Rebase a package to a new upstream version |
-| Triage | `agents_as_skills/triage/` | Triage CVE/bug JIRA issues for RHEL packages |
-| Rebuild | `agents_as_skills/rebuild/` | Rebuild a package in the build system |
-| Preliminary Testing | `agents_as_skills/preliminary_testing/` | Run preliminary tests on a package |
-| Issue Verification | `agents_as_skills/issue_verification/` | Issue verification agent (post-fix lifecycle management) |
-
-### Claude Code
-
-Claude Code discovers skills from `~/.claude/skills/`. Each skill is a
-directory containing a single `SKILL.md` file. You can download them straight
-from GitHub -- no need to clone the repository:
+The skills live in `agents_as_skills/` in this repository. You can either clone
+the repo and point your client at that directory, or download individual
+`SKILL.md` files directly:
 
 ```bash
 REPO_URL="https://raw.githubusercontent.com/packit/ai-workflows/main/agents_as_skills"
+SKILLS_DIR=~/.claude/skills  # adjust to your client's skills directory
 
-# Install all skills at once
-for skill in backport rebase triage rebuild preliminary_testing; do
-  mkdir -p ~/.claude/skills/"$skill"
-  curl -fsSL "$REPO_URL/$skill/SKILL.md" -o ~/.claude/skills/"$skill"/SKILL.md
+for skill in backport rebase triage rebuild preliminary-testing issue-verification; do
+  mkdir -p "$SKILLS_DIR/$skill"
+  curl -fsSL "$REPO_URL/$skill/SKILL.md" -o "$SKILLS_DIR/$skill/SKILL.md"
 done
 ```
 
-Or install a single skill:
-
-```bash
-REPO_URL="https://raw.githubusercontent.com/packit/ai-workflows/main/agents_as_skills"
-mkdir -p ~/.claude/skills/backport
-curl -fsSL "$REPO_URL/backport/SKILL.md" -o ~/.claude/skills/backport/SKILL.md
-```
-
-After downloading, restart Claude Code (or start a new session) so that the
-skills are picked up.
-
-### Cursor
-
-Cursor discovers skills from `~/.cursor/skills-cursor/`. The same approach
-applies:
-
-```bash
-REPO_URL="https://raw.githubusercontent.com/packit/ai-workflows/main/agents_as_skills"
-
-# Install all skills at once
-for skill in backport rebase triage rebuild preliminary_testing issue_verification; do
-  mkdir -p ~/.cursor/skills-cursor/"$skill"
-  curl -fsSL "$REPO_URL/$skill/SKILL.md" -o ~/.cursor/skills-cursor/"$skill"/SKILL.md
-done
-```
-
-After downloading, restart Cursor so that the new skills appear in the skill
-list.
 
 ---
 
@@ -87,9 +55,8 @@ running. The rest of this guide covers that setup.
 | **Privileged** | `ymir.tools.privileged.gateway` | GitLab, Jira, Copr, Koji/Kerberos, lookaside cache, dist-git branching |
 | **Unprivileged** | `ymir.tools.unprivileged.gateway` | Filesystem, shell, specfile, git operations, patches, upstream search, z-stream search |
 
-Claude Code starts both servers in `stdio` mode and communicates with them
-directly. Both run as child processes managed by Claude Code and are available
-simultaneously throughout the session.
+Both gateways run as child processes (via `stdio` MCP transport) managed by
+your agent client and are available simultaneously throughout the session.
 
 ## Prerequisites
 
@@ -139,8 +106,8 @@ cp templates/rhel-config.json ./rhel-config.json
 # Edit ./rhel-config.json with actual RHEL stream data
 ```
 
-Set the working directory in the Claude Code server configuration (see below)
-to the directory that contains this file.
+Set the working directory in the MCP server configuration (see below) to the
+directory that contains this file.
 
 ## 3. Environment variables
 
@@ -148,7 +115,7 @@ to the directory that contains this file.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `MCP_TRANSPORT` | **Yes** | Set to `stdio` so Claude Code can communicate with the process. |
+| `MCP_TRANSPORT` | **Yes** | Set to `stdio` so the agent can communicate with the process. |
 | `GITLAB_TOKEN` | **Yes** | GitLab API personal access token. |
 | `JIRA_URL` | **Yes** | Base URL of the Jira instance (e.g. `https://issues.redhat.com/`). |
 | `JIRA_EMAIL` | **Yes** | Email address for Jira Basic Auth. |
@@ -166,18 +133,17 @@ to the directory that contains this file.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `MCP_TRANSPORT` | **Yes** | Set to `stdio` so Claude Code can communicate with the process. |
+| `MCP_TRANSPORT` | **Yes** | Set to `stdio` so the agent can communicate with the process. |
 | `UPSTREAM_SEARCH_API_URL` | **Yes** | Base URL of the upstream search service (provides `/find_repository` and `/find_commit` endpoints). |
 | `MCP_GATEWAY_URL` | No | SSE URL of a running privileged gateway. See the note on cross-gateway calls below. |
 | `DEBUG_FILE` | No | Path to a log file. When set, gateway logs are written to this file in addition to stderr. Useful for debugging local installations. |
 | `REQUESTS_CA_BUNDLE` | No | Path to a Certificate Authority (CA) bundle, if additional or custom ones are required for workflow services. |
 
-## 4. Configure Claude Code
+## 4. Configure your agent client
 
-Add both servers to your Claude Code MCP configuration. You can do this
-with the CLI or by editing the settings file directly.
+### Claude Code
 
-### Option A -- Using `claude mcp add`
+Add both servers using `claude mcp add`:
 
 ```bash
 VENV="$HOME/.local/share/ymir-venv"
@@ -198,12 +164,8 @@ claude mcp add ymir-unprivileged \
   -- "$VENV/bin/ymir-unprivileged-gateway"
 ```
 
-### Option B -- Editing `~/.claude.json`
-
-Add the following to the top-level `mcpServers` object:
-
-Replace `<your-home>` with the absolute path to your home directory
-(e.g. `/home/you`). The `~` shorthand is **not** expanded inside JSON values.
+Or edit `~/.claude.json` directly, adding to the top-level `mcpServers` object
+(replace `<your-home>` with the absolute path — `~` is not expanded in JSON):
 
 ```json
 {
@@ -216,9 +178,7 @@ Replace `<your-home>` with the absolute path to your home directory
         "JIRA_URL": "https://redhat.atlassian.net",
         "JIRA_EMAIL": "you@redhat.com",
         "JIRA_TOKEN": "your-jira-api-token",
-        "KRB5CCNAME": "FILE:/tmp/krb5cc_1000",
-        "LOG_DETECTIVE_URL": "https://logdetective-placeholder-server.com/",
-        "LOG_DETECTIVE_TOKEN": "your-log-detective-api-token"
+        "KRB5CCNAME": "FILE:/tmp/krb5cc_1000"
       }
     },
     "ymir-unprivileged": {
@@ -237,6 +197,40 @@ For project-scoped configuration, place the same `mcpServers` block in
 `.claude/settings.json` inside your project directory instead. If that
 does not work for you, use the `.mcp.json` at the root of your project.
 
+### opencode
+
+Add both servers to `~/.config/opencode/opencode.json` under the `mcp` key
+(replace `<your-home>` with the absolute path):
+
+```json
+{
+  "mcp": {
+    "ymir-privileged": {
+      "type": "local",
+      "command": ["<your-home>/.local/share/ymir-venv/bin/ymir-privileged-gateway"],
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "GITLAB_TOKEN": "<your-gitlab-token>",
+        "JIRA_URL": "https://redhat.atlassian.net",
+        "JIRA_EMAIL": "you@redhat.com",
+        "JIRA_TOKEN": "your-jira-api-token",
+        "KRB5CCNAME": "FILE:/tmp/krb5cc_1000"
+      }
+    },
+    "ymir-unprivileged": {
+      "type": "local",
+      "command": ["<your-home>/.local/share/ymir-venv/bin/ymir-unprivileged-gateway"],
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "UPSTREAM_SEARCH_API_URL": "http://upstream-search.hosted.upshift.rdu2.redhat.com:80/v1"
+      }
+    }
+  }
+}
+```
+
+Restart opencode after editing the config.
+
 ### Note: Kerberos keytab
 
 If you use a keytab for automated Kerberos authentication, add `KEYTAB_FILE`
@@ -246,7 +240,7 @@ to the privileged server's `env`:
 "KEYTAB_FILE": "/path/to/your.keytab"
 ```
 
-Without a keytab, you must run `kinit` manually before launching Claude Code
+Without a keytab, you must run `kinit` manually before launching your agent
 so that a valid ticket exists in the cache pointed to by `KRB5CCNAME`.
 
 If you are using `KEYRING` credential cache (used by Kerberos by default),
@@ -254,19 +248,14 @@ you do not need to set `KRB5CCNAME`. All you need is a successful `kinit`.
 
 ## 5. Verify the setup
 
-Launch Claude Code and confirm both servers are running:
-
-```
-/mcp
-```
-
-This lists all connected MCP servers and their available tools. You should see
-tools from both `ymir-privileged` and `ymir-unprivileged` servers.
+After starting your agent, confirm both MCP servers are connected. In Claude
+Code run `/mcp`; in opencode the server list appears at startup. You should
+see tools from both `ymir-privileged` and `ymir-unprivileged`.
 
 ## Network topology
 
 ```
-Claude Code
+Agent client
   |
   |-- stdio --> ymir-privileged (child process)
   |               |-- GitLab API        (GITLAB_TOKEN)


### PR DESCRIPTION
It's always a bit sad to me when FOSS projects hardcode references to just proprietary tools like Claude Code and Cursor.

I understand why this probably happened: the "skills" thing was not standardized well, but now it is! There's https://agentskills.io/home

We needed some fixes though:

- Add missing 'name:' frontmatter field to all six SKILL.md files.
- The spec requires name to be lowercase alphanumeric + hyphens, so preliminary_testing → preliminary-testing and issue_verification → issue-verification (directories renamed accordingly).
- Remove the Ymir-specific 'arguments:' frontmatter block from all skills. Cross-checking every major client confirms none of them would consume it usefully: agentskills.io/skills-ref rejects it as an unknown field; Claude Code supports 'arguments:' but only as a flat list of names mapping to $name substitutions (our YAML object structure with description/required subfields and {{name}} syntax is not what it expects); Cursor has its own extensions (paths, disable-model-invocation) but no 'arguments:'; opencode silently ignores unknown fields. The argument docs are already in the '## Input Arguments' body section of each skill, so nothing is lost.
- Add a validate-skills job to check-in-container.yml that runs 'skills-ref validate' against every skill directory on each PR.

A few other tweaks included to make the install instructions more generic.

Assisted-by: OpenCode (Claude Sonnet 4.6)

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now uses the standard agentskills.io format.

RELEASE NOTES END
