### PR TITLE
Automate daily CVE batch: unsuspend jira-issue-fetcher, bump to 40 issues

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -106,28 +106,34 @@ Two CronJobs run the fetcher with different JQL queries:
 
 | CronJob | Schedule | QUERY | ConfigMap |
 |---|---|---|---|
-| `jira-issue-fetcher` | `*/30 * * * *` | A generic filter for processing a batch of issues (e.g. early adopters) — currently `filter = "Ymir early adopters CVEs"` | `jira-issue-fetcher-filter-env` |
+| `jira-issue-fetcher` | `0 8 * * *` (daily, 8am UTC) | Main CVE batch — processes up to `MAX_ISSUES` issues from the filter in `jira-issue-fetcher-filter-env` | `jira-issue-fetcher-filter-env` |
 | `jira-issue-fetcher-todo` | `*/5 * * * *` | `labels = "ymir_todo"` | `jira-issue-fetcher-todo-env` |
 
 Both share the common knobs (`IGNORED_COMPONENTS`, `MAX_ISSUES`, `LOGLEVEL`) from `jira-issue-fetcher-env`. Each pod mounts the shared configmap plus its per-cron QUERY configmap. To target a different batch, edit `configmap-jira-issue-fetcher-filter-env.yml` and re-apply.
 
-Manually run either fetcher:
+Both CronJobs ship with `suspend: false` and run on their schedules out of the box. Pause or resume either one:
 
 ```bash
-make run-jira-issue-fetcher       # generic batch filter
+make suspend-jira-issue-fetcher          # stop scheduled runs
+make unsuspend-jira-issue-fetcher        # resume scheduled runs
+make suspend-jira-issue-fetcher-todo     # stop scheduled runs
+make unsuspend-jira-issue-fetcher-todo   # resume scheduled runs
+```
+
+These patch the live CronJob (`oc patch ... suspend`). Re-applying the manifests (`./deploy.sh`) resets each CronJob to the `suspend` value in its manifest (both default to `false`), so to change the default permanently edit `suspend` in the manifest.
+
+**Manual on-demand runs** work regardless of the suspend state — `suspend` only stops the scheduler, not manual triggers:
+
+```bash
+make run-jira-issue-fetcher       # trigger a one-off run now (works even when suspended)
 make run-jira-issue-fetcher-todo  # ymir_todo sweep
 ```
 
-`jira-issue-fetcher-todo` ships with `suspend: false` (it runs on its schedule out of the box); `jira-issue-fetcher` ships with `suspend: true` and must be resumed before it fires. Enable or pause each one's schedule:
+If the daily scheduled run is already active, check before triggering manually to avoid pushing duplicate issues to the queue:
 
 ```bash
-make unsuspend-jira-issue-fetcher        # resume the generic batch fetcher
-make unsuspend-jira-issue-fetcher-todo   # resume the ymir_todo sweep
-make suspend-jira-issue-fetcher          # pause it again
-make suspend-jira-issue-fetcher-todo     # pause it again
+oc get jobs -l app=jira-issue-fetcher
 ```
-
-These patch the live CronJob (`oc patch ... suspend`). Re-applying the manifests (`./deploy.sh`) resets each CronJob to whatever `suspend` value its `cronjob-jira-issue-fetcher*.yml` declares (`jira-issue-fetcher-todo` → running, `jira-issue-fetcher` → suspended), so to change a fetcher's default permanently edit `suspend` in its manifest.
 
 ## Agent runtime knobs (`agents-env` ConfigMap)
 

--- a/openshift/configmap-jira-issue-fetcher-env.yml
+++ b/openshift/configmap-jira-issue-fetcher-env.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   IGNORED_COMPONENTS: "firefox,thunderbird,firefox-flatpak-container,thunderbird-flatpak-container,webkit2gtk3,openjdk,postfix,xorg-x11-server,xorg-x11-server-Xwayland,OpenEXR"
-  MAX_ISSUES: "20"
+  MAX_ISSUES: "40"
   LOGLEVEL: "INFO"
 immutable: false
 kind: ConfigMap

--- a/openshift/cronjob-jira-issue-fetcher.yml
+++ b/openshift/cronjob-jira-issue-fetcher.yml
@@ -6,11 +6,11 @@ metadata:
     app: jira-issue-fetcher
     component: scheduler
 spec:
-  schedule: "*/30 * * * *"  # Every 30 minutes — runs the early-adopters filter
+  schedule: "0 8 * * *"  # Daily at 8am UTC — automated CVE batch
   concurrencyPolicy: Forbid  # Prevent overlapping runs
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5
-  suspend: true
+  suspend: false
   jobTemplate:
     metadata:
       labels:
@@ -18,7 +18,7 @@ spec:
         component: job
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 600  # 10 minutes max runtime (cron is */30, must not overlap)
+      activeDeadlineSeconds: 600  # 10 minutes max runtime
       template:
         metadata:
           labels:


### PR DESCRIPTION
Previously the Skald rotation required manually triggering batches of CVE Jiras each day via `make run-jira-issue-fetcher`. This was the main human-in-the-loop step that prevented Ymir from processing issues over weekends or on days when the on-call person was unavailable.

This commit removes that requirement by switching jira-issue-fetcher from a manually-triggered suspended CronJob to a daily automated run:

- Unsuspend jira-issue-fetcher (suspend: true → false)
- Change schedule from */30 * * * * to daily at 8am UTC
- Bump MAX_ISSUES from 20 to 40 — daily cadence means a larger batch is appropriate; the filter ordering by due date ensures the most urgent issues are always picked first
- Update README to reflect the new schedule and clarify that both CronJobs now run unsuspended by default

The Skald rotation shifts from "trigger + monitor" to purely "monitor": responding to MR feedback, closing bad MRs, and running the Monday review. If production issues arise, the batch can be paused immediately:

    make suspend-jira-issue-fetcher    # stop scheduled runs
    make unsuspend-jira-issue-fetcher  # resume

Manual one-off runs still work at any time via make run-jira-issue-fetcher.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>
