### PR TITLE
OpenAI API specs impose max 64 characters limit on tool names

### DIFF
--- a/ymir/agents/preliminary_testing_agent.py
+++ b/ymir/agents/preliminary_testing_agent.py
@@ -91,7 +91,7 @@ def create_preliminary_testing_agent(gateway_tools: list) -> ReasoningAgent:
             in [
                 "fetch_gitlab_mr_notes",
                 "get_jira_details",
-                "get_failed_pipeline_jobs_from_merge_request",
+                "get_failed_pipeline_jobs_from_mr",
             ]
         ],
         memory=UnconstrainedMemory(),

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -718,7 +718,7 @@ class GetFailedPipelineJobsFromMergeRequestTool(
         JSONToolOutput[list[FailedPipelineJob]],
     ]
 ):
-    name = "get_failed_pipeline_jobs_from_merge_request"
+    name = "get_failed_pipeline_jobs_from_mr"
     description = """
     Gets the failed pipeline jobs from the latest pipeline of a merge request.
     Returns a list of failed pipeline jobs with their details.
@@ -843,7 +843,7 @@ class GetAuthorizedCommentsFromMergeRequestTool(
         JSONToolOutput[list[MergeRequestComment]],
     ]
 ):
-    name = "get_authorized_comments_from_merge_request"
+    name = "get_authorized_comments_from_mr"
     description = """
     Gets all comments from a merge request, filtered to only include
     comments from authorized members with Developer role or higher.


### PR DESCRIPTION
This is something i ran into testing agents as skills with Claude Code using open weight models served by vLLM via OpenAI compatible API adapter. The problem is that OpenAI API spec limits tool names to 64 characters (which is a departure from the MCP spec where its up to 128 but its really up to implementation) and Claude Code prefixes everything so tool names blow up past 64 characters eg

mcp__ymir-privileged__get_failed_pipeline_jobs_from_merge_request

Since there is nothing that can be done about Claude Code behavior here its therefore a good workaround to shorten tool names where we can and where it doesnt compromise the meaning of those names so this PR does just that. 