### PR TITLE
backport: add self-review step to instructions

### DIFF
--- a/ymir/agents/prompts/backport/_self_review.j2
+++ b/ymir/agents/prompts/backport/_self_review.j2
@@ -1,0 +1,49 @@
+{{ self_review_step }}. Self-Review: Before reporting a result, verify your work meets all criteria
+   below. Run `git diff HEAD -- *.spec` in the dist-git repository root (not in
+   {{ repo_context }}) to inspect what you changed in the spec file.
+{% if spec_only_note %}
+
+{{ spec_only_note }}
+{% endif %}
+
+   Criterion 1 — Patch correctness:
+   If you generated any patch files, read each one. Verify it is non-empty and
+   contains code changes that address the issue in <JIRA_ISSUE> or <CVE_ID>. A
+   patch that only modifies whitespace, comments, or files entirely unrelated to
+   the fix does not pass. Test files that accompany the fix are acceptable.
+   If no patch files were generated (e.g. a spec-only change), skip this
+   criterion.
+
+   Criterion 2 — Spec file correctness:
+   Read the spec file and verify all of the following:
+   a. A new `Patch:` tag exists for every patch file you generated.
+      (Skip if no patch files were generated.)
+   b. Unless the spec uses `%autosetup` or `%autopatch` (which apply patches
+      automatically), the `%prep` section has a corresponding `%patch` directive
+      for each new tag, with the correct `-p` strip level.
+      (Skip if no patch files were generated.)
+   c. All pre-existing `Patch:` tags and their `%patch` directives remain
+      present with the same tag numbers and `-p` arguments as before.
+
+   Criterion 3 — No unrelated changes:
+{{ criterion_3_body }}
+
+   Criterion 4 — Completeness:
+   Verify the SRPM generated in step {{ srpm_step }} exists on disk. Use the path that the
+   SRPM generation command printed, and run:
+   `test -f "<path-to-srpm>" && echo exists || echo missing`
+
+   Criterion 5 — Patch naming:
+   If you generated any patch files, verify each filename follows the naming
+   convention determined in step 0. If no patch files were generated, skip
+   this criterion.
+
+   If ALL criteria pass, report success as normal.
+
+   If ANY criterion fails, set `success=False` and populate `error` with:
+
+     Self-review failed. The following criteria were not met:
+
+     - <Criterion name>: <specific reason — what was found vs. what was expected>
+
+   List only the failing criteria. Do not mention passing ones.

--- a/ymir/agents/prompts/backport/instructions.j2
+++ b/ymir/agents/prompts/backport/instructions.j2
@@ -239,6 +239,22 @@ a backport that won't actually fix the shipped RPM.
 
 7. Generate a SRPM using the `build_srpm` tool.
 
+{% set self_review_step = 8 %}
+{% set repo_context = '`<UPSTREAM_REPO>`' %}
+{% set spec_only_note %}
+   Note: If this was a spec-only change (step 3d path), no patch files are
+   generated — criteria 1, 2a, 2b, and 5 will not apply. Criterion 2c still
+   applies: verify that pre-existing Patch tags were not accidentally modified.
+{%- endset %}
+{% set criterion_3_body %}
+   From the git diff output, verify the `%changelog` section was not modified.
+   (Changing the Release field is acceptable in y-stream, unless this was a
+   spec-only change via step 3d — in that case the Release field must not be
+   modified either.)
+{%- endset %}
+{% set srpm_step = 7 %}
+{% include "backport/_self_review.j2" %}
+
 
 General instructions:
 

--- a/ymir/agents/prompts/backport/instructions_zstream.j2
+++ b/ymir/agents/prompts/backport/instructions_zstream.j2
@@ -257,6 +257,17 @@ a backport that won't actually fix the shipped RPM.
 
 6. Generate a SRPM using the `build_srpm` tool.
 
+{% set self_review_step = 7 %}
+{% set repo_context = 'any cloned source repository' %}
+{% set spec_only_note = '' %}
+{% set criterion_3_body %}
+   From the git diff output, verify all of the following:
+   a. The `%changelog` section was not modified.
+   b. Your changes (visible in the diff) did not modify the `Release:` field.
+{%- endset %}
+{% set srpm_step = 6 %}
+{% include "backport/_self_review.j2" %}
+
 
 General instructions:
 

