### PR TITLE
Introduce Log Detective MCP server to agents

### DIFF
--- a/Containerfile.c9s-tests
+++ b/Containerfile.c9s-tests
@@ -40,7 +40,8 @@ RUN python3.11 -m venv --system-site-packages /opt/beeai-venv \
        rpkg \
        GitPython \
        nitrate \
-       tomli-w
+       tomli-w \
+       logdetective-mcp
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -42,7 +42,8 @@ RUN pip install --no-cache-dir \
       pytest-asyncio \
       rpm \
       rpkg \
-      specfile
+      specfile \
+      logdetective-mcp
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -40,6 +40,7 @@ This skill uses the following tools. Do not restrict tool usage — use any tool
 - `download_artifacts` — Download build log artifacts (*.log.gz)
 - `download_sources` — Download sources for a dist-git package
 - `get_patch_from_url` — Download patch content from a URL
+- `extract_log_snippets` — Extract representative log snippets from build logs using Drain3 clustering
 
 **Local Tools (text, filesystem, git, specfile):**
 - `create` — Create new files
@@ -158,8 +159,8 @@ If the backport fails (success=false), skip to **Step 10: Comment in JIRA** with
 
 When analyzing build failures:
 1. Download all `*.log.gz` files returned in `artifacts_urls` (if any) using `download_artifacts`.
-2. Start with `builder-live.log` to identify the build failure. If not found, try `root.log`.
-3. IMPORTANT: Before viewing log files, check their size using `wc -l` command. If a log file has more than 2000 lines, use the view tool with offset and limit parameters to read only the LAST 1000 lines.
+2. Use `extract_log_snippets` with `log_path` pointing to `builder-live.log` to extract the most relevant snippets. If `builder-live.log` is not available, try `root.log` instead.
+3. Analyze the returned snippets to identify the build failure.
 4. Summarize the failure as the `build_error` for the retry.
 5. Remove the downloaded `*.log.gz` files after analysis.
 

--- a/agents_as_skills/rebase/SKILL.md
+++ b/agents_as_skills/rebase/SKILL.md
@@ -38,6 +38,7 @@ This skill uses the following tools. Do not restrict tool usage — use any tool
 - `get_maintainer_rules` — Get maintainer-specific rules and guidelines for a package
 - `build_package` — Build an SRPM and return results
 - `download_artifacts` — Download build log artifacts (*.log.gz)
+- `extract_log_snippets` — Extract representative log snippets from build logs using Drain3 clustering
 
 **Local Tools (text, filesystem, git, specfile):**
 - `create` — Create new files
@@ -134,8 +135,8 @@ If the rebase fails (success=false), skip to **Step 9: Comment in JIRA** with th
 
 When analyzing build failures:
 1. Download all `*.log.gz` files returned in `artifacts_urls` (if any) using `download_artifacts`.
-2. Start with `builder-live.log` to identify the build failure. If not found, try `root.log`.
-3. IMPORTANT: Before viewing log files, check their size using `wc -l` command. If a log file has more than 2000 lines, use the view tool with offset and limit parameters to read only the LAST 1000 lines.
+2. Use `extract_log_snippets` with `log_path` pointing to `builder-live.log` to extract the most relevant snippets. If `builder-live.log` is not available, try `root.log` instead.
+3. Analyze the returned snippets to identify the build failure.
 4. Summarize the failure as the `build_error` for the retry.
 5. Remove the downloaded `*.log.gz` files after analysis.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ beautifulsoup4>=4.13.4
 beeai-framework[duckduckgo]==0.1.80
 copr>=1.129
 fastmcp>=2.11.3
