### PR TITLE
Post backport failure feedback to Jira on the final retry

### DIFF
--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -840,7 +840,9 @@ async def main() -> None:
                 + (" (user-triggered via ymir_todo)" if user_triggered else "")
             )
 
-            async def retry(task, error, backport_data=backport_data, user_triggered=user_triggered):
+            async def retry(
+                task, error, comment_text=None, backport_data=backport_data, user_triggered=user_triggered
+            ):
                 task.attempts += 1
                 if task.attempts < max_retries:
                     logger.warning(
@@ -850,6 +852,7 @@ async def main() -> None:
                     retry_queue = backport_queue_todo if task.user_triggered else backport_queue
                     await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
+                    # Final attempt exhausted — mark errored and stop retrying.
                     logger.error(
                         f"Task failed after {max_retries} attempts, "
                         f"moving to error list: {backport_data.jira_issue}"
@@ -861,6 +864,30 @@ async def main() -> None:
                         dry_run=dry_run,
                         user_triggered=user_triggered,
                     )
+                    # Post failure feedback to Jira once, here on the final attempt
+                    # only — never for intermediate retries. Restricted to
+                    # user-triggered (ymir_todo) runs: a maintainer who didn't ask
+                    # for processing shouldn't be notified, so skip the gateway
+                    # connection entirely otherwise.
+                    if user_triggered and comment_text and not dry_run:
+                        try:
+                            async with mcp_tools(
+                                os.environ["MCP_GATEWAY_URL"],
+                                call_meta={"jira_issue": backport_data.jira_issue},
+                            ) as gateway_tools:
+                                await tasks.comment_in_jira(
+                                    jira_issue=backport_data.jira_issue,
+                                    agent_type="Backport",
+                                    comment_text=comment_text,
+                                    available_tools=gateway_tools,
+                                    is_error=True,
+                                    user_triggered=user_triggered,
+                                )
+                        except Exception as comment_error:
+                            logger.warning(
+                                f"Failed to post final backport failure comment for "
+                                f"{backport_data.jira_issue}: {comment_error}"
+                            )
                     await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
 
             try:
@@ -889,9 +916,11 @@ async def main() -> None:
             except Exception as e:
                 error = "".join(traceback.format_exception(e))
                 logger.error(f"Exception during backport processing for {backport_data.jira_issue}: {error}")
+                reason = e.explain() if isinstance(e, FrameworkError) else e
                 await retry(
                     task,
                     ErrorData(details=error, jira_issue=backport_data.jira_issue).model_dump_json(),
+                    comment_text=f"Agent failed to perform a backport: {reason}",
                 )
             else:
                 if state.backport_result.success:
@@ -926,6 +955,10 @@ async def main() -> None:
                         dry_run=dry_run,
                         user_triggered=user_triggered,
                     )
+                    # No comment_text here: the in-workflow comment_in_jira step has
+                    # already posted the failure feedback for this graceful path.
+                    # Only the crash path (which never reaches that step) passes
+                    # comment_text, so we never double-comment.
                     await retry(task, state.backport_result.error)
 
 


### PR DESCRIPTION
## Problem

When a backport fails in an **unguarded** step — `fork_and_prepare_dist_git` (which runs `get_patch_from_url`) or `run_backport_agent` (which does the patch-apply) — the exception propagates out of the workflow to `main()`'s top-level `except`. That handler sets `ymir_backport_errored` and pushes the traceback to `error_list`, but **never posts a Jira comment**. The in-workflow `comment_in_jira` step is only reached on *graceful* failures, so crashes leave the maintainer with a silently-flipped label and no explanation.

This is especially bad for `ymir_todo`-triggered runs, where a human explicitly asked for processing and is waiting on a result.

### Seen in production

**RHEL-184829** (perl-HTTP-Daemon, CVE-2026-8450, rhel-9.8.z) was triggered via `ymir_todo`. Triage posted ack + "Resolution: backport" comments, then all three backport attempts crashed in unguarded steps (a transient `get_patch_from_url` error, a Chat Model error, and a real patch-apply conflict). The label flipped to `ymir_backport_errored` with **no comment** explaining why.

## Fix

Post a single failure comment from `retry()`'s **final-attempt** branch (`task.attempts >= max_retries`) — never for intermediate retries:

- Gated on `user_triggered` so only `ymir_todo` runs notify, and so we don't open an MCP gateway connection otherwise.
- Only the **crash** path passes `comment_text` (a concise `str(e)`; the full traceback still goes to `error_list`). The **graceful** path is left untouched — its in-workflow `comment_in_jira` step already posted feedback — so there is no double-comment.
- The shared `comment_in_jira` method is not modified.

## Net effect

- Crash failures now get exactly one feedback comment, on the last retry, for `ymir_todo` runs.
- Graceful failures keep their existing behavior.
- No duplicate comments; no comments added for intermediate attempts.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>