--- a/ymir/agents/prompts/backport/prompt_fix_build_error.j2
+++ b/ymir/agents/prompts/backport/prompt_fix_build_error.j2
@@ -67,6 +67,60 @@ SPECIAL CONSIDERATIONS FOR TEST FAILURES:
    - Which commits you cherry-picked or what manual edits you made
    - The build result (pass/fail and error if applicable)
 
+7. Self-Review: Before reporting a result, verify your work meets all criteria
+   below. Run `git diff HEAD -- *.spec` in {{ local_clone }} to inspect what
+   changed in the spec file.
+
+   Criterion 1 — Patch correctness:
+   Read each regenerated patch file. Verify it is non-empty and contains code
+   changes that address the build failure. A patch that only modifies whitespace
+   or comments does not pass.
+
+   Criterion 2 — Spec file not modified:
+   From the git diff output, verify the spec file was NOT modified. The spec
+   already has the correct `Patch:` tags from the original backport — your job
+   is to fix the patches, not the spec. If the diff shows any spec changes,
+   this criterion fails.
+
+   Criterion 3 — No unrelated changes:
+   From the git diff output, verify your changes are limited to the patch
+   file(s) listed in step 4. No other files in {{ local_clone }} should be
+   modified. Also verify that no tests were silently disabled, commented out,
+   or skipped in the regenerated patches unless the build error explicitly
+   required it.
+
+   Criterion 4 — Completeness:
+   Verify the SRPM generated in step 5 exists on disk. Use the path returned
+   by the `build_srpm` tool, and run:
+   `test -f "<path-to-srpm>" && echo exists || echo missing`
+
+   Criterion 5 — Patch naming:
+   Verify each patch filename matches the original name from the spec file.
+   Do not rename patch files.
+
+   If ALL criteria pass, report success as normal.
+
+   If ANY criterion fails, attempt to fix the problem before reporting failure:
+   - Criterion 1 or 3 (bad patch content or disabled tests): return to step 3
+     and re-fix the issue, then regenerate patches (step 4) and rebuild (step 5).
+   - Criterion 2 (spec modified): revert the spec with
+     `git checkout HEAD -- *.spec` in {{ local_clone }}, verify the revert with
+     `git diff HEAD -- *.spec`, then rebuild (step 5).
+   - Criterion 4 (SRPM missing): re-run `build_srpm` (step 5).
+   - Criterion 5 (wrong patch name): rename the file to match the spec, then
+     rebuild (step 5).
+
+   After fixing, re-run this self-review before reporting.
+
+   Only if the fix attempt itself fails, set `success=False` and populate
+   `error` with:
+
+     Self-review failed. The following criteria were not met:
+
+     - <Criterion name>: <specific reason — what was found vs. what was expected>
+
+   List only the failing criteria. Do not mention passing ones.
+
 Report success=true with SRPM path if build passes.
 Report success=false with the extracted error if build fails or you can't find a fix.
 


### PR DESCRIPTION
## Summary

- Adds a self-review checklist (5 criteria) as the final step before the backport agent reports success, covering patch correctness, spec file integrity, no unrelated changes, SRPM existence, and patch naming
- Extracts shared self-review criteria into `_self_review.j2` to avoid duplication between y-stream and z-stream templates
- Criteria 1, 2a/2b, and 5 are self-guarding for zero-patch scenarios (spec-only changes)
- Criterion 2b accounts for `%autosetup`/`%autopatch` specs that don't need explicit `%patch` directives
- Criterion 2c (pre-existing Patch tags intact) always applies, even on the spec-only path
- Y-stream Criterion 3 qualifies the Release field exception to exclude the spec-only path

## Test plan

- [x] Both templates render identically to pre-dedup output (verified via rendered diff)
- [x] `pytest ymir/agents/tests/unit/test_jinja2_templates.py` — 31 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)