### PR TITLE
Use venv Python in MCP gateway deployment

### DIFF
--- a/openshift/deployment-mcp-gateway.yml
+++ b/openshift/deployment-mcp-gateway.yml
@@ -22,7 +22,7 @@ spec:
         - -m
         - ymir.tools.privileged.gateway
         command:
-        - /usr/bin/python
+        - /opt/beeai-venv/bin/python
         env:
         - name: GIT_REPO_BASEPATH
           valueFrom:


### PR DESCRIPTION
The MCP gateway deployment was using /usr/bin/python (Python 3.14) which doesn't have access to the packages installed in /opt/beeai-venv where beeai-framework and ymir-tools are installed.

Fix: Use /opt/beeai-venv/bin/python (Python 3.13) which matches the Containerfile.mcp venv setup and has all required packages.

This resolves the ModuleNotFoundError for beeai_framework at runtime.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>