### PR TITLE
Ignore OpenEXR in the Jira issue fetcher

### DIFF
--- a/openshift/configmap-jira-issue-fetcher-env.yml
+++ b/openshift/configmap-jira-issue-fetcher-env.yml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  IGNORED_COMPONENTS: "firefox,thunderbird,firefox-flatpak-container,thunderbird-flatpak-container,webkit2gtk3,openjdk,postfix,xorg-x11-server,xorg-x11-server-Xwayland"
+  IGNORED_COMPONENTS: "firefox,thunderbird,firefox-flatpak-container,thunderbird-flatpak-container,webkit2gtk3,openjdk,postfix,xorg-x11-server,xorg-x11-server-Xwayland,OpenEXR"
   MAX_ISSUES: "20"
   LOGLEVEL: "INFO"
 immutable: false


### PR DESCRIPTION
download_sources fails for OpenEXR (RHEL-182265, RHEL-182266): it does not use the standard rpms/<package> dist-git namespace the agent assumes. Skip it as a stopgap until the dist-git resolution is fixed.
