### PR TITLE
Filter get_jira_details output and request only needed fields

### DIFF
--- a/ymir/tools/privileged/aiohttp_client_session_mock.py
+++ b/ymir/tools/privileged/aiohttp_client_session_mock.py
@@ -28,12 +28,17 @@ async def _get_unverified_user():
     return {"groups": {"items": []}}
 
 
-async def _read_jira_mock(issue_key: str, remote_link=False) -> dict:
+async def _read_jira_mock(
+    issue_key: str, remote_link: bool = False, requested_fields: set[str] | None = None
+) -> dict | list:
     try:
         async with aiofiles.open(f"{os.environ['JIRA_MOCK_FILES']}/{issue_key}") as jira_file:
+            data = json.loads(await jira_file.read())
             if remote_link:
-                return json.loads(await jira_file.read())["remote_links"]
-            return json.loads(await jira_file.read())
+                return data.get("remote_links", [])
+            if requested_fields is not None and "fields" in data:
+                data["fields"] = {k: v for k, v in data["fields"].items() if k in requested_fields}
+            return data
     except (OSError, FileNotFoundError, json.JSONDecodeError) as e:
         raise ToolError(f"Error while reading mock up Jira issue {e}") from e
 
@@ -77,20 +82,33 @@ class aiohttpClientSessionMock:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
 
+    @staticmethod
+    def _parse_requested_fields(kwargs: dict) -> set[str] | None:
+        """Extract the ``fields`` query parameter into a set, or None if absent."""
+        raw = kwargs.get("params", {}).get("fields") if kwargs.get("params") else None
+        if raw is None:
+            return None
+        return set(raw.split(","))
+
     @asynccontextmanager
     async def get(self, *args, **kwargs):
         if match_data := self.issue_get_regex.fullmatch(args[0]):
+            requested_fields = self._parse_requested_fields(kwargs)
             yield flexmock(
                 status=200,
                 raise_for_status=lambda: None,
-                json=partial(_read_jira_mock, issue_key=match_data.group(1), remote_link=False),
+                json=partial(
+                    _read_jira_mock,
+                    issue_key=match_data.group(1),
+                    remote_link=False,
+                    requested_fields=requested_fields,
+                ),
             )
         elif match_data := self.remote_link_get_regex.fullmatch(args[0]):
             yield flexmock(
                 status=200,
                 raise_for_status=lambda: None,
-                json=partial(_read_jira_mock, issue_key=match_data.group(1)),
-                remote_link=True,
+                json=partial(_read_jira_mock, issue_key=match_data.group(1), remote_link=True),
             )
         elif match_data := self.transitions_get_regex.fullmatch(args[0]):
             yield flexmock(status=200, raise_for_status=lambda: None, json=_get_transitions)

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -36,6 +36,46 @@ else:
 SEVERITY_CUSTOM_FIELD = "customfield_10840"
 TARGET_END_CUSTOM_FIELD = "customfield_10023"
 EMBARGO_CUSTOM_FIELD = "customfield_10860"
+FIXED_IN_BUILD_CUSTOM_FIELD = "customfield_10578"
+TEST_COVERAGE_CUSTOM_FIELD = "customfield_10638"
+PRELIMINARY_TESTING_CUSTOM_FIELD = "customfield_10879"
+ASSIGNED_TEAM_CUSTOM_FIELD = "customfield_10371"
+ERRATA_LINK_CUSTOM_FIELD = "customfield_10418"
+ERRATA_LINK_FALLBACK_CUSTOM_FIELD = "customfield_10626"
+
+# Fields requested from the Jira API by GetJiraDetailsTool.
+# Passed as the ``fields`` query parameter so the server only returns what
+# agents actually consume (see Jira API best-practices for field filtering).
+_REQUESTED_FIELDS = [
+    "summary",
+    "description",
+    "status",
+    "labels",
+    "components",
+    "fixVersions",
+    "comment",
+    "issuelinks",
+    "versions",
+    "attachment",
+    "resolution",
+    "issuetype",
+    "priority",
+    "reporter",
+    "assignee",
+    "creator",
+    "created",
+    "updated",
+    "security",
+    FIXED_IN_BUILD_CUSTOM_FIELD,
+    TEST_COVERAGE_CUSTOM_FIELD,
+    PRELIMINARY_TESTING_CUSTOM_FIELD,
+    ASSIGNED_TEAM_CUSTOM_FIELD,
+    ERRATA_LINK_CUSTOM_FIELD,
+    ERRATA_LINK_FALLBACK_CUSTOM_FIELD,
+    SEVERITY_CUSTOM_FIELD,
+    TARGET_END_CUSTOM_FIELD,
+    EMBARGO_CUSTOM_FIELD,
+]
 
 RH_EMPLOYEE_GROUP = "Red Hat Employee"
 
