### PR TITLE
Fix MCP gateway ModuleNotFoundError for beeai_framework

### DIFF
--- a/.github/workflows/check-in-container.yml
+++ b/.github/workflows/check-in-container.yml
@@ -50,3 +50,26 @@ jobs:
         TEST_IMAGE: beeai-tests
         TEST_IMAGE_C9S: beeai-tests-c9s
       run: make ${{ matrix.target }}
+
+  smoke-test-mcp-containerfile:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - name: Set up Podman
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman
+        podman --version
+    - name: Build MCP gateway container
+      run: |
+        podman build --no-cache -f Containerfile.mcp -t mcp-gateway-test:pr .
+    - name: Test beeai_framework import
+      run: |
+        podman run --rm mcp-gateway-test:pr python3.13 -c "from beeai_framework.adapters.mcp.serve.server import MCPServer; print('✓ beeai_framework import successful')"
+    - name: Test privileged gateway module
+      run: |
+        podman run --rm mcp-gateway-test:pr python3.13 -c "from ymir.tools.privileged.gateway import main; print('✓ privileged gateway import successful')"
+    - name: Test unprivileged gateway module
+      run: |
+        podman run --rm mcp-gateway-test:pr python3.13 -c "from ymir.tools.unprivileged.gateway import main; print('✓ unprivileged gateway import successful')"

--- a/Containerfile.mcp
+++ b/Containerfile.mcp
@@ -39,8 +39,18 @@ COPY requirements-global.txt /home/mcp/
 COPY ymir/common/ /home/mcp/ymir/common/
 COPY ymir/tools/ /home/mcp/ymir/tools/
 
-# Install dependencies via pyproject.toml; litellm pinned separately to exclude compromised versions
-RUN pip install --no-cache-dir "litellm!=1.82.7,!=1.82.8" /home/mcp/ymir/common/ /home/mcp/ymir/tools/
+# Install build-system dependencies to allow building local packages without isolation
+RUN pip install --no-cache-dir hatchling hatch-requirements-txt
+
+# Build wheels for local packages without isolation (so hatch-requirements-txt can
+# resolve ../../requirements-global.txt) but without dependencies (--no-deps prevents
+# applying --no-build-isolation to third-party packages, which could break if they
+# need to build from source with their own build tools)
+RUN pip wheel --no-build-isolation --no-deps --wheel-dir /tmp/wheels /home/mcp/ymir/common/ /home/mcp/ymir/tools/
+
+# Install the built wheels and all dependencies with standard pip (build isolation
+# enabled for third-party packages); litellm pinned separately to exclude compromised versions
+RUN pip install --no-cache-dir "litellm!=1.82.7,!=1.82.8" /tmp/wheels/*.whl && rm -rf /tmp/wheels
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \


### PR DESCRIPTION
## Problem

The MCP gateway was failing to start with:
```
ModuleNotFoundError: No module named 'beeai_framework'
```

## Root Cause

**PEP 517 build isolation.** When pip builds wheels from local directories (`/home/mcp/ymir/tools/`), it copies only that subdirectory to a temporary build location (e.g., `/tmp/pip-req-build-xxxxxx`). This breaks the relative path `../../requirements-global.txt` referenced in `ymir/tools/pyproject.toml`, causing `hatch-requirements-txt` to silently fail and produce wheels with incomplete dependency metadata (missing `beeai-framework[mcp]`).

## Solution

Use a two-step build process:

1. **Build wheels for ymir packages** with `--no-build-isolation --no-deps`
   - Ensures `hatch-requirements-txt` can resolve the relative path `../../requirements-global.txt`
   - `--no-deps` prevents applying `--no-build-isolation` to third-party packages

2. **Install the built wheels** with standard pip (build isolation enabled)
   - Preserves build isolation for third-party packages that may need to compile from source
   - Ensures all dependencies are installed with their proper build requirements

This approach ensures:
- ✅ `ymir-tools` wheels have complete dependency metadata (critical since we distribute them)
- ✅ Third-party packages maintain safe build isolation
- ✅ No risk of build failures from missing build tools (poetry-core, setuptools, etc.)

## Testing

Added a dedicated smoke test job `smoke-test-mcp-containerfile` that:
- Builds `Containerfile.mcp` from scratch with `--no-cache`
- Verifies `beeai_framework` imports successfully
- Verifies both privileged and unprivileged gateway modules import correctly

This catches build-time dependency resolution issues that the existing `check-mcp-install-in-container` test might miss.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>