### PR TITLE
Improve consistency of Jira refs in spec patch naming and changelog

### DIFF
--- a/ymir/agents/prompts/backport/instructions_zstream.j2
+++ b/ymir/agents/prompts/backport/instructions_zstream.j2
@@ -107,8 +107,12 @@ a backport that won't actually fix the shipped RPM.
           - Identify which files are new patch files and what spec changes
             were made.
           - Extract new patch file(s) added by the commit into the local
-            dist-git clone working tree:
-            `git -C <DISTGIT_SOURCE> show <commit_hash>:<patch_filename> > <LOCAL_CLONE>/<patch_filename>`
+            dist-git clone working tree. If the patch filename contains a
+            Jira issue key matching the pattern of <JIRA_ISSUE> that differs
+            from <JIRA_ISSUE>, replace only that key with <JIRA_ISSUE> and
+            keep the rest of the filename intact. Do NOT rename patches
+            otherwise. Ensure all resulting filenames are unique:
+            `git -C <DISTGIT_SOURCE> show <commit_hash>:<patch_filename> > <LOCAL_CLONE>/<target_filename>`
           - Examine the spec file changes for reference:
             `git -C <DISTGIT_SOURCE> diff <commit_hash>^..<commit_hash> -- *.spec`
           - Note what Patch tags and `%prep` entries were added. Use this as

--- a/ymir/agents/prompts/log/instructions.j2
+++ b/ymir/agents/prompts/log/instructions.j2
@@ -15,10 +15,12 @@ of changes performed, do the following:
 
    If a source changelog message is provided in the prompt, use those lines as the
    exact changelog message content. Keep the descriptive lines exactly as-is — do not
-   rephrase, summarize, or add to them. In any Resolves/Related lines, replace all
-   original Jira issue references with <JIRA_ISSUES>, ensuring no duplicates remain.
+   rephrase, summarize, or add to them. If the source changelog message contains
+   Jira references to the issue(s) it resolves, replace only those references with
+   <JIRA_ISSUES> — leave other Jira references that appear in descriptive text unchanged.
+   Match the format and style of the target spec file's changelog for Jira references.
 
-   If no source changelog message is provided, write a new entry. In general,
+   Otherwise, if no source changelog message is provided, write a new entry. In general,
    the entry should contain a short summary of the changes, ideally fitting on a single line,
    and a single line referencing all Jira issues. Use
    "- Resolves: <JIRA_ISSUES>" (comma-separated on one line) unless
@@ -26,7 +28,8 @@ of changes performed, do the following:
 
    IMPORTANT: The changelog entry should focus on user-facing changes only. Do not mention
    technical packaging details such as added/removed patches, changed BuildRequires,
-   or other spec file modifications that are not visible to end users.
+   or other spec file modifications that are not visible to end users. When reusing a source
+   changelog, do not supplement it with additional packaging details.
 
 4. Generate a title for commit message and merge request. It should be descriptive
    but shouldn't be longer than 80 characters.


### PR DESCRIPTION
As the title suggests these changes just improve Jira references in the spec file patch names and changelog entries when backporting. This is specifically to accommodate the older z-stream requirements. We have been running with these changes for a couple of weeks now and they seem to hold and do whats generally expected/accepted for older z-stream backports.