### PR TITLE
Fix discover_patch_p failing on patches that only add new files

### DIFF
--- a/ymir/tools/unprivileged/tests/unit/test_wicked_git.py
+++ b/ymir/tools/unprivileged/tests/unit/test_wicked_git.py
@@ -244,6 +244,17 @@ async def test_git_log_search_tool_found(git_repo, cve_id, jira_issue, expected)
             "+Line 3\n",
             2,
         ),
+        (
+            "diff --git a/t/new-test.t b/t/new-test.t\n"
+            "new file mode 100644\n"
+            "index 0000000..cb75215\n"
+            "--- /dev/null\n"
+            "+++ b/t/new-test.t\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+use Test::More;\n"
+            "+ok(1);\n",
+            1,
+        ),
     ],
 )
 async def test_discover_patch_p(git_repo, tmp_path, patch_content, expected_n):

--- a/ymir/tools/unprivileged/wicked_git.py
+++ b/ymir/tools/unprivileged/wicked_git.py
@@ -297,6 +297,16 @@ async def discover_patch_p(patch_file_path: AbsolutePath, repository_path: Absol
                 # I know this is naive, but we certainly cannot check all files
                 # because some may be missing in the checkout
                 return n
+
+    # Fallback: the file-existence heuristic fails when all files in the patch
+    # are new (e.g. a patch that only adds test files). In that case, ask git
+    # directly whether the patch can be applied at a given strip level.
+    for n in range(1, 6):
+        cmd = ["git", "apply", "--check", f"-p{n}", str(patch_file_path)]
+        exit_code, _, _ = await run_subprocess(cmd, cwd=repository_path)
+        if exit_code == 0:
+            return n
+
     raise ToolError(f"Failed to discover the value for `-p` for patch file: {patch_file_path}")
 
 


### PR DESCRIPTION
The file-existence heuristic in discover_patch_p fails when every file in a patch is new (e.g. a standalone regression test commit) because none of the paths exist in the repository yet. Add a git apply --check fallback that directly tests whether the patch can be applied at each strip level.

Observed in RHEL-184829 where the second upstream patch only created t/send-file-magic-open.t.

Assisted-By: Claude Opus 4.6