### PR TITLE
Surface real subprocess errors from lookaside tools

### DIFF
--- a/ymir/tools/privileged/lookaside.py
+++ b/ymir/tools/privileged/lookaside.py
@@ -33,12 +33,23 @@ async def _try_init_kerberos():
 
 
 async def _run_capturing(argv: list[str], cwd: str | os.PathLike[str], fail_msg: str) -> str:
-    """Run argv in cwd, capturing stdout+stderr.
+    """Run argv in cwd, capturing stdout and stderr together.
 
-    On non-zero exit, raise ToolError including the command and a tail of its
-    output so the real reason (e.g. a lookaside 404, Kerberos failure, or
-    network error from rhpkg/centpkg) propagates back to the agent and Phoenix
-    instead of an opaque "Failed to ..." message.
+    Args:
+        argv: Command and its arguments to execute.
+        cwd: Working directory to run the command in.
+        fail_msg: Prefix for the error message raised on failure.
+
+    Returns:
+        The captured combined output, stripped of surrounding whitespace.
+
+    Raises:
+        ToolError: If argv is empty, the command cannot be executed (e.g. cwd
+            does not exist), or it exits non-zero. The error includes the
+            command and a tail of its output so the real reason (e.g. a
+            lookaside 404, Kerberos failure, or network error from
+            rhpkg/centpkg) propagates back to the agent and Phoenix instead of
+            an opaque "Failed to ..." message.
     """
     if not argv:
         raise ToolError(f"{fail_msg}: No command specified")

--- a/ymir/tools/privileged/lookaside.py
+++ b/ymir/tools/privileged/lookaside.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import shlex
+from pathlib import Path
 
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
@@ -61,7 +62,7 @@ async def _run_capturing(argv: list[str], cwd: str | os.PathLike[str], fail_msg:
             stderr=asyncio.subprocess.STDOUT,
         )
     except OSError as e:
-        if not os.path.isdir(cwd):
+        if not Path(cwd).is_dir():
             raise ToolError(f"{fail_msg}: Directory '{cwd}' does not exist") from e
         raise ToolError(f"{fail_msg}: Failed to execute {argv[0]}: {e}") from e
     out, _ = await proc.communicate()

--- a/ymir/tools/privileged/lookaside.py
+++ b/ymir/tools/privileged/lookaside.py
@@ -32,7 +32,7 @@ async def _try_init_kerberos():
         logger.warning("Kerberos initialization failed, continuing without it: %s", e)
 
 
-async def _run_capturing(argv: list[str], cwd: str, fail_msg: str) -> str:
+async def _run_capturing(argv: list[str], cwd: str | os.PathLike[str], fail_msg: str) -> str:
     """Run argv in cwd, capturing stdout+stderr.
 
     On non-zero exit, raise ToolError including the command and a tail of its
@@ -40,6 +40,8 @@ async def _run_capturing(argv: list[str], cwd: str, fail_msg: str) -> str:
     network error from rhpkg/centpkg) propagates back to the agent and Phoenix
     instead of an opaque "Failed to ..." message.
     """
+    if not argv:
+        raise ToolError(f"{fail_msg}: No command specified")
     try:
         proc = await asyncio.create_subprocess_exec(
             *argv,
@@ -47,9 +49,10 @@ async def _run_capturing(argv: list[str], cwd: str, fail_msg: str) -> str:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )
-    except FileNotFoundError as e:
-        cmd_name = argv[0] if argv else "command"
-        raise ToolError(f"{fail_msg}: {cmd_name} is not installed") from e
+    except OSError as e:
+        if not os.path.isdir(cwd):
+            raise ToolError(f"{fail_msg}: Directory '{cwd}' does not exist") from e
+        raise ToolError(f"{fail_msg}: Failed to execute {argv[0]}: {e}") from e
     out, _ = await proc.communicate()
     output = out.decode(errors="replace").strip()
     if proc.returncode:

--- a/ymir/tools/privileged/lookaside.py
+++ b/ymir/tools/privileged/lookaside.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import shlex
 
 from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
@@ -31,6 +32,34 @@ async def _try_init_kerberos():
         logger.warning("Kerberos initialization failed, continuing without it: %s", e)
 
 
+async def _run_capturing(argv: list[str], cwd: str, fail_msg: str) -> str:
+    """Run argv in cwd, capturing stdout+stderr.
+
+    On non-zero exit, raise ToolError including the command and a tail of its
+    output so the real reason (e.g. a lookaside 404, Kerberos failure, or
+    network error from rhpkg/centpkg) propagates back to the agent and Phoenix
+    instead of an opaque "Failed to ..." message.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=cwd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+    except FileNotFoundError as e:
+        cmd_name = argv[0] if argv else "command"
+        raise ToolError(f"{fail_msg}: {cmd_name} is not installed") from e
+    out, _ = await proc.communicate()
+    output = out.decode(errors="replace").strip()
+    if proc.returncode:
+        tail = ("..." + output[-1500:]) if len(output) > 1500 else output
+        raise ToolError(
+            f"{fail_msg} (`{shlex.join(argv)}` exited {proc.returncode}): {tail or '<no output>'}"
+        )
+    return output
+
+
 class DownloadSourcesToolInput(BaseModel):
     dist_git_path: AbsolutePath = Field(description="Absolute path to cloned dist-git repository")
     package: str = Field(description="Package name")