@@ -80,6 +120,52 @@ class GetJiraDetailsTool(Tool[GetJiraDetailsToolInput, ToolRunOptions, JSONToolO
             creator=self,
         )
 
+    @staticmethod
+    def _remove_avatar_urls(obj: Any) -> Any:
+        """Recursively strip ``avatarUrls`` keys from dicts and lists."""
+        if isinstance(obj, dict):
+            return {k: GetJiraDetailsTool._remove_avatar_urls(v) for k, v in obj.items() if k != "avatarUrls"}
+        if isinstance(obj, list):
+            return [GetJiraDetailsTool._remove_avatar_urls(item) for item in obj]
+        return obj
+
+    @staticmethod
+    def _filter_remote_links(remote_links: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Trim remote link objects to only the data agents use."""
+        cleaned = []
+        for link in remote_links:
+            obj = link.get("object", {})
+            entry: dict[str, Any] = {"id": link.get("id")}
+            if link.get("relationship"):
+                entry["relationship"] = link["relationship"]
+            if obj:
+                entry["object"] = {k: v for k, v in obj.items() if k in ("url", "title", "summary")}
+            cleaned.append(entry)
+        return cleaned
+
+    @staticmethod
+    def _postprocess_issue_data(issue_data: dict[str, Any]) -> dict[str, Any]:
+        """Clean up a Jira API response before returning it to agents.
+
+        Field selection is handled at the API level via the ``fields`` query
+        parameter (``_REQUESTED_FIELDS``).  This function handles the
+        remaining cleanup that the Jira API cannot do: stripping
+        ``avatarUrls`` and trimming remote-link objects.
+        """
+        result: dict[str, Any] = {
+            "key": issue_data.get("key"),
+            "id": issue_data.get("id"),
+            "fields": issue_data.get("fields", {}),
+        }
+
+        remote_links = issue_data.get("remote_links")
+        if isinstance(remote_links, list):
+            result["remote_links"] = GetJiraDetailsTool._filter_remote_links(remote_links)
+        else:
+            result["remote_links"] = remote_links
+
+        return GetJiraDetailsTool._remove_avatar_urls(result)
+
     async def _run(
         self,
         tool_input: GetJiraDetailsToolInput,
@@ -96,7 +182,7 @@ class GetJiraDetailsTool(Tool[GetJiraDetailsToolInput, ToolRunOptions, JSONToolO
                 async with aiohttp_get_with_retries(
                     session,
                     jira_url,
-                    params={"expand": "comments"},
+                    params={"fields": ",".join(_REQUESTED_FIELDS), "expand": "comments"},
                     headers=headers,
                 ) as response:
                     response.raise_for_status()
@@ -119,7 +205,7 @@ class GetJiraDetailsTool(Tool[GetJiraDetailsToolInput, ToolRunOptions, JSONToolO
             except aiohttp.ClientError:
                 issue_data["remote_links"] = []
 
-        return JSONToolOutput(result=issue_data)
+        return JSONToolOutput(result=self._postprocess_issue_data(issue_data))
 
 
 class SetJiraFieldsToolInput(BaseModel):

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -54,15 +54,44 @@ async def test_get_jira_details():
     issue_data = {
         "key": issue_key,
         "id": "12345",
-        "fields": {"summary": "Test issue"},
-        "comment": {"comments": [{"body": "Test comment"}], "total": 1},
+        "fields": {
+            "summary": "Test issue",
+            "description": None,
+            "customfield_10578": "curl-8.0-1.el9",
+            "assignee": {
+                "displayName": "Dev One",
+                "emailAddress": "dev@redhat.com",
+                "avatarUrls": {"48x48": "https://jira/avatar/48"},
+            },
+            "comment": {
+                "comments": [
+                    {
+                        "id": "100",
+                        "body": "Test comment",
+                        "author": {
+                            "displayName": "Author",
+                            "avatarUrls": {"48x48": "https://jira/avatar/48"},
+                        },
+                        "created": "2024-01-01T00:00:00.000+0000",
+                    }
+                ],
+                "total": 1,
+            },
+        },
     }
     remote_links_data = [
         {
             "id": 10000,
+            "self": "https://jira/rest/api/2/issueLink/10000",
+            "globalId": "system=http://bugzilla",
+            "application": {"type": "com.atlassian.jira"},
+            "relationship": "relates to",
             "object": {
                 "url": "https://github.com/example/repo/pull/123",
                 "title": "Fix issue RHEL-12345",
+                "summary": "A pull request",
+                "icon": {"url16x16": "https://github.com/favicon.ico"},
+                "status": {"resolved": True},
             },
         }
     ]
@@ -71,6 +100,7 @@ async def test_get_jira_details():
     async def get(url, params=None, headers=None):
         if url.endswith(f"rest/api/3/issue/{issue_key}"):
             assert params.get("expand") == "comments"
+            assert "fields" in params, "fields parameter must be sent to the Jira API"
 
             async def json():
                 return issue_data
@@ -88,10 +118,126 @@ async def test_get_jira_details():
     flexmock(aiohttp.ClientSession).should_receive("get").replace_with(get)
 
     result = (await GetJiraDetailsTool().run(input={"issue_key": issue_key})).result
-    expected_result = issue_data.copy()
-    expected_result["remote_links"] = remote_links_data
 
-    assert result == expected_result
+    assert result["key"] == issue_key
+    assert result["id"] == "12345"
+    assert "expand" not in result
+    assert "self" not in result
+
+    # Null requested fields are preserved (agents check for None)
+    assert result["fields"]["description"] is None
+    assert result["fields"]["summary"] == "Test issue"
+    assert result["fields"]["customfield_10578"] == "curl-8.0-1.el9"
+
+    # avatarUrls stripped everywhere
+    assert "avatarUrls" not in result["fields"]["assignee"]
+    comment_author = result["fields"]["comment"]["comments"][0]["author"]
+    assert "avatarUrls" not in comment_author
+
+    # remote_links cleaned
+    rl = result["remote_links"][0]
+    assert rl["object"]["url"] == "https://github.com/example/repo/pull/123"
+    assert rl["object"]["title"] == "Fix issue RHEL-12345"
+    assert "icon" not in rl["object"]
+    assert "status" not in rl["object"]
+    assert "globalId" not in rl
+    assert "application" not in rl
+    assert "self" not in rl
+
+
+def test_postprocess_preserves_null_fields():
+    data = {
+        "key": "RHEL-1",
+        "id": "1",
+        "fields": {
+            "summary": "Bug",
+            "description": None,
+            "resolution": None,
+            "customfield_10578": "build-1.0",
+            "customfield_10879": None,
+        },
+        "remote_links": [],
+    }
+    result = GetJiraDetailsTool._postprocess_issue_data(data)
+    assert result["fields"]["summary"] == "Bug"
+    assert result["fields"]["description"] is None
+    assert result["fields"]["resolution"] is None
+    assert result["fields"]["customfield_10578"] == "build-1.0"
+    assert result["fields"]["customfield_10879"] is None
+
+
+def test_postprocess_avatar_urls_deeply_nested():
+    data = {
+        "key": "RHEL-1",
+        "id": "1",
+        "fields": {
+            "summary": "Bug",
+            "comment": {
+                "comments": [
+                    {
+                        "id": "1",
+                        "body": "text",
+                        "author": {
+                            "displayName": "Dev",
+                            "avatarUrls": {"48x48": "https://jira/av"},
+                        },
+                    }
+                ],
+            },
+            "reporter": {
+                "displayName": "Reporter",
+                "avatarUrls": {"48x48": "https://jira/av"},
+            },
+        },
+        "remote_links": [],
+    }
+    result = GetJiraDetailsTool._postprocess_issue_data(data)
+    assert "avatarUrls" not in result["fields"]["reporter"]
+    assert "avatarUrls" not in result["fields"]["comment"]["comments"][0]["author"]
+
+
+def test_postprocess_remote_links_cleaned():
+    data = {
+        "key": "RHEL-1",
+        "id": "1",
+        "fields": {"summary": "Bug"},
+        "remote_links": [
+            {
+                "id": 1,
+                "self": "https://jira/link/1",
+                "globalId": "system=http://bz",
+                "application": {"type": "com.atlassian.jira"},
+                "relationship": "relates to",
+                "object": {
+                    "url": "https://bugzilla/123",
+                    "title": "BZ#123",
+                    "summary": "Bug summary",
+                    "icon": {"url16x16": "https://bz/icon"},
+                    "status": {"resolved": True, "icon": {"url16x16": "https://bz/ok"}},
+                },
+            },
+            {
+                "id": 2,
+                "object": {"url": "https://github.com/pr/1"},
+            },
+        ],
+    }
+    result = GetJiraDetailsTool._postprocess_issue_data(data)
+    rl = result["remote_links"]
+    assert len(rl) == 2
+
+    assert rl[0]["id"] == 1
+    assert rl[0]["relationship"] == "relates to"
+    assert rl[0]["object"] == {
+        "url": "https://bugzilla/123",
+        "title": "BZ#123",
+        "summary": "Bug summary",
+    }
+    assert "self" not in rl[0]
+    assert "globalId" not in rl[0]
+    assert "application" not in rl[0]
+
+    assert rl[1]["object"] == {"url": "https://github.com/pr/1"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use the Jira API `fields` query parameter to request only the ~29 fields agents actually consume (20 standard + 9 custom) instead of receiving all ~174. Postprocess the response to strip avatarUrls unconditionally, drop null-valued fields, and trim remote-link objects to {id, relationship, object.{url, title, summary}}.

Teach the aiohttp mock to honour the `fields` parameter as well so that token consumption in MOCK_JIRA runs is representative. Also fix a pre-existing mock bug where remote_link=True was passed to flexmock instead of to the _read_jira_mock partial.