+logdetective-mcp>=0.1.0
 ogr>=0.55.0
 openinference-instrumentation-beeai>=0.1.8
 redis>=6.4.0

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -163,7 +163,13 @@ async def create_backport_agent(
 
     # Add build tools if requested (for iterative build error fixing)
     if include_build_tools:
-        base_tools.extend([t for t in mcp_tools if t.name in ["build_package", "download_artifacts"]])
+        base_tools.extend(
+            [
+                t
+                for t in mcp_tools
+                if t.name in ["build_package", "download_artifacts", "extract_log_snippets"]
+            ]
+        )
 
     return ReasoningAgent(
         name="BackportAgent",

--- a/ymir/agents/build_agent.py
+++ b/ymir/agents/build_agent.py
@@ -54,7 +54,7 @@ def create_build_agent(mcp_tools: list[Tool], local_tool_options: dict[str, Any]
             SearchTextTool(options=local_tool_options),
             GetCWDTool(options=local_tool_options),
         ]
-        + [t for t in mcp_tools if t.name in ["build_package", "download_artifacts"]],
+        + [t for t in mcp_tools if t.name in ["build_package", "download_artifacts", "extract_log_snippets"]],
         memory=UnconstrainedMemory(),
         requirements=[
             ConditionalRequirement(
@@ -66,6 +66,7 @@ def create_build_agent(mcp_tools: list[Tool], local_tool_options: dict[str, Any]
             ),
             ConditionalRequirement("build_package", min_invocations=1),
             ConditionalRequirement("download_artifacts", only_after=["build_package"]),
+            ConditionalRequirement("extract_log_snippets", only_after=["download_artifacts"]),
         ],
         middlewares=[GlobalTrajectoryMiddleware(pretty=True)],
         role="Red Hat Enterprise Linux developer",

--- a/ymir/agents/prompts/backport/prompt_fix_build_error.j2
+++ b/ymir/agents/prompts/backport/prompt_fix_build_error.j2
@@ -60,7 +60,10 @@ SPECIAL CONSIDERATIONS FOR TEST FAILURES:
    - Use the `run_package_prep` tool to verify patches apply cleanly
    - Use the `build_srpm` tool to generate a SRPM
    - Call `build_package` with the SRPM path, dist_git_branch, and jira_issue
-   - If build fails: use `download_artifacts` to get logs and identify the new error
+   - If build fails: use `download_artifacts` to get logs, then use
+     `extract_log_snippets` with `log_path` pointing to `builder-live.log`
+     (or `root.log` if unavailable) to extract the most relevant snippets
+     and identify the new error
 
 6. Append a summary to {{ local_clone }}-upstream/build-logs/fix-attempts.md documenting:
    - What you identified as the root cause

--- a/ymir/agents/prompts/build/instructions.j2
+++ b/ymir/agents/prompts/build/instructions.j2
@@ -3,7 +3,8 @@ You are an expert on building packages in RHEL ecosystem and analyzing build fai
 Build a package using the `build_package` tool. If the build succeeded, your work is done.
 If the build failed, download all *.log.gz files returned in `artifacts_urls`, if any,
 using the `download_artifacts` tool to the current directory. If there are no log files,
-just return the error message. Otherwise, start with `builder-live.log` and try to identify
+just return the error message. Otherwise, use the `extract_log_snippets` tool with
+`log_path` pointing to the location of `builder-live.log` and try to identify
 the build failure. If not found, try the same with `root.log`. Summarize the findings
 and return them as `error`. Set `is_timeout` to the value of the `is_timeout` field
 from the `build_package` tool output.

--- a/ymir/tools/gateway_utils.py
+++ b/ymir/tools/gateway_utils.py
@@ -6,6 +6,8 @@ import re
 from typing import Any
 
 from beeai_framework.emitter.emitter import Emitter
+from beeai_framework.tools.mcp import MCPTool
+from mcp import StdioServerParameters, stdio_client
 
 from ymir.common.logging_setup import configure_logging
 
@@ -56,3 +58,10 @@ def setup_logging():
     Emitter.root().on(re.compile(r"^tool\..+\.start$"), on_tool_start)
     Emitter.root().on(re.compile(r"^tool\..+\.success$"), on_tool_success)
     Emitter.root().on(re.compile(r"^tool\..+\.error$"), on_tool_error)
+
+
+async def get_log_detective_mcp() -> list[MCPTool]:
+    """Get MCP tools provided by Log Detective MCP server."""
+    client = stdio_client(StdioServerParameters(command="logdetective-mcp"))
+
+    return await MCPTool.from_client(client)

--- a/ymir/tools/privileged/gateway.py
+++ b/ymir/tools/privileged/gateway.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import re
@@ -11,7 +12,7 @@ from beeai_framework.adapters.mcp.serve.server import (
 
 from ymir.common.base_utils import parse_klist_principals
 from ymir.common.mock_repos import apply_zstream_override_from_env
-from ymir.tools.gateway_utils import setup_logging
+from ymir.tools.gateway_utils import get_log_detective_mcp, setup_logging
 from ymir.tools.privileged.copr import BuildPackageTool, DownloadArtifactsTool
 from ymir.tools.privileged.distgit import CreateZstreamBranchTool
 from ymir.tools.privileged.errata import GetErratumBuildNvrTool, GetErratumTool
@@ -103,7 +104,7 @@ def _kerberos_principal() -> str | None:
     return None
 
 
-def main():
+async def _async_main():
     transport = os.getenv("MCP_TRANSPORT", "sse")
     config_kwargs = {"name": "Ymir Privileged MCP Gateway", "transport": transport}
     if transport == "sse":
@@ -117,6 +118,10 @@ def main():
     apply_zstream_override_from_env()
     tool_options: dict = {"working_directory": None}
     mcp = MCPServer(config=config)
+
+    # Get available tools from Log Detective MCP server
+    log_detective_tools = await get_log_detective_mcp()
+
     mcp.register_many(
         [
             BuildPackageTool(options=tool_options),
@@ -159,10 +164,15 @@ def main():
             UploadSourcesTool(options=tool_options),
             ZStreamSearchTool(options=tool_options),
             MaintainerRulesTool(options=tool_options),
+            *log_detective_tools,
         ]
     )
 
-    mcp.serve()
+    await mcp.aserve()
+
+
+def main():
+    asyncio.run(_async_main())
 
 
 if __name__ == "__main__":

--- a/ymir/tools/privileged/tests/unit/test_gateway.py
+++ b/ymir/tools/privileged/tests/unit/test_gateway.py
@@ -198,6 +198,10 @@ class TestRedactFunction:
             assert "[REDACTED]" not in result
 
 
+async def mock_aserve():
+    pass
+
+
 class TestGatewaySharedOptions:
     def test_all_tools_share_options_dict(self):
         registered_tools = []
@@ -206,7 +210,7 @@ class TestGatewaySharedOptions:
         mock_server.should_receive("register_many").once().replace_with(
             lambda tools: registered_tools.extend(tools)
         )
-        mock_server.should_receive("serve").once()
+        mock_server.should_receive("aserve").once().replace_with(mock_aserve)
 
         import ymir.tools.privileged.gateway as gateway_module
 
@@ -220,6 +224,9 @@ class TestGatewaySharedOptions:
         first_options = registered_tools[0].options
         assert first_options is not None
         for tool in registered_tools[1:]:
+            if tool.name == "extract_log_snippets":
+                # extract_log_snippets from Log Detective doesn't need shared options
+                continue
             assert tool.options is first_options, (
                 f"{type(tool).__name__} does not share the same options dict"
             )

--- a/ymir/tools/privileged/tests/unit/test_gateway_utils.py
+++ b/ymir/tools/privileged/tests/unit/test_gateway_utils.py
@@ -1,0 +1,61 @@
+"""Unit tests for ymir.tools.gateway_utils.get_log_detective_mcp."""
+
+import pytest
+from beeai_framework.tools.mcp import MCPTool
+from flexmock import flexmock
+from mcp import StdioServerParameters
+
+import ymir.tools.gateway_utils as gateway_utils_module
+from ymir.tools.gateway_utils import get_log_detective_mcp
+
+
+def _create_async_return(value):
+    """Wrap a value in a coroutine so it can be awaited."""
+
+    async def async_return(*args, **kwargs):
+        return value
+
+    return async_return()
+
+
+class TestGetLogDetectiveMcp:
+    @pytest.mark.asyncio
+    async def test_returns_tools_from_mcp_server(self):
+        expected_tools = [flexmock(name="extract_log_snippets")]
+
+        mock_client = flexmock()
+        flexmock(gateway_utils_module).should_receive("stdio_client").once().and_return(mock_client)
+        flexmock(MCPTool).should_receive("from_client").with_args(mock_client).once().and_return(
+            _create_async_return(expected_tools)
+        )
+
+        result = await get_log_detective_mcp()
+
+        assert result == expected_tools
+
+    @pytest.mark.asyncio
+    async def test_passes_logdetective_mcp_command(self):
+        mock_client = flexmock()
+
+        def verify_params(params):
+            assert isinstance(params, StdioServerParameters)
+            assert params.command == "logdetective-mcp"
+            return mock_client
+
+        flexmock(gateway_utils_module).should_receive("stdio_client").replace_with(verify_params)
+        flexmock(MCPTool).should_receive("from_client").with_args(mock_client).once().and_return(
+            _create_async_return([])
+        )
+
+        await get_log_detective_mcp()
+
+    @pytest.mark.asyncio
+    async def test_propagates_runtime_error(self):
+        mock_client = flexmock()
+        flexmock(gateway_utils_module).should_receive("stdio_client").once().and_return(mock_client)
+        flexmock(MCPTool).should_receive("from_client").with_args(mock_client).once().and_raise(
+            RuntimeError("MCP Client Session has been destroyed.")
+        )
+
+        with pytest.raises(RuntimeError, match="MCP Client Session has been destroyed"):
+            await get_log_detective_mcp()

--- a/ymir/tools/requirements.txt
+++ b/ymir/tools/requirements.txt
@@ -11,3 +11,4 @@ requests-gssapi>=1.3.0
 rpm>=0.4.0
 rpkg>=1.65
 specfile>=0.36.0
+logdetective-mcp>=0.1.0


### PR DESCRIPTION
The MCP server is introduced as a tool provided by the privileged gateway.

Since Log Detective is a standard MCP server, it has to be wrapped in `MCPTool`[1] from beeai framework to be accessible as a tool. This requires certain changes in the gateway code, turning `main` into effectively async function. That being said, their behavior remains essentially the same. 

I am open to moving the async boundary into utility function. The current arrangement is merely my preference.

[1] https://framework.beeai.dev/modules/tools#using-stdio-transport

RELEASE NOTES BEGIN

Log Detective MCP server is now included in the Ymir backport and build agents. Instructions for the server usage were also added to the backport and rebase skills.

RELEASE NOTES END