@@ -58,16 +87,7 @@ class DownloadSourcesTool(Tool[DownloadSourcesToolInput, ToolRunOptions, StringT
     ) -> StringToolOutput:
         await _try_init_kerberos()
         cmd = _pkg_cmd(tool_input.package, tool_input.dist_git_branch)
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                "sources",
-                cwd=tool_input.dist_git_path,
-            )
-        except FileNotFoundError as e:
-            raise ToolError(f"Failed to download sources: {cmd[0]} is not installed") from e
-        if await proc.wait():
-            raise ToolError("Failed to download sources")
+        await _run_capturing([*cmd, "sources"], tool_input.dist_git_path, "Failed to download sources")
         return StringToolOutput(result="Successfully downloaded sources from lookaside cache")
 
 
@@ -100,16 +120,7 @@ class PrepSourcesTool(Tool[PrepSourcesToolInput, ToolRunOptions, StringToolOutpu
         cmd = _pkg_cmd(tool_input.package, tool_input.dist_git_branch)
         if not is_cs_branch(tool_input.dist_git_branch):
             cmd.extend(["--offline", "--released"])
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *cmd,
-                "prep",
-                cwd=tool_input.dist_git_path,
-            )
-        except FileNotFoundError as e:
-            raise ToolError(f"Failed to prep sources: {cmd[0]} is not installed") from e
-        if await proc.wait():
-            raise ToolError("Failed to prep sources")
+        await _run_capturing([*cmd, "prep"], tool_input.dist_git_path, "Failed to prep sources")
         return StringToolOutput(result="Successfully prepped sources")
 
 
@@ -147,15 +158,13 @@ class UploadSourcesTool(Tool[UploadSourcesToolInput, ToolRunOptions, StringToolO
             await init_kerberos_ticket()
         except KerberosError as e:
             raise ToolError(f"Failed to initialize Kerberos ticket: {e}") from e
-        proc = await asyncio.create_subprocess_exec(
+        argv = [
             tool,
             f"--name={tool_input.package}",
             "--namespace=rpms",
             f"--release={tool_input.dist_git_branch}",
             "new-sources",
             *tool_input.new_sources,
-            cwd=tool_input.dist_git_path,
-        )
-        if await proc.wait():
-            raise ToolError("Failed to upload sources")
+        ]
+        await _run_capturing(argv, tool_input.dist_git_path, "Failed to upload sources")
         return StringToolOutput(result="Successfully uploaded the specified new sources to lookaside cache")

--- a/ymir/tools/privileged/tests/unit/test_lookaside.py
+++ b/ymir/tools/privileged/tests/unit/test_lookaside.py
@@ -117,3 +117,39 @@ async def test_upload_sources(branch):
         )
     ).result
     assert result.startswith("Successfully")
+
+
+@pytest.mark.asyncio
+async def test_run_capturing_surfaces_output_on_failure():
+    async def create_subprocess_exec(cmd, *args, **kwargs):
+        async def communicate():
+            return (b"Could not download Source0: 404 Not Found from lookaside", None)
+
+        return flexmock(communicate=communicate, returncode=1)
+
+    flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)
+    with pytest.raises(lookaside_tools.ToolError) as exc:
+        await lookaside_tools._run_capturing(["rhpkg", "sources"], os.getcwd(), "Failed to download sources")
+    msg = str(exc.value)
+    assert "Failed to download sources" in msg
+    assert "rhpkg sources" in msg  # shlex.join'd command
+    assert "exited 1" in msg
+    assert "404 Not Found from lookaside" in msg  # captured output tail
+
+
+@pytest.mark.asyncio
+async def test_run_capturing_rejects_empty_argv():
+    with pytest.raises(lookaside_tools.ToolError, match="No command specified"):
+        await lookaside_tools._run_capturing([], os.getcwd(), "Failed to download sources")
+
+
+@pytest.mark.asyncio
+async def test_run_capturing_reports_missing_cwd():
+    async def create_subprocess_exec(cmd, *args, **kwargs):
+        raise FileNotFoundError
+
+    flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)
+    with pytest.raises(lookaside_tools.ToolError, match="does not exist"):
+        await lookaside_tools._run_capturing(
+            ["rhpkg", "sources"], "/nonexistent/dir/does-not-exist", "Failed to download sources"
+        )

