### PR TITLE
Post rebase and rebuild failure feedback to Jira on the final retry

### DIFF
--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -959,7 +959,13 @@ async def main() -> None:
                     # already posted the failure feedback for this graceful path.
                     # Only the crash path (which never reaches that step) passes
                     # comment_text, so we never double-comment.
-                    await retry(task, state.backport_result.error)
+                    await retry(
+                        task,
+                        ErrorData(
+                            details=getattr(state.backport_result, "error", None) or "Unknown backport error",
+                            jira_issue=backport_data.jira_issue,
+                        ).model_dump_json(),
+                    )
 
 
 if __name__ == "__main__":

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -579,7 +579,13 @@ async def main() -> None:
                     # already posted the failure feedback for this graceful path.
                     # Only the crash path (which never reaches that step) passes
                     # comment_text, so we never double-comment.
-                    await retry(task, state.rebase_result.error)
+                    await retry(
+                        task,
+                        ErrorData(
+                            details=getattr(state.rebase_result, "error", None) or "Unknown rebase error",
+                            jira_issue=rebase_data.jira_issue,
+                        ).model_dump_json(),
+                    )
 
 
 if __name__ == "__main__":

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -469,7 +469,9 @@ async def main() -> None:
                 + (" (user-triggered via ymir_todo)" if user_triggered else "")
             )
 
-            async def retry(task, error, rebase_data=rebase_data, user_triggered=user_triggered):
+            async def retry(
+                task, error, comment_text=None, rebase_data=rebase_data, user_triggered=user_triggered
+            ):
                 task.attempts += 1
                 if task.attempts < max_retries:
                     logger.warning(
@@ -479,6 +481,7 @@ async def main() -> None:
                     retry_queue = rebase_queue_todo if task.user_triggered else rebase_queue
                     await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
+                    # Final attempt exhausted — mark errored and stop retrying.
                     logger.error(
                         f"Task failed after {max_retries} attempts, "
                         f"moving to error list: {rebase_data.jira_issue}"
@@ -490,6 +493,30 @@ async def main() -> None:
                         dry_run=dry_run,
                         user_triggered=user_triggered,
                     )
+                    # Post failure feedback to Jira once, here on the final attempt
+                    # only — never for intermediate retries. Restricted to
+                    # user-triggered (ymir_todo) runs: a maintainer who didn't ask
+                    # for processing shouldn't be notified, so skip the gateway
+                    # connection entirely otherwise.
+                    if user_triggered and comment_text and not dry_run:
+                        try:
+                            async with mcp_tools(
+                                os.environ["MCP_GATEWAY_URL"],
+                                call_meta={"jira_issue": rebase_data.jira_issue},
+                            ) as gateway_tools:
+                                await tasks.comment_in_jira(
+                                    jira_issue=rebase_data.jira_issue,
+                                    agent_type="Rebase",
+                                    comment_text=comment_text,
+                                    available_tools=gateway_tools,
+                                    is_error=True,
+                                    user_triggered=user_triggered,
+                                )
+                        except Exception as comment_error:
+                            logger.warning(
+                                f"Failed to post final rebase failure comment for "
+                                f"{rebase_data.jira_issue}: {comment_error}"
+                            )
                     await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
 
             try:
@@ -513,9 +540,11 @@ async def main() -> None:
             except Exception as e:
                 error = "".join(traceback.format_exception(e))
                 logger.error(f"Exception during rebase processing for {rebase_data.jira_issue}: {error}")
+                reason = e.explain() if isinstance(e, FrameworkError) else e
                 await retry(
                     task,
                     ErrorData(details=error, jira_issue=rebase_data.jira_issue).model_dump_json(),
+                    comment_text=f"Agent failed to perform a rebase: {reason}",
                 )
             else:
                 if state.rebase_result.success:
@@ -546,6 +575,10 @@ async def main() -> None:
                         dry_run=dry_run,
                         user_triggered=user_triggered,
                     )
+                    # No comment_text here: the in-workflow comment_in_jira step has
+                    # already posted the failure feedback for this graceful path.
+                    # Only the crash path (which never reaches that step) passes
+                    # comment_text, so we never double-comment.
                     await retry(task, state.rebase_result.error)
 
 

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -384,7 +384,9 @@ async def main() -> None:
                 + (" (user-triggered via ymir_todo)" if user_triggered else "")
             )
 