--- a/ymir/tools/privileged/tests/unit/test_lookaside.py
+++ b/ymir/tools/privileged/tests/unit/test_lookaside.py
@@ -32,10 +32,10 @@ async def test_download_sources(branch):
         assert cmd == "rhpkg" if branch.startswith("rhel") else "centpkg"
         assert args[3] == "sources"
 
-        async def wait():
-            return 0
+        async def communicate():
+            return (b"", None)
 
-        return flexmock(wait=wait)
+        return flexmock(communicate=communicate, returncode=0)
 
     _mock_kerberos()
     flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)
@@ -64,10 +64,10 @@ async def test_prep_sources(branch):
         # prep can be on various places due to --offline and --released flags
         assert "prep" in args
 
-        async def wait():
-            return 0
+        async def communicate():
+            return (b"", None)
 
-        return flexmock(wait=wait)
+        return flexmock(communicate=communicate, returncode=0)
 
     _mock_kerberos()
     flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)
@@ -99,10 +99,10 @@ async def test_upload_sources(branch):
         assert cmd == "rhpkg" if branch.startswith("rhel") else "centpkg"
         assert args[3:] == ("new-sources", *new_sources)
 
-        async def wait():
-            return 0
+        async def communicate():
+            return (b"", None)
 
-        return flexmock(wait=wait)
+        return flexmock(communicate=communicate, returncode=0)
 
     flexmock(lookaside_tools).should_receive("init_kerberos_ticket").replace_with(init_kerberos_ticket).once()
     flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)


### PR DESCRIPTION
## Problem

`download_sources`, `prep_sources`, and `upload_sources` run `rhpkg`/`centpkg` without capturing stdout/stderr and raise a bare `"Failed to ..."`. The real reason is thrown away, so it never reaches the agent or Phoenix.

Concretely: OpenEXR z-stream backports (RHEL-182266 / RHEL-182265) failed `download_sources` deterministically on June 5 **and** June 10. Every layer — the backport-agent traceback, the MCP `ToolError`, and the Phoenix span — showed only:

```
ToolError: Error executing tool download_sources: Failed to download sources
```

The actual `rhpkg sources` error (these issues route to RHEL branches `rhel-9.8.0`/`rhel-10.2` via `rhpkg` → internal lookaside, whereas CentOS-Stream packages use `centpkg` → public lookaside and succeed) is invisible, making it impossible to tell a lookaside 404 from a Kerberos failure from a network error without shelling into the pod.

## Change

Add a shared `_run_capturing()` helper that pipes `stdout`/`stderr` and, on non-zero exit, raises a `ToolError` that includes the command and a tail of its output:

```
Failed to download sources (`rhpkg --name=OpenEXR --namespace=rpms --release=rhel-9.8.0 sources` exited 1): <real error tail>
```

Applied to all three lookaside tools. Unit-test proc stubs updated from `wait()` to `communicate()`/`returncode` (argv unchanged).

## Note

This is the observability half. The underlying OpenEXR failure (backport agents can't reach the **RHEL internal lookaside** for `rhpkg`, which `needs_internal_fix` z-streams require) is a separate infra fix — but with this change its real cause will be self-evident in the logs next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)