-            async def retry(task, error, rebuild_data=rebuild_data, user_triggered=user_triggered):
+            async def retry(
+                task, error, comment_text=None, rebuild_data=rebuild_data, user_triggered=user_triggered
+            ):
                 task.attempts += 1
                 if task.attempts < max_retries:
                     logger.warning(
@@ -394,6 +396,7 @@ async def main() -> None:
                     retry_queue = rebuild_queue_todo if task.user_triggered else rebuild_queue
                     await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
+                    # Final attempt exhausted — mark errored and stop retrying.
                     logger.error(
                         f"Task failed after {max_retries} attempts, "
                         f"moving to error list: {rebuild_data.jira_issue}"
@@ -409,6 +412,37 @@ async def main() -> None:
                             )
                         except Exception as e:
                             logger.warning(f"Failed to set labels on {issue_key}: {e}")
+                    # Post failure feedback to Jira once, here on the final attempt
+                    # only — never for intermediate retries. Restricted to
+                    # user-triggered (ymir_todo) runs: a maintainer who didn't ask
+                    # for processing shouldn't be notified, so skip the gateway
+                    # connection entirely otherwise.
+                    if user_triggered and comment_text and not dry_run:
+                        try:
+                            async with mcp_tools(
+                                os.environ["MCP_GATEWAY_URL"],
+                                call_meta={"jira_issue": rebuild_data.jira_issue},
+                            ) as gateway_tools:
+                                for issue_key in rebuild_data.all_jira_issues:
+                                    try:
+                                        await tasks.comment_in_jira(
+                                            jira_issue=issue_key,
+                                            agent_type="Rebuild",
+                                            comment_text=comment_text,
+                                            available_tools=gateway_tools,
+                                            is_error=True,
+                                            user_triggered=user_triggered,
+                                        )
+                                    except Exception as comment_error:
+                                        logger.warning(
+                                            f"Failed to post final rebuild failure comment for "
+                                            f"{issue_key}: {comment_error}"
+                                        )
+                        except Exception as gateway_error:
+                            logger.warning(
+                                f"Failed to connect to MCP gateway for final rebuild failure comment: "
+                                f"{gateway_error}"
+                            )
                     await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
 
             try:
@@ -433,9 +467,11 @@ async def main() -> None:
             except Exception as e:
                 error = "".join(traceback.format_exception(e))
                 logger.error(f"Exception during rebuild processing for {rebuild_data.jira_issue}: {error}")
+                reason = e.explain() if isinstance(e, FrameworkError) else e
                 await retry(
                     task,
                     ErrorData(details=error, jira_issue=rebuild_data.jira_issue).model_dump_json(),
+                    comment_text=f"Agent failed to perform a rebuild: {reason}",
                 )
             else:
                 if state.rebuild_success:
@@ -477,6 +513,10 @@ async def main() -> None:
                             )
                         except Exception as e:
                             logger.warning(f"Failed to set labels on {issue_key}: {e}")
+                    # No comment_text here: the in-workflow comment_in_jira step has
+                    # already posted the failure feedback for this graceful path.
+                    # Only the crash path (which never reaches that step) passes
+                    # comment_text, so we never double-comment.
                     await retry(
                         task,
                         ErrorData(

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -269,7 +269,7 @@ async def main() -> None:
                 logger.info(f"Result to be put in Jira comment: {comment_text}")
 
                 all_issues = [state.jira_issue] + [item.issue_key for item in state.consolidated_issues]
-                for issue_key in all_issues:
+                for issue_key in dict.fromkeys(all_issues):
                     try:
                         await tasks.comment_in_jira(
                             jira_issue=issue_key,
@@ -401,7 +401,7 @@ async def main() -> None:
                         f"Task failed after {max_retries} attempts, "
                         f"moving to error list: {rebuild_data.jira_issue}"
                     )
-                    for issue_key in rebuild_data.all_jira_issues:
+                    for issue_key in dict.fromkeys(rebuild_data.all_jira_issues):
                         try:
                             await tasks.set_jira_labels(
                                 jira_issue=issue_key,
@@ -423,7 +423,7 @@ async def main() -> None:
                                 os.environ["MCP_GATEWAY_URL"],
                                 call_meta={"jira_issue": rebuild_data.jira_issue},
                             ) as gateway_tools:
-                                for issue_key in rebuild_data.all_jira_issues:
+                                for issue_key in dict.fromkeys(rebuild_data.all_jira_issues):
                                     try:
                                         await tasks.comment_in_jira(
                                             jira_issue=issue_key,
@@ -476,7 +476,7 @@ async def main() -> None:
             else:
                 if state.rebuild_success:
                     logger.info(f"Rebuild successful for {rebuild_data.jira_issue}, adding to completed list")
-                    for issue_key in rebuild_data.all_jira_issues:
+                    for issue_key in dict.fromkeys(rebuild_data.all_jira_issues):
                         try:
                             await tasks.set_jira_labels(
                                 jira_issue=issue_key,
@@ -502,7 +502,7 @@ async def main() -> None:
                     )
                 else:
                     logger.warning(f"Rebuild failed for {rebuild_data.jira_issue}: {state.rebuild_error}")
-                    for issue_key in rebuild_data.all_jira_issues:
+                    for issue_key in dict.fromkeys(rebuild_data.all_jira_issues):
                         try:
                             await tasks.set_jira_labels(
                                 jira_issue=issue_key,

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -520,7 +520,7 @@ async def main() -> None:
                     await retry(
                         task,
                         ErrorData(
-                            details=state.rebuild_error,
+                            details=state.rebuild_error or "Unknown rebuild error",
                             jira_issue=rebuild_data.jira_issue,
                         ).model_dump_json(),
                     )


### PR DESCRIPTION
Apply the same error feedback pattern from PR #603 to the rebase and rebuild agents. When a task crashes (exception path) and exhausts all retries, post the error message to Jira if the task was user-triggered.

This ensures users get feedback for unexpected crashes that never reach the workflow's comment_in_jira step. Graceful failures (workflow-level) already post comments via the workflow, so we skip comment_text there to avoid double-commenting.

Related: #603

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>