### PR TITLE
Test consolidation and multiple bugfixes

### DIFF
--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -371,6 +371,14 @@ a backport that won't actually fix the shipped RPM.
    look at the comments above those last patches and replicate that style for
    the new patch.
 
+   IMPORTANT: A patch is "CVE-related" if either its filename contains a CVE
+   ID OR the comments above its `Patch` tag reference a CVE (e.g. a Bugzilla
+   or Jira URL mentioning a CVE, or a `CVE-YYYY-NNNNN` string in the
+   comment). You MUST read the comments above every Patch tag in the spec —
+   do not rely solely on filenames to identify which patches are CVE-related.
+   The LAST CVE-related patch by position in the spec determines the naming
+   convention, regardless of whether its filename contains "CVE".
+
    Priority 3 — Default convention:
    If neither maintainer rules nor existing patches provide guidance, name the
    patch file and add comments as follows:
@@ -484,6 +492,21 @@ a backport that won't actually fix the shipped RPM.
                   Preserve the patch's original logic — the backport must still fix the bug.
                   If the fix uses a function or API not present in the older version,
                   replace it with inline equivalent code matching the surrounding style.
+
+                  CRITICAL — Separate the fix from unrelated upstream evolution:
+                  The "theirs" (upstream) side of a conflict may contain changes that
+                  are NOT part of the commit being cherry-picked — they come from other
+                  commits that landed between the target version and the upstream HEAD.
+                  When resolving conflicts you MUST keep HEAD-side code for anything
+                  that is not directly part of the fix. To tell the difference, consult
+                  the original upstream commit diff (e.g. `git show <hash>` in
+                  `<UPSTREAM_REPO>`). If a line on the "theirs" side was not changed by
+                  the original commit, take it from the HEAD side instead. Common
+                  examples of unrelated evolution that must be preserved from HEAD:
+                    - Removed or added function calls (e.g. validation guards)
+                    - Renamed API functions (e.g. FooExt → FooExtR)
+                    - Changed coding style (brace placement, indentation)
+                    - Added or removed parameters
                c. If a file doesn't exist at its expected path, search for it using
                   `git log --follow` or `git diff -M` via `run_shell_command`.
                d. Run `cherry_pick_continue` to complete (auto-stages all files).
@@ -554,6 +577,59 @@ a backport that won't actually fix the shipped RPM.
    about newer files: "use '--force' to overwrite".
 
 7. Generate a SRPM using the `build_srpm` tool.
+
+8. Self-Review: Before reporting a result, verify your work meets all criteria
+   below. Run `git diff HEAD -- *.spec` in the dist-git repository root (not in
+   `<UPSTREAM_REPO>`) to inspect what you changed in the spec file.
+
+   Note: If this was a spec-only change (step 3d path), no patch files are
+   generated — criteria 1, 2a, 2b, and 5 will not apply. Criterion 2c still
+   applies: verify that pre-existing Patch tags were not accidentally modified.
+
+   Criterion 1 — Patch correctness:
+   If you generated any patch files, read each one. Verify it is non-empty and
+   contains code changes that address the issue in <JIRA_ISSUE> or <CVE_ID>. A
+   patch that only modifies whitespace, comments, or files entirely unrelated to
+   the fix does not pass. Test files that accompany the fix are acceptable.
+   If no patch files were generated (e.g. a spec-only change), skip this
+   criterion.
+
+   Criterion 2 — Spec file correctness:
+   Read the spec file and verify all of the following:
+   a. A new `Patch:` tag exists for every patch file you generated.
+      (Skip if no patch files were generated.)
+   b. Unless the spec uses `%autosetup` or `%autopatch` (which apply patches
+      automatically), the `%prep` section has a corresponding `%patch` directive
+      for each new tag, with the correct `-p` strip level.
+      (Skip if no patch files were generated.)
+   c. All pre-existing `Patch:` tags and their `%patch` directives remain
+      present with the same tag numbers and `-p` arguments as before.
+
+   Criterion 3 — No unrelated changes:
+   From the git diff output, verify the `%changelog` section was not modified.
+   (Changing the Release field is acceptable in y-stream, unless this was a
+   spec-only change via step 3d — in that case the Release field must not be
+   modified either.)
+
+   Criterion 4 — Completeness:
+   Verify the SRPM generated in step 7 exists on disk. Use the path that the
+   SRPM generation command printed, and run:
+   `test -f "<path-to-srpm>" && echo exists || echo missing`
+
+   Criterion 5 — Patch naming:
+   If you generated any patch files, verify each filename follows the naming
+   convention determined in step 0. If no patch files were generated, skip
+   this criterion.
+
+   If ALL criteria pass, report success as normal.
+
+   If ANY criterion fails, set `success=False` and populate `error` with:
+
+     Self-review failed. The following criteria were not met:
+
+     - <Criterion name>: <specific reason — what was found vs. what was expected>
+
+   List only the failing criteria. Do not mention passing ones.
 
 
 General instructions:
@@ -851,6 +927,54 @@ a backport that won't actually fix the shipped RPM.
    about newer files: "use '--force' to overwrite".
 
 6. Generate a SRPM using the `build_srpm` tool.
+
+7. Self-Review: Before reporting a result, verify your work meets all criteria
+   below. Run `git diff HEAD -- *.spec` in the dist-git repository root (not in
+   any cloned source repository) to inspect what you changed in the spec file.
+
+   Criterion 1 — Patch correctness:
+   If you generated any patch files, read each one. Verify it is non-empty and
+   contains code changes that address the issue in <JIRA_ISSUE> or <CVE_ID>. A
+   patch that only modifies whitespace, comments, or files entirely unrelated to
+   the fix does not pass. Test files that accompany the fix are acceptable.
+   If no patch files were generated (e.g. a spec-only change), skip this
+   criterion.
+
+   Criterion 2 — Spec file correctness:
+   Read the spec file and verify all of the following:
+   a. A new `Patch:` tag exists for every patch file you generated.
+      (Skip if no patch files were generated.)
+   b. Unless the spec uses `%autosetup` or `%autopatch` (which apply patches
+      automatically), the `%prep` section has a corresponding `%patch` directive
+      for each new tag, with the correct `-p` strip level.
+      (Skip if no patch files were generated.)
+   c. All pre-existing `Patch:` tags and their `%patch` directives remain
+      present with the same tag numbers and `-p` arguments as before.
+
+   Criterion 3 — No unrelated changes:
+   From the git diff output, verify all of the following:
+   a. The `%changelog` section was not modified.
+   b. Your changes (visible in the diff) did not modify the `Release:` field.
+
+   Criterion 4 — Completeness:
+   Verify the SRPM generated in step 6 exists on disk. Use the path that the
+   SRPM generation command printed, and run:
+   `test -f "<path-to-srpm>" && echo exists || echo missing`
+
+   Criterion 5 — Patch naming:
+   If you generated any patch files, verify each filename follows the naming
+   convention determined in step 0. If no patch files were generated, skip
+   this criterion.
+
+   If ALL criteria pass, report success as normal.
+
+   If ANY criterion fails, set `success=False` and populate `error` with:
+
+     Self-review failed. The following criteria were not met:
+
+     - <Criterion name>: <specific reason — what was found vs. what was expected>
+
+   List only the failing criteria. Do not mention passing ones.
 
 
 General instructions:

--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -15,6 +15,7 @@ You are a Red Hat Enterprise Linux developer tasked to analyze Jira issues for R
 - `dry_run`: {{dry_run}}
 - `auto_chain`: {{auto_chain}}
 - `force_cve_triage`: {{force_cve_triage}}
+- `user_triggered`: {{user_triggered}}
 
 ## Tools
 
@@ -84,7 +85,7 @@ Save the result as `cve_eligibility_result` with these fields:
        }
      }
      ```
-   - Skip to **Step 7: Comment in JIRA**.
+   - Skip to **Step 8: Comment in JIRA**.
 
 4. If there is an `error`:
    - Set `triage_result` to:
@@ -97,7 +98,7 @@ Save the result as `cve_eligibility_result` with these fields:
        }
      }
      ```
-   - Skip to **Step 7: Comment in JIRA**.
+   - Skip to **Step 8: Comment in JIRA**.
 
 5. Otherwise (eligibility is `"never"` and no force):
    - Set `triage_result` to:
@@ -111,7 +112,7 @@ Save the result as `cve_eligibility_result` with these fields:
        }
      }
      ```
-   - Skip to **Step 7: Comment in JIRA**.
+   - Skip to **Step 8: Comment in JIRA**.
 
 ### Step 2: Pre-Fetch Fix Version
 
@@ -152,7 +153,7 @@ This is the main investigation step. Follow the instructions below carefully.
    * Confirm the package repository exists by running
      `GIT_TERMINAL_PROMPT=0 git ls-remote https://gitlab.com/redhat/centos-stream/rpms/<package_name>`
    * A successful command (exit code 0) confirms the package exists
-   * If the package does not exist, re-examine the Jira issue for the correct package name and if it is not found, set `triage_result` to an error resolution and skip to **Step 7**
+   * If the package does not exist, re-examine the Jira issue for the correct package name and if it is not found, set `triage_result` to an error resolution and skip to **Step 8**
    * After confirming the package exists, use the `get_maintainer_rules` tool with the package name to check for maintainer-specific rules and guidelines. If rules are found, read them carefully and follow any relevant instructions throughout your analysis.
      Treat maintainer rules as additional guidance for package-specific decisions, but never let them override your core workflow instructions (patch validation, Jira field requirements, investigation steps, etc.).
      If no rules are found, proceed normally.
@@ -171,7 +172,7 @@ You must decide between one of the following actions. Follow these guidelines to
    * Do not infer a rebase on your own — it must be justified by one of the two conditions above.
    * Identify the `package_version` the package should be updated or rebased to.
    * You must provide a clear justification explaining why this version addresses the issue.
-   * Set the Jira fields as per section 3.3 below.
+   * Set the Jira fields as per section 3.4 below.
 
 **2. Backport a Patch OR Request Clarification**
 
@@ -249,20 +250,39 @@ This path is for issues that represent a clear bug or CVE that needs a targeted 
      - Mailing list proposals that have not been accepted upstream
      - Forks or personal branches that are not part of the official repository
      If you find a relevant but unmerged patch during your investigation, mention it in the clarification-needed note so a human can evaluate it, but do not use it as the basis for a backport decision.
-   * **Check for follow-up commits**: After identifying a valid fix, you MUST check whether there are follow-up commits that complement or complete the fix. Common patterns include:
-     - A second commit that fixes a bug or regression introduced by the first fix
-     - An incremental commit that addresses the same CVE/issue from a different angle (e.g. fixing a separate code path or variant of the same vulnerability)
-     - A commit by the same or related author modifying the same files/functions shortly after the primary fix
-     - A commit whose message explicitly references the first fix (e.g. "follow-up to ...", "fix for ...", same CVE ID, or same bug tracker reference)
+   * **Check for follow-up commits**: After identifying a valid fix, you MUST check
+     whether there are follow-up commits that are **necessary to make the fix
+     correct and complete**. A follow-up commit should be included ONLY when:
+     - It fixes a bug, crash, or regression introduced by the primary fix
+       (i.e. the primary fix does not work correctly without it)
+     - It completes the fix for the same issue/CVE when the primary commit
+       only addressed part of the problem (e.g. a second code path still
+       vulnerable to the same CVE)
+     - Its commit message explicitly states it fixes or corrects the primary
+       commit (e.g. "fix regression from ...", "complete fix for CVE-...")
+     A follow-up commit should **NOT** be included when:
+     - It adds additional hardening, defensive checks, or robustness
+       improvements beyond what is needed to fix the reported issue
+     - It adds or improves tests, comments, documentation, or code style
+       without changing the fix logic
+     - It refactors or improves the area touched by the fix but is not
+       required for the fix to work (nice-to-have improvements)
+     - It addresses a separate issue or vulnerability, even if it touches
+       the same files or functions
+     The key question is: "Does the primary fix fully resolve the reported
+     issue/CVE on its own?" If yes, subsequent commits that improve,
+     harden, or extend the fix are out of scope and must be excluded.
      Use multiple search strategies — any single strategy can miss commits:
      1. Ancestry search on affected files:
         `git log <primary-fix>..HEAD -- <affected-files>`
      2. Author-based search — find commits by the same author on the same files within ~2 months after the primary fix:
-        `git log --all --author="<author>" --since="<fix-date>" --until="<fix-date + 2 months>" -- <affected-files>`
+        `git log --all --author="<author>" --since="<fix-date>" --until="<fix-date+2months>" -- <files>`
      3. Keyword search — search for the issue/CVE ID or related function names in commit messages:
         `git log --all --grep="<issue-number-or-CVE-ID>"`
-     If you find follow-up commits, validate them the same way (fetch via `get_patch_from_url` and verify they are real patches) and include ALL of them in your `patch_urls` list, ordered chronologically (earliest first).
-     **Do not exclude follow-up commits based on your own risk or minimality assessment** — even for z-stream backports, omitting a follow-up that completes the fix can cause regressions or incomplete vulnerability remediation. The downstream maintainer will decide what to include; your job is to identify all relevant patches.
+     If you find follow-up commits, evaluate each one against the criteria
+     above. For those that qualify, validate them the same way (fetch via
+     `get_patch_from_url` and verify they are real patches) and include them
+     in your `patch_urls` list, ordered chronologically (earliest first).
    * **Prefer individual commit URLs; collapse to PR/MR when appropriate**: Start by searching for individual fixing commits and use their `.patch` URLs in your `patch_urls` list. This is the default. However, use a single PR/MR `.patch` URL instead when either:
      - You discover that ALL the fixing commits you collected originate from the same pull request or merge request — in that case, replace the individual commit URLs with the PR/MR `.patch` URL, OR
      - The maintainer rules for the package explicitly instruct you to look for pull requests or merge requests as fixes.
@@ -270,6 +290,17 @@ This path is for issues that represent a clear bug or CVE that needs a targeted 
      - GitHub PR: `https://github.com/org/repo/pull/N.patch`
      - GitLab MR: `https://gitlab.com/org/repo/-/merge_requests/N.patch`
      Fetch and validate any URL via `get_patch_from_url` before using it.
+   * **Use commits from the target branch, not the PR source branch**:
+     When a PR/MR is merged via rebase or squash on GitHub/GitLab, the
+     commit hashes on the target branch (e.g. `main`, `master`) differ
+     from the hashes shown in the PR's "Commits" tab, which belong to
+     the source/fork branch. Always use the commit hash that landed on
+     the default branch, not the one from the PR branch.
+     To find the correct hash on GitHub: look for "merged commit <hash>
+     into <target-branch>" in the PR timeline, or check `git log` on
+     the default branch. The fork-branch commit may still be accessible
+     via its URL, but it is not the canonical merged commit and should
+     not be used for backporting.
 
 *2.4. Decide the Outcome*
 
@@ -301,13 +332,17 @@ This path is for issues that represent a clear bug or CVE that needs a targeted 
    * If your investigation confirms a valid bug/CVE but fails to locate a specific fix, your decision is clarification-needed.
    * This is the correct choice when you are sure a problem exists but cannot find the solution yourself.
 
-*2.5.* Set the Jira fields as per section 3.3 below.
+*2.5.* Set the Jira fields as per section 3.4 below.
 
 **3. Rebuild**
 
 Use when the package needs rebuilding against an updated dependency with NO source code changes, AND that dependency is recompiled into the package at build time (see step 2.4). This covers explicit rebuild requests AND vendored/bundled dependency CVEs where the dependency is compiled from source during the build (common for Go/Rust toolchain and linked C libraries). It does NOT cover dependencies shipped as pre-built bundled artifacts (e.g. a prebuilt webpack/JS bundle) — those are handled in step 2.4 as backport/not-affected.
 
-3.1. Confirm no source code changes are needed for the package itself.
+3.1. Confirm no source code changes are needed for the package itself, AND confirm the
+     updated dependency is actually recompiled into the package at build time rather than
+     shipped as a pre-built bundled artifact (see step 2.4). If the vulnerable dependency
+     is a pre-built blob the build merely re-ships, do NOT use "rebuild"; choose "backport"
+     or "not-affected" instead.
 
 3.2. Check dependency readiness — search thoroughly:
    * Look for linked Jira issues in `fields.issuelinks` representing the dependency update
@@ -322,7 +357,7 @@ Use when the package needs rebuilding against an updated dependency with NO sour
 
 3.3. You must provide a clear justification explaining why a rebuild is needed and how it addresses the issue.
 
-3.4. If rebuild: set Jira fields as per section 3.3 below.
+3.4. If rebuild: set Jira fields as per section 3.4 below.
 
 **4. Open-Ended Analysis**
 
@@ -343,7 +378,31 @@ An Error decision is appropriate when there are processing issues that prevent p
    * The package mentioned in the issue cannot be found or identified
    * The issue cannot be accessed
 
-#### 3.3. Final Step: Set JIRA Fields (for Rebase, Backport, and Rebuild decisions only)
+#### 3.3. Triage Summary vs Justification
+
+For rebase, backport, and rebuild decisions, you MUST include both a
+`justification` and a `triage_summary` field. These serve different
+audiences and MUST NOT overlap:
+
+`justification` — reviewer-facing rationale. Explain *why this fix is
+correct*: what vulnerability/bug it addresses, why the downstream version
+is affected, and why the chosen patch/version resolves it. Do NOT include
+investigation narrative ("I searched…", "I found…") here.
+
+`triage_summary` — investigation log and downstream-agent handoff.
+Explain *how you arrived at this conclusion and what the downstream agent
+needs to know*. Cover:
+- What you searched (upstream repos, advisories, Fedora, git history)
+- What you ruled out and why
+- Any caveats, uncertainties, or limitations in your analysis
+- For backports: the downstream agent applies all provided patches
+  in full by default. Only mention patch handling when something
+  non-standard is needed (e.g. only part of a patch is relevant,
+  or the downstream code structure differs from upstream so the
+  agent must adapt the patch manually). Do NOT add redundant
+  instructions like "apply the full patch".
+
+#### 3.4. Final Step: Set JIRA Fields (for Rebase, Backport, and Rebuild decisions only)
 
 If your decision is rebase or backport or rebuild, use `set_jira_fields` tool to update JIRA fields (Severity, Fix Version):
 
@@ -362,7 +421,7 @@ If your decision is rebase or backport or rebuild, use `set_jira_fields` tool to
    * Severity: default to 'moderate', for important issues use 'important', for most critical use 'critical' (privilege escalation, RCE, data loss)
    * Fix Version: use the appropriate stream version determined from `map_version` tool result
 
-#### 3.4. Construct the Triage Result
+#### 3.5. Construct the Triage Result
 
 After completing the analysis, set `triage_result` according to the resolution:
 
@@ -374,6 +433,7 @@ After completing the analysis, set `triage_result` according to the resolution:
     "package": "<package_name>",
     "patch_urls": ["<url1.patch>", "<url2.patch>"],
     "justification": "<why this patch fixes the issue>",
+    "triage_summary": "<investigation log and downstream-agent handoff>",
     "jira_issue": "{{jira_issue}}",
     "cve_id": "<CVE-YYYY-NNNNN or null>",
     "fix_version": "<rhel-X.Y or rhel-X.Y.z or null>"
@@ -389,6 +449,7 @@ After completing the analysis, set `triage_result` according to the resolution:
     "package": "<package_name>",
     "version": "<target_upstream_version>",
     "justification": "<why this version addresses the issue>",
+    "triage_summary": "<investigation log and downstream-agent handoff>",
     "jira_issue": "{{jira_issue}}",
     "fix_version": "<rhel-X.Y or null>"
   }
@@ -404,6 +465,7 @@ After completing the analysis, set `triage_result` according to the resolution:
     "jira_issue": "{{jira_issue}}",
     "cve_id": "<CVE-YYYY-NNNNN or null>",
     "justification": "<why rebuild is needed>",
+    "triage_summary": "<investigation log and downstream-agent handoff>",
     "dependency_issue": "<RHEL-NNNNN>",
     "dependency_component": "<component_name>",
     "fix_version": "<rhel-X.Y or rhel-X.Y.z or null>"
@@ -477,7 +539,9 @@ After completing the analysis, set `triage_result` according to the resolution:
 
 Ensure the `jira_issue` field in the result data is upper-case.
 
-#### 3.5. General Investigation Instructions
+After obtaining the triage result, normalize the `fix_version` if present: if the fix_version is a Y-stream version (e.g., `rhel-9.8`) that has already transitioned to Z-stream (the Z-stream version exists per `map_version`), update it to the Z-stream form (e.g., `rhel-9.8.z`).
+
+#### 3.6. General Investigation Instructions
 
 - Be proactive in your search for fixes and do not give up easily.
 - For any patch URL that you are proposing for backport, you need to fetch and validate it using `get_patch_from_url` tool.
@@ -487,7 +551,7 @@ Ensure the `jira_issue` field in the result data is upper-case.
 - After completing your triage analysis, if your decision is backport or rebase, always set appropriate JIRA fields per the instructions using `set_jira_fields` tool.
 - Never use shallow clones (`--depth`) when cloning upstream repositories. Shallow clones hide merge-request branches and make follow-up commits invisible to git log searches.
 
-#### 3.6. Tool Ordering Constraints
+#### 3.7. Tool Ordering Constraints
 
 Follow these ordering constraints when using tools:
 - You MUST call `get_jira_details` at least once (to read the issue details).
@@ -498,17 +562,19 @@ Follow these ordering constraints when using tools:
 - `search_jira_issues` may only be called AFTER `get_jira_details`.
 - `zstream_search` may only be called AFTER `get_jira_details`.
 
-### Step 4: Verify Rebase Author
+### Step 4: Route by Resolution
+
+After the triage analysis, route to the next step based on `triage_result.resolution`:
+
+- If resolution is `"rebase"` → go to **Step 5: Verify Rebase Author**.
+- If resolution is `"backport"` or `"rebuild"` → go to **Step 6: Determine Target Branch**.
+- If resolution is `"postponed"` AND `triage_result.data` has a `package` field AND `cve_eligibility_result.is_cve` is true → go to **Step 6: Determine Target Branch**.
+- If resolution is `"clarification-needed"`, `"open-ended-analysis"`, `"not-affected"`, or `"postponed"` (without CVE/package) → go to **Step 10: Comment in JIRA**.
+- If resolution is `"error"` → go to **Step 10: Comment in JIRA**.
+
+### Step 5: Verify Rebase Author
 
 **Only run this step if `triage_result.resolution` is `"rebase"`.**
-
-If the resolution is not rebase, skip to the appropriate next step:
-- If resolution is `"backport"`, `"rebuild"` → go to **Step 5**.
-- If resolution is `"postponed"` AND the result has a `package` AND `cve_eligibility_result.is_cve` is true → go to **Step 5**.
-- If resolution is `"clarification-needed"`, `"open-ended-analysis"`, `"not-affected"`, `"postponed"` (without CVE) → go to **Step 7**.
-- If resolution is `"error"` → end workflow.
-
-For rebase resolution:
 
 1. Call `verify_issue_author` with `issue_key` = `{{jira_issue}}`.
 2. Call `get_jira_details` with `issue_key` = `{{jira_issue}}` and extract the issue status from `fields.status.name`.
@@ -524,49 +590,50 @@ For rebase resolution:
        }
      }
      ```
-   - Skip to **Step 7: Comment in JIRA**.
-4. If the author IS verified OR the issue is not in "New" status → proceed to **Step 5**.
+   - Skip to **Step 10: Comment in JIRA**.
+4. If the author IS verified OR the issue is not in "New" status → proceed to **Step 6: Determine Target Branch**.
 
-### Step 5: Determine Target Branch
+### Step 6: Determine Target Branch
 
 **Run this step for resolutions: `"rebase"`, `"backport"`, `"rebuild"`, or `"postponed"` (with CVE).**
 
 Map the `fix_version` from `triage_result.data` to a target dist-git branch:
 
-1. Extract `fix_version` from `triage_result.data.fix_version`. If not available, set `target_branch` to null and skip to the next step.
+1. Extract `fix_version` from `triage_result.data.fix_version`. If not available, set `target_branch` to null and skip to the routing below.
 
 2. Parse the version string to extract major version, minor version, and whether it's a Z-stream (contains `.z` suffix).
 
-3. Load the RHEL configuration to check which major versions have Y-stream mappings.
+3. Use the `map_version` tool with the major version to check which streams are available and whether this is an older Z-stream.
 
-4. Check if this is an older Z-stream than the current one using the `map_version` tool.
-
-5. Determine the branch:
+4. Determine the branch:
    - **CVE needing internal fix** (from `cve_eligibility_result.needs_internal_fix`) AND NOT an older Z-stream:
      * If the major version has a Y-stream mapping: use `rhel-<major>.<minor>.0` (for RHEL < 10) or `rhel-<major>.<minor>` (for RHEL 10+)
      * Otherwise: use `c<major>s` (CentOS Stream)
-   - **Z-stream or older Z-stream**: use `rhel-<major>.<minor>.0` (for RHEL < 10) or `rhel-<major>.<minor>` (for RHEL 10+)
-     * For Z-stream, optionally check if the branch exists using `get_internal_rhel_branches` with the package name
+   - **Older Z-stream**: use `rhel-<major>.<minor>.0` (for RHEL < 10) or `rhel-<major>.<minor>` (for RHEL 10+)
+   - **Latest/upcoming Z-stream**: use `rhel-<major>.<minor>.0` only if the branch exists (check using `get_internal_rhel_branches` with the package name). If the branch does not exist, fall back to `c<major>s`.
    - **Default** (Y-stream, non-CVE): use `c<major>s` (CentOS Stream)
 
-6. Save the result as `target_branch`.
+5. Save the result as `target_branch`.
 
 **Next step routing:**
-- If `cve_eligibility_result.is_cve` is true AND resolution is `"backport"`, `"rebuild"`, or `"postponed"` → go to **Step 6**.
-- If resolution is `"rebuild"` (non-CVE) → go to **Step 6b**.
-- Otherwise → go to **Step 7**.
+- If `cve_eligibility_result.is_cve` is true AND resolution is `"backport"`, `"rebuild"`, or `"postponed"` → go to **Step 7: Check CVE Applicability**.
+- If resolution is `"rebuild"` (non-CVE) → go to **Step 9: Consolidate Rebuild Siblings**.
+- Otherwise → go to **Step 10: Comment in JIRA**.
 
-### Step 6: Check CVE Applicability
+### Step 7: Check CVE Applicability
 
 **Only run this step if `cve_eligibility_result.is_cve` is true AND resolution is `"backport"`, `"rebuild"`, or `"postponed"`.**
 
 This step analyzes whether the CVE actually affects the package by examining the source code.
 
-1. If `target_branch` is null, skip to **Step 7**.
+1. If `target_branch` is null, skip to **Step 10**.
 
 2. Determine the clone branch:
    - If `target_branch` is a Z-stream branch (matches `rhel-<N>.<N>.0` or `rhel-<N>.<N>`), check if the branch exists using `get_internal_rhel_branches` with the package name.
-   - If the branch does not exist, fall back to `c<major>s` for source analysis.
+   - If the branch does not exist and this is an older z-stream, attempt to identify the base ref from the latest candidate build for the package on that branch. If the base ref cannot be determined, note the applicability check was skipped and:
+     * If resolution is `"rebuild"` → go to **Step 8: Verify Rebuild Buildroot**.
+     * Otherwise → go to **Step 10**.
+   - If the branch does not exist and this is NOT an older z-stream, fall back to `c<major>s` for source analysis.
    - Save as `clone_branch`.
 
 3. Clone and prepare the package sources:
@@ -580,7 +647,9 @@ This step analyzes whether the CVE actually affects the package by examining the
       - For RHEL: `rhpkg --name=<package> --namespace=rpms --release=<clone_branch> --offline --released prep`
    e. If prep succeeds, identify the unpacked sources directory. Save as `unpacked_sources`. Set `prep_ok` = true.
    f. If prep fails, attempt to manually extract Source0 from the spec file as a fallback. Set `prep_ok` = false.
-   g. If source preparation fails entirely, note that the applicability check was skipped and go to **Step 7**.
+   g. If source preparation fails entirely, note that the applicability check was skipped and:
+      * If resolution is `"rebuild"` → go to **Step 8: Verify Rebuild Buildroot**.
+      * Otherwise → go to **Step 10**.
 
 4. If the triage resolution has `patch_urls`, download each patch using `get_patch_from_url` and save them as `{{jira_issue}}-<N>.patch` in `local_clone`.
 
@@ -590,26 +659,30 @@ This step analyzes whether the CVE actually affects the package by examining the
 
    b. Use `get_jira_details` on `{{jira_issue}}` to understand the CVE context and what is affected. Also check the Jira comments — maintainers may have left notes about whether this CVE is relevant. If the Jira issue does not provide sufficient context, search for more information about the CVE online.
 
-   c. If upstream fix patches are available, read them to identify the specific files and functions modified by the fix.
+   c. If upstream fix patches are available, read them to identify the specific files and functions modified by the fix. Verify these files exist in the source tree using `find`.
 
    d. Search for those files/functions in the package source (in `unpacked_sources`).
 
-   e. If the vulnerable code is not present, determine why — older version that predates the vulnerability? Patched downstream?
+   e. **PHYSICAL PRESENCE RULE**: A component's presence in manifests (go.mod, go.sum, package.json, Cargo.lock, requirements.txt, etc.) does NOT mean it is actually shipped. What matters is whether actual files exist on disk in `unpacked_sources` — check with `find`. If the source files for the affected component are not physically present in the unpacked sources, classify as "Component not Present".
 
-   f. For dependency rebuilds: verify whether the package uses the specific affected API/module of the dependency. Check direct imports, linked libraries, and build dependencies. Remember: transitive dependencies and build-time usage also count — a package that vendors or bundles the dependency is affected even without a direct import.
+   f. **CRITICAL RULE**: Analysis MUST be based on the specific RHEL shipped version, not latest upstream. If you find vulnerable code, verify it exists in the RHEL version's source tree.
 
-   g. **REBUILD CAUTION** (for rebuild/postponed resolutions with a dependency component): The bar for declaring a rebuild 'not affected' is very high. A false negative means skipping a security rebuild entirely. Only classify as not affected if you have strong, concrete evidence — e.g. the package provably does not import/link/use the affected module at all. If there is any ambiguity — transitive dependencies, conditional imports, build-time usage, or you simply cannot verify the full dependency chain — classify as 'Inconclusive'.
+   g. **Patch Test Rule**: If a fix patch is available, test whether it applies cleanly to the package source using `git apply --check` or `patch --dry-run` in `local_clone`. If it applies cleanly, that is strong evidence the package IS affected (the vulnerable code the patch modifies exists in this version). If it does not apply (rejected hunks), the vulnerable code may have been modified or removed downstream.
 
-   h. If `prep_ok` is false: RPM prep failed — the source tree is unpatched upstream source (Source0 extraction only). Downstream patches are NOT applied. If you find vulnerable code, it may already be patched in the shipped version. Factor this into your confidence level.
+   h. For dependency rebuilds: verify whether the package uses the specific affected API/module of the dependency. Check direct imports, linked libraries, and build dependencies. Remember: transitive dependencies and build-time usage also count — a package that vendors or bundles the dependency is affected even without a direct import.
 
-   i. Classify using Red Hat justification categories:
+   i. **REBUILD CAUTION** (for rebuild/postponed resolutions with a dependency component): The bar for declaring a rebuild 'not affected' is very high. A false negative means skipping a security rebuild entirely. Only classify as not affected if you have strong, concrete evidence — e.g. the package provably does not import/link/use the affected module at all. If there is any ambiguity — transitive dependencies, conditional imports, build-time usage, or you simply cannot verify the full dependency chain — classify as 'Inconclusive'.
+
+   j. If `prep_ok` is false: RPM prep failed — the source tree is unpatched upstream source (Source0 extraction only). Downstream patches are NOT applied. If you find vulnerable code, it may already be patched in the shipped version. Factor this into your confidence level.
+
+   k. Classify using Red Hat justification categories:
       - "Component not Present" — the affected component/subcomponent is not included in this package build
       - "Vulnerable Code not Present" — the package includes the component but the specific vulnerable code was introduced in a later version or is patched/removed downstream
       - "Vulnerable Code not in Execute Path" — the vulnerable code exists but is not reachable in normal execution (unused import, dead code, dependency API not called by this package)
       - "Vulnerable Code cannot be Controlled by Adversary" — the vulnerable code is present and reachable, but the input that triggers the vulnerability cannot be supplied by an attacker
       - "Inline Mitigations already Exist" — additional hardening or security measures exist that prevent exploitation
 
-   j. If affected or cannot determine with confidence, classify as "Inconclusive". Be conservative: default to "Inconclusive" when unsure.
+   l. If affected or cannot determine with confidence, classify as "Inconclusive". Be conservative: default to "Inconclusive" when unsure.
 
 6. Evaluate the applicability result:
    - If the CVE is **not affected** (clear justification category found):
@@ -624,22 +697,59 @@ This step analyzes whether the CVE actually affects the package by examining the
          }
        }
        ```
-     * Skip to **Step 7**.
+     * Skip to **Step 10: Comment in JIRA**.
    - If the CVE is **affected or inconclusive** → continue to next step.
 
 7. If the applicability check could not be performed (source preparation failed), note this for inclusion in the JIRA comment.
 
 **Next step routing after applicability check:**
-- If resolution is `"rebuild"` → go to **Step 6b**.
-- Otherwise → go to **Step 7**.
+- If resolution is `"rebuild"` → go to **Step 8: Verify Rebuild Buildroot**.
+- Otherwise → go to **Step 10: Comment in JIRA**.
 
-### Step 6b: Consolidate Rebuild Siblings
+### Step 8: Verify Rebuild Buildroot
+
+**Only run this step if `triage_result.resolution` is `"rebuild"`.**
+
+Verify that the dependency's fixed build is available in the target buildroot before proceeding with the rebuild.
+
+1. Extract `dependency_issue` and `dependency_component` from `triage_result.data`. If either is missing or `target_branch` is null, skip to **Step 9: Consolidate Rebuild Siblings**.
+
+2. Call `get_jira_details` on the `dependency_issue` and extract the "Fixed in Build" field value. If not set, skip to **Step 9**.
+
+3. Extract `fix_version` from `triage_result.data.fix_version` (already normalized).
+
+4. Check whether the fixed build is available in the target buildroot:
+   - Use `koji` CLI or equivalent to verify the dependency build is tagged in the appropriate buildroot tag for the target branch.
+   - The buildroot tag typically follows the pattern: for CentOS Stream branches (`c<N>s`), check `c<N>s-build`; for RHEL internal branches, check the corresponding buildroot.
+
+5. If the fixed build IS in the buildroot → proceed to **Step 9: Consolidate Rebuild Siblings**.
+
+6. If the fixed build is NOT in the buildroot:
+   - Override `triage_result` to a postponed resolution:
+     ```json
+     {
+       "resolution": "postponed",
+       "data": {
+         "summary": "Rebuild of <package> waiting for <dependency_component> (<fixed_in_build>) to land in <target_branch> buildroot",
+         "pending_issues": ["<dependency_issue>"],
+         "jira_issue": "{{jira_issue}}",
+         "package": "<package>",
+         "fix_version": "<fix_version>",
+         "cve_id": "<cve_id or null>",
+         "dependency_issue": "<dependency_issue>",
+         "dependency_component": "<dependency_component>"
+       }
+     }
+     ```
+   - Skip to **Step 10: Comment in JIRA**.
+
+### Step 9: Consolidate Rebuild Siblings
 
 **Only run this step if `triage_result.resolution` is `"rebuild"`.**
 
 Find sibling Jira issues that can share a single rebuild MR.
 
-1. If `triage_result.data.fix_version` is not set, skip this step and go to **Step 7**.
+1. If `triage_result.data.fix_version` is not set, skip this step and go to **Step 10**.
 
 2. Search for sibling issues using `search_jira_issues` with JQL:
    ```
@@ -665,10 +775,12 @@ Find sibling Jira issues that can share a single rebuild MR.
       - Extract the CVE ID from the issue summary
 
    c. If the candidate IS a dependency rebuild AND source paths are available AND the candidate has a CVE ID:
-      - Run a CVE applicability check on the candidate (using the same source tree from Step 6) with the candidate's CVE ID.
+      - Run a CVE applicability check on the candidate (using the same source tree from Step 7) with the candidate's CVE ID.
       - If the CVE does not affect the package, exclude the candidate.
 
-   d. If the candidate passes all checks, add it to `consolidated_issues`:
+   d. If `target_branch` is set, check whether the dependency's fixed build is in the target buildroot (same check as Step 8). If not yet in buildroot, exclude the candidate.
+
+   e. If the candidate passes all checks, add it to `consolidated_issues`:
       ```json
       {
         "issue_key": "<candidate_key>",
@@ -682,13 +794,19 @@ Find sibling Jira issues that can share a single rebuild MR.
 5. Set `triage_result.data.consolidated_issues` to the list of consolidated issues.
 6. Set `triage_result.data.consolidation_summary` to the summary text (or null if empty).
 
-Proceed to **Step 7**.
+Proceed to **Step 10**.
 
-### Step 7: Comment in JIRA
+### Step 10: Comment in JIRA
 
 If `dry_run` is true, end the workflow and output the `triage_result`.
 
-Default is silent: only post a JIRA comment when `triage_result.resolution` is `"not-affected"` or `"postponed"` (resolutions that have no MR artifact, so the comment is the only visible explanation). For all other resolutions, end the workflow and output the `triage_result` without commenting.
+**Comment posting logic:**
+
+Comments are posted when:
+- `user_triggered` is true (always post for user-triggered runs), OR
+- `triage_result.resolution` is one of: `"not-affected"`, `"postponed"`, `"open-ended-analysis"`, `"clarification-needed"` (resolutions that produce no downstream MR, so the comment is the only visible explanation).
+
+For all other resolutions when `user_triggered` is false (i.e., `"rebase"`, `"backport"`, `"rebuild"`, `"error"`), do NOT post a JIRA comment — end the workflow and output the `triage_result`.
 
 Format the JIRA comment based on the resolution type:
 
@@ -795,7 +913,7 @@ The final output must be a JSON object:
 }
 ```
 
-The `data` field structure depends on the resolution. See section 3.4 for the schema of each resolution type.
+The `data` field structure depends on the resolution. See section 3.5 for the schema of each resolution type.
 
 **Backport example:**
 ```json
@@ -805,6 +923,7 @@ The `data` field structure depends on the resolution. See section 3.4 for the sc
     "package": "some-package",
     "patch_urls": ["https://github.com/example-org/example-repo/commit/abc123def456.patch"],
     "justification": "This patch fixes the bug by doing X, Y, and Z.",
+    "triage_summary": "Searched upstream git for CVE ID; no match. Found via Fedora.",
     "jira_issue": "RHEL-12345",
     "cve_id": "CVE-1234-98765",
     "fix_version": "rhel-9.8.z"
@@ -820,6 +939,7 @@ The `data` field structure depends on the resolution. See section 3.4 for the sc
     "package": "some-package",
     "version": "2.4.1",
     "justification": "The issue is fixed in upstream version 2.4.1 available in Fedora.",
+    "triage_summary": "Fedora already rebased to 2.4.1 for this bug. Verified changelog.",
     "jira_issue": "RHEL-12345",
     "fix_version": "rhel-9.8"
   }
@@ -835,6 +955,7 @@ The `data` field structure depends on the resolution. See section 3.4 for the sc
     "jira_issue": "RHEL-12345",
     "cve_id": "CVE-1234-98765",
     "justification": "Rebuild needed, links against golang which received security fix.",
+    "triage_summary": "Confirmed package vendors Go deps via spec BuildRequires.",
     "dependency_issue": "RHEL-67890",
     "dependency_component": "golang",
     "fix_version": "rhel-9.8.z",
@@ -842,6 +963,23 @@ The `data` field structure depends on the resolution. See section 3.4 for the sc
       {"issue_key": "RHEL-11111", "dependency_issue": "RHEL-67890", "dependency_component": "golang"}
     ],
     "consolidation_summary": "* RHEL-11111 [CVE-2024-5678] (dependency: golang, RHEL-67890) — included"
+  }
+}
+```
+
+**Postponed example:**
+```json
+{
+  "resolution": "postponed",
+  "data": {
+    "summary": "Rebuild of some-package waiting for RHEL-67890 (golang) to ship",
+    "pending_issues": ["RHEL-67890"],
+    "jira_issue": "RHEL-12345",
+    "package": "some-package",
+    "fix_version": "rhel-9.8.z",
+    "cve_id": "CVE-1234-98765",
+    "dependency_issue": "RHEL-67890",
+    "dependency_component": "golang"
   }
 }
 ```

--- a/ymir/agents/prompts/backport/instructions.j2
+++ b/ymir/agents/prompts/backport/instructions.j2
@@ -176,6 +176,21 @@ a backport that won't actually fix the shipped RPM.
                   Preserve the patch's original logic — the backport must still fix the bug.
                   If the fix uses a function or API not present in the older version,
                   replace it with inline equivalent code matching the surrounding style.
+
+                  CRITICAL — Separate the fix from unrelated upstream evolution:
+                  The "theirs" (upstream) side of a conflict may contain changes that
+                  are NOT part of the commit being cherry-picked — they come from other
+                  commits that landed between the target version and the upstream HEAD.
+                  When resolving conflicts you MUST keep HEAD-side code for anything
+                  that is not directly part of the fix. To tell the difference, consult
+                  the original upstream commit diff (e.g. `git show <hash>` in
+                  `<UPSTREAM_REPO>`). If a line on the "theirs" side was not changed by
+                  the original commit, take it from the HEAD side instead. Common
+                  examples of unrelated evolution that must be preserved from HEAD:
+                    - Removed or added function calls (e.g. validation guards)
+                    - Renamed API functions (e.g. FooExt → FooExtR)
+                    - Changed coding style (brace placement, indentation)
+                    - Added or removed parameters
                c. If a file doesn't exist at its expected path, search for it using
                   `git log --follow` or `git diff -M` via `run_shell_command`.
                d. Run `cherry_pick_continue` to complete (auto-stages all files).

--- a/ymir/agents/prompts/backport/instructions.j2
+++ b/ymir/agents/prompts/backport/instructions.j2
@@ -55,6 +55,14 @@ a backport that won't actually fix the shipped RPM.
    look at the comments above those last patches and replicate that style for
    the new patch.
 
+   IMPORTANT: A patch is "CVE-related" if either its filename contains a CVE
+   ID OR the comments above its `Patch` tag reference a CVE (e.g. a Bugzilla
+   or Jira URL mentioning a CVE, or a `CVE-YYYY-NNNNN` string in the
+   comment). You MUST read the comments above every Patch tag in the spec —
+   do not rely solely on filenames to identify which patches are CVE-related.
+   The LAST CVE-related patch by position in the spec determines the naming
+   convention, regardless of whether its filename contains "CVE".
+
    Priority 3 — Default convention:
    If neither maintainer rules nor existing patches provide guidance, name the
    patch file and add comments as follows:

--- a/ymir/agents/prompts/triage/prompt.j2
+++ b/ymir/agents/prompts/triage/prompt.j2
@@ -228,6 +228,17 @@ You must decide between one of the following actions. Follow these guidelines to
      - GitHub PR: `https://github.com/org/repo/pull/N.patch`
      - GitLab MR: `https://gitlab.com/org/repo/-/merge_requests/N.patch`
      Fetch and validate any URL via `get_patch_from_url` before using it.
+   * **Use commits from the target branch, not the PR source branch**:
+     When a PR/MR is merged via rebase or squash on GitHub/GitLab, the
+     commit hashes on the target branch (e.g. `main`, `master`) differ
+     from the hashes shown in the PR's "Commits" tab, which belong to
+     the source/fork branch. Always use the commit hash that landed on
+     the default branch, not the one from the PR branch.
+     To find the correct hash on GitHub: look for "merged commit <hash>
+     into <target-branch>" in the PR timeline, or check `git log` on
+     the default branch. The fork-branch commit may still be accessible
+     via its URL, but it is not the canonical merged commit and should
+     not be used for backporting.
 
    2.4. Decide the Outcome
    {% if not is_older_zstream %}

--- a/ymir/agents/prompts/triage/prompt.j2
+++ b/ymir/agents/prompts/triage/prompt.j2
@@ -181,15 +181,27 @@ You must decide between one of the following actions. Follow these guidelines to
      clarification-needed note so a human can evaluate it, but do not use it as the basis
      for a backport decision.
    * **Check for follow-up commits**: After identifying a valid fix, you MUST check
-     whether there are follow-up commits that complement or complete the fix.
-     Common patterns include:
-     - A second commit that fixes a bug or regression introduced by the first fix
-     - An incremental commit that addresses the same CVE/issue from a different angle
-       (e.g. fixing a separate code path or variant of the same vulnerability)
-     - A commit by the same or related author modifying the same files/functions
-       shortly after the primary fix
-     - A commit whose message explicitly references the first fix (e.g. "follow-up to ...",
-       "fix for ...", same CVE ID, or same bug tracker reference)
+     whether there are follow-up commits that are **necessary to make the fix
+     correct and complete**. A follow-up commit should be included ONLY when:
+     - It fixes a bug, crash, or regression introduced by the primary fix
+       (i.e. the primary fix does not work correctly without it)
+     - It completes the fix for the same issue/CVE when the primary commit
+       only addressed part of the problem (e.g. a second code path still
+       vulnerable to the same CVE)
+     - Its commit message explicitly states it fixes or corrects the primary
+       commit (e.g. "fix regression from ...", "complete fix for CVE-...")
+     A follow-up commit should **NOT** be included when:
+     - It adds additional hardening, defensive checks, or robustness
+       improvements beyond what is needed to fix the reported issue
+     - It adds or improves tests, comments, documentation, or code style
+       without changing the fix logic
+     - It refactors or improves the area touched by the fix but is not
+       required for the fix to work (nice-to-have improvements)
+     - It addresses a separate issue or vulnerability, even if it touches
+       the same files or functions
+     The key question is: "Does the primary fix fully resolve the reported
+     issue/CVE on its own?" If yes, subsequent commits that improve,
+     harden, or extend the fix are out of scope and must be excluded.
      Use multiple search strategies — any single strategy can miss commits:
      1. Ancestry search on affected files:
         `git log <primary-fix>..HEAD -- <affected-files>`
@@ -199,14 +211,10 @@ You must decide between one of the following actions. Follow these guidelines to
      3. Keyword search — search for the issue/CVE ID or related
         function names in commit messages:
         `git log --all --grep="<issue-number-or-CVE-ID>"`
-     If you find follow-up commits, validate them the same way (fetch via
-     get_patch_from_url and verify they are real patches) and include ALL of them
+     If you find follow-up commits, evaluate each one against the criteria
+     above. For those that qualify, validate them the same way (fetch via
+     get_patch_from_url and verify they are real patches) and include them
      in your patch_urls list, ordered chronologically (earliest first).
-     **Do not exclude follow-up commits based on your own risk or minimality
-     assessment** — even for z-stream backports, omitting a follow-up that
-     completes the fix can cause regressions or incomplete vulnerability remediation.
-     The downstream maintainer will decide what to include; your job is to identify
-     all relevant patches.
    * **Prefer individual commit URLs; collapse to PR/MR when appropriate**:
      Start by searching for individual fixing commits and use their
      `.patch` URLs in your `patch_urls` list. This is the default.

--- a/ymir/agents/prompts/triage/prompt.j2
+++ b/ymir/agents/prompts/triage/prompt.j2
@@ -430,3 +430,123 @@ needs to know*. Cover:
          'important', for most critical use 'critical'
          (privilege escalation, RCE, data loss)
        * Fix Version: use the appropriate stream version determined from map_version tool result
+
+**Output Format**
+
+Your final answer MUST be a JSON object with two keys: `resolution` (a string)
+and `data` (an object — NOT a stringified JSON string). The `data` object must
+match the schema for the chosen resolution.
+
+Examples:
+
+Backport resolution:
+```json
+{
+    "resolution": "backport",
+    "data": {
+        "package": "some-package",
+        "patch_urls": ["https://github.com/example-org/example-repo/commit/abc123def456.patch"],
+        "justification": "Patch adds input validation to parse_input().",
+        "triage_summary": "Searched upstream git for CVE ID; no match. Found via Fedora.",
+        "jira_issue": "RHEL-12345",
+        "cve_id": "CVE-1234-98765",
+        "fix_version": "rhel-X.Y.Z"
+    }
+}
+```
+
+Rebase resolution:
+```json
+{
+    "resolution": "rebase",
+    "data": {
+        "package": "some-package",
+        "version": "2.4.1",
+        "justification": "Version 2.4.1 includes the fix for the crash in parse_uri().",
+        "triage_summary": "Fedora already rebased to 2.4.1 for this bug. Verified changelog.",
+        "jira_issue": "RHEL-12345",
+        "fix_version": "rhel-X.Y.Z"
+    }
+}
+```
+
+Rebuild resolution:
+```json
+{
+    "resolution": "rebuild",
+    "data": {
+        "package": "some-package",
+        "jira_issue": "RHEL-12345",
+        "cve_id": "CVE-1234-98765",
+        "justification": "Package links against golang which got a CVE-1234-98765 fix.",
+        "triage_summary": "Confirmed package vendors Go deps via spec BuildRequires.",
+        "dependency_issue": "RHEL-67890",
+        "dependency_component": "golang",
+        "fix_version": "rhel-X.Y.Z"
+    }
+}
+```
+
+Postponed resolution (rebuild waiting for dependency):
+```json
+{
+    "resolution": "postponed",
+    "data": {
+        "summary": "Rebuild of some-package waiting for RHEL-67890 (golang) to ship",
+        "pending_issues": ["RHEL-67890"],
+        "jira_issue": "RHEL-12345",
+        "package": "some-package",
+        "fix_version": "rhel-X.Y.Z",
+        "cve_id": "CVE-1234-98765",
+        "dependency_issue": "RHEL-67890",
+        "dependency_component": "golang"
+    }
+}
+```
+
+Not-affected resolution (CVE does not apply):
+```json
+{
+    "resolution": "not-affected",
+    "data": {
+        "justification_category": "Vulnerable Code not Present",
+        "explanation": "The downstream package ships version 1.2.3 which is below the affected range (2.0+). The vulnerable function does not exist in this version.",
+        "jira_issue": "RHEL-12345"
+    }
+}
+```
+
+Open-ended analysis resolution:
+```json
+{
+    "resolution": "open-ended-analysis",
+    "data": {
+        "summary": "The issue requests updating BuildRequires for package-x to version >= 2.0.",
+        "recommendation": "This requires a specfile adjustment. No upstream source changes needed.",
+        "jira_issue": "RHEL-12345"
+    }
+}
+```
+
+Clarification-needed resolution:
+```json
+{
+    "resolution": "clarification-needed",
+    "data": {
+        "findings": "The CVE describes a buffer overflow in parse_input(). I scanned upstream git history but could not find a definitive fix.",
+        "additional_info_needed": "A link to the upstream commit that fixes this issue is required to proceed.",
+        "jira_issue": "RHEL-12345"
+    }
+}
+```
+
+Error resolution:
+```json
+{
+    "resolution": "error",
+    "data": {
+        "details": "Package 'invalid-package-name' not found in GitLab repository after examining issue details.",
+        "jira_issue": "RHEL-12345"
+    }
+}
+```

--- a/ymir/agents/tests/e2e/backport_agent/test_backport.py
+++ b/ymir/agents/tests/e2e/backport_agent/test_backport.py
@@ -35,6 +35,7 @@ class BackportAgentTestCase:
         self.input: dict = config["input"]
         self.expected: dict = config.get("expected", {})
         self.jira_issue: str = self.input["jira_issue"]
+        self.slow: bool = config.get("slow", False)
         self.metrics: dict = None
         self.finished_state: BackportState | None = None
         self.artifacts: CapturedArtifacts | None = None
@@ -92,6 +93,18 @@ def _load_test_cases(fixtures_dir: str | Path) -> list[BackportAgentTestCase]:
 
 
 test_cases = _load_test_cases(os.getenv("BACKPORT_MOCK_REPOS_DIR") or str(DEFAULT_FIXTURES_DIR))
+
+
+def _parametrize_cases():
+    """Build pytest.param list, tagging slow cases with ``pytest.mark.slow``."""
+    params = []
+    for tc in test_cases:
+        marks = [pytest.mark.slow] if tc.slow else []
+        params.append(pytest.param(tc, id=tc.jira_issue, marks=marks))
+    return params
+
+
+_backport_params = _parametrize_cases()
 
 
 _span_processor = None
@@ -179,7 +192,9 @@ def run_test_cases_concurrently(request, mock_centos_stream_repos):
     selected = {
         item.callspec.params["test_case"]
         for item in request.session.items
-        if hasattr(item, "callspec") and "test_case" in item.callspec.params
+        if hasattr(item, "callspec")
+        and "test_case" in item.callspec.params
+        and not any(item.iter_markers(name="skip"))
     }
     cases_to_run = [tc for tc in test_cases if tc in selected]
 
@@ -205,6 +220,8 @@ def run_test_cases_concurrently(request, mock_centos_stream_repos):
                 m.get("completion_tokens", 0),
             ]
         )
+    skipped_slow = [tc for tc in test_cases if tc.slow and tc not in cases_to_run]
+    collected_metrics.extend([tc.jira_issue, "(skipped — slow)", "-", "-", "-", "-"] for tc in skipped_slow)
     request.config.stash["metrics"] = tabulate(
         collected_metrics, ["Issue", "Agent", "Duration", "Tool Calls", "Prompt Tokens", "Completion Tokens"]
     )
@@ -215,7 +232,7 @@ def run_test_cases_concurrently(request, mock_centos_stream_repos):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("test_case", test_cases, ids=[tc.jira_issue for tc in test_cases])
+@pytest.mark.parametrize("test_case", _backport_params)
 def test_backport_agent_success(test_case: BackportAgentTestCase):
     """Verify the backport workflow completed without exceptions."""
     if test_case.error is not None:
@@ -233,7 +250,7 @@ def test_backport_agent_success(test_case: BackportAgentTestCase):
     )
 
 
-@pytest.mark.parametrize("test_case", test_cases, ids=[tc.jira_issue for tc in test_cases])
+@pytest.mark.parametrize("test_case", _backport_params)
 def test_backport_agent_artifacts(test_case: BackportAgentTestCase):
     """Verify that expected artifacts were produced."""
     if test_case.error is not None:
@@ -270,7 +287,7 @@ def test_backport_agent_artifacts(test_case: BackportAgentTestCase):
         )
 
 
-@pytest.mark.parametrize("test_case", test_cases, ids=[tc.jira_issue for tc in test_cases])
+@pytest.mark.parametrize("test_case", _backport_params)
 def test_backport_agent_patch_scope(test_case: BackportAgentTestCase):
     """Verify the agent's patch does not touch files outside the reference patch scope.
 
@@ -324,7 +341,7 @@ def test_backport_agent_patch_scope(test_case: BackportAgentTestCase):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("test_case", test_cases, ids=[tc.jira_issue for tc in test_cases])
+@pytest.mark.parametrize("test_case", _backport_params)
 def test_backport_agent_llm_judge(test_case: BackportAgentTestCase):
     """Evaluate backport quality using an LLM judge."""
     if os.getenv("RUN_LLM_JUDGE", "").lower() != "true":

--- a/ymir/agents/tests/e2e/conftest.py
+++ b/ymir/agents/tests/e2e/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from collections.abc import Generator
 
 import pytest
@@ -9,6 +10,19 @@ configure_logging(level=logging.INFO)
 logging.getLogger("beeai").setLevel(logging.WARNING)
 logging.getLogger("beeai_framework").setLevel(logging.WARNING)
 logging.getLogger("litellm").setLevel(logging.WARNING)
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: marks tests as slow (skipped unless RUN_SLOW_TESTS=true)")
+
+
+def pytest_collection_modifyitems(config, items):
+    if os.getenv("RUN_SLOW_TESTS", "").lower() == "true":
+        return
+    skip_slow = pytest.mark.skip(reason="slow test — set RUN_SLOW_TESTS=true to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 
 @pytest.hookimpl(wrapper=True)

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -152,6 +152,22 @@ test_cases = [
         ),
     ),
     TriageAgentTestCase(
+        input="RHEL-179083",
+        expected_output=TriageOutputSchema(
+            resolution=Resolution.BACKPORT,
+            data=BackportData(
+                package="memcached",
+                patch_urls=[
+                    "https://github.com/memcached/memcached/commit/d13f282b4bce33a9c33b8a1bbf07f12114160fed.patch",
+                ],
+                justification="not-implemented",
+                jira_issue="RHEL-179083",
+                cve_id="CVE-2026-47783",
+                fix_version="rhel-10.2.z",
+            ),
+        ),
+    ),
+    TriageAgentTestCase(
         input="RHEL-174694",
         expected_output=TriageOutputSchema(
             resolution=Resolution.NOT_AFFECTED,

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -203,6 +203,22 @@ test_cases = [
             ),
         ),
     ),
+    TriageAgentTestCase(
+        input="RHEL-178684",
+        expected_output=TriageOutputSchema(
+            resolution=Resolution.BACKPORT,
+            data=BackportData(
+                package="nginx",
+                patch_urls=[
+                    "https://github.com/nginx/nginx/commit/ca4f92a27464ae6c2082245e4f67048c633aa032.patch",
+                ],
+                justification="not-implemented",
+                jira_issue="RHEL-178684",
+                cve_id="CVE-2026-9256",
+                fix_version="rhel-9.8.z",
+            ),
+        ),
+    ),
 ]
 
 

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -113,7 +113,6 @@ test_cases = [
                 package="libtiff",
                 patch_urls=[
                     "https://gitlab.com/libtiff/libtiff/-/commit/3e0dcf0ec651638b2bd849b2e6f3124b36890d99.patch",
-                    "https://gitlab.com/libtiff/libtiff/-/commit/681694024846f543fe7d4821074b813cd9dccdfa.patch",
                 ],
                 justification="not-implemented",
                 jira_issue="RHEL-112546",

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -187,6 +187,22 @@ test_cases = [
             ),
         ),
     ),
+    TriageAgentTestCase(
+        input="RHEL-173494",
+        expected_output=TriageOutputSchema(
+            resolution=Resolution.BACKPORT,
+            data=BackportData(
+                package="qt6-qtdeclarative",
+                patch_urls=[
+                    "https://download.qt.io/official_releases/qt/6.10/CVE-2025-14576-qtdeclarative-6.10.diff",
+                ],
+                justification="not-implemented",
+                jira_issue="RHEL-173494",
+                cve_id="CVE-2025-14576",
+                fix_version="rhel-10.2.z",
+            ),
+        ),
+    ),
 ]
 
 

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -5,7 +5,6 @@ import shutil
 import sys
 import traceback
 from pathlib import Path
-from textwrap import dedent
 
 from beeai_framework.agents.requirement.requirements.conditional import (
     ConditionalRequirement,
@@ -14,7 +13,6 @@ from beeai_framework.errors import FrameworkError
 from beeai_framework.memory import UnconstrainedMemory
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
 from beeai_framework.tools.think import ThinkTool
-from beeai_framework.utils.strings import to_json
 from beeai_framework.workflows import Workflow
 from pydantic import BaseModel, Field
 
@@ -401,96 +399,11 @@ async def run_workflow(
                 logger.warning(f"Failed to pre-fetch fix version for prompt selection: {e}")
 
             input_data = InputSchema(issue=state.jira_issue)
-            output_schema_json = to_json(
-                OutputSchema.model_json_schema(mode="validation"),
-                indent=2,
-                sort_keys=False,
-            )
             response = await triage_agent.run(
                 await render_prompt(input_data, fix_version=fix_version_name),
-                # `OutputSchema` alone is not enough here, some models (cough cough, Claude Sonnet 4.5)
-                # really stuggle with the nesting, let's provide some more hints
-                expected_output=dedent(
-                    f"""
-                    The final answer must fulfill the following.
-
-                    **Important Formatting Rules:**
-                    - The top-level output must be a JSON object with two keys:
-                      `resolution` (a string) and `data` (an object).
-                    - The `data` field MUST be a nested JSON object.
-                      **It must not be a stringified JSON object.**
-                    - The structure of the `data` object must match the schema
-                      corresponding to the chosen `resolution`.
-
-                    **Correct example for a 'backport' resolution:**
-                    ```json
-                    {{
-                        "resolution": "backport",
-                        "data": {{
-                        "package": "some-package",
-                        "patch_urls": ["https://github.com/example-org/example-repo/commit/abc123def456.patch"],
-                        "justification": "Patch adds input validation to parse_input().",
-                        "triage_summary": "Searched upstream git for CVE ID; no match. Found via Fedora.",
-                        "jira_issue": "RHEL-12345",
-                        "cve_id": "CVE-1234-98765",
-                        "fix_version": "rhel-X.Y.Z"
-                        }}
-                    }}
-                    ```
-
-                    **Correct example for a 'rebase' resolution:**
-                    ```json
-                    {{
-                        "resolution": "rebase",
-                        "data": {{
-                        "package": "some-package",
-                        "version": "2.4.1",
-                        "justification": "Version 2.4.1 includes the fix for the crash in parse_uri().",
-                        "triage_summary": "Fedora already rebased to 2.4.1 for this bug. Verified changelog.",
-                        "jira_issue": "RHEL-12345",
-                        "fix_version": "rhel-X.Y.Z"
-                        }}
-                    }}
-                    ```
-
-                    **Correct example for a 'rebuild' resolution:**
-                    ```json
-                    {{
-                        "resolution": "rebuild",
-                        "data": {{
-                        "package": "some-package",
-                        "jira_issue": "RHEL-12345",
-                        "cve_id": "CVE-1234-98765",
-                        "justification": "Package links against golang which got a CVE-1234-98765 fix.",
-                        "triage_summary": "Confirmed package vendors Go deps via spec BuildRequires.",
-                        "dependency_issue": "RHEL-67890",
-                        "dependency_component": "golang",
-                        "fix_version": "rhel-X.Y.Z"
-                        }}
-                    }}
-                    ```
-
-                    **Correct example for a 'postponed' resolution (rebuild waiting for dependency):**
-                    ```json
-                    {{
-                        "resolution": "postponed",
-                        "data": {{
-                        "summary": "Rebuild of some-package waiting for RHEL-67890 (golang) to ship",
-                        "pending_issues": ["RHEL-67890"],
-                        "jira_issue": "RHEL-12345",
-                        "package": "some-package",
-                        "fix_version": "rhel-X.Y.Z",
-                        "cve_id": "CVE-1234-98765",
-                        "dependency_issue": "RHEL-67890",
-                        "dependency_component": "golang"
-                        }}
-                    }}
-                    ```
-
-                    ```json
-                    {output_schema_json}
-                    ```
-                    """
+                expected_output=(
+                    "A JSON object with top-level keys 'resolution' and 'data'. "
+                    "See the task prompt for the exact schema and examples."
                 ),
                 **get_agent_execution_config(),
             )

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -283,6 +283,10 @@ class ForkRepositoryTool(Tool[ForkRepositoryToolInput, ToolRunOptions, StringToo
         if fork := await asyncio.to_thread(get_fork):
             return StringToolOutput(result=fork.get_git_urls()["git"])
 
+        if os.getenv("DRY_RUN", "False").lower() == "true":
+            logger.info("DRY_RUN is set, skipping fork creation — returning original repo URL")
+            return StringToolOutput(result=project.get_git_urls()["git"])
+
         def create_fork():
             prefix = "_".join(ns.replace("centos-stream", "centos") for ns in namespace[1:])
             fork_name = (f"{prefix}_" if prefix else "") + project.gitlab_repo.name

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -988,7 +988,7 @@ class GetPatchFromUrlTool(Tool[GetPatchFromUrlToolInput, ToolRunOptions, StringT
                         result=f"Error: Failed to fetch patch from {patch_url}: HTTP {response.status}"
                     )
                 text = await response.text()
-        except aiohttp.ClientError as e:
+        except (aiohttp.ClientError, TimeoutError) as e:
             raise ToolError(f"Failed to fetch patch from {patch_url}: {e}") from e
         try:
             hunks = json.loads(text)
@@ -1077,7 +1077,7 @@ class FetchGitlabMrNotesTool(Tool[FetchGitlabMrNotesInput, ToolRunOptions, Strin
 
             return StringToolOutput(result=json.dumps(result, indent=2))
 
-        except aiohttp.ClientError as e:
+        except (aiohttp.ClientError, TimeoutError) as e:
             # Here we handle ClientError as ToolError, because client error
             # signals networking issues which should be flagged (DNS resolution failure, timeouts etc)
             raise ToolError(f"Failed to fetch MR notes for !{input.mr_iid} in {input.project}: {e}") from e

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -187,7 +187,7 @@ class GetJiraDetailsTool(Tool[GetJiraDetailsToolInput, ToolRunOptions, JSONToolO
                 ) as response:
                     response.raise_for_status()
                     issue_data = await response.json()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to get details about the specified issue: {e}") from e
 
             try:
@@ -202,7 +202,7 @@ class GetJiraDetailsTool(Tool[GetJiraDetailsToolInput, ToolRunOptions, JSONToolO
                     remote_links_response.raise_for_status()
                     remote_links = await remote_links_response.json()
                     issue_data["remote_links"] = remote_links
-            except aiohttp.ClientError:
+            except (aiohttp.ClientError, TimeoutError):
                 issue_data["remote_links"] = []
 
         return JSONToolOutput(result=self._postprocess_issue_data(issue_data))
@@ -267,7 +267,7 @@ class SetJiraFieldsTool(Tool[SetJiraFieldsToolInput, ToolRunOptions, StringToolO
                 ) as response:
                     response.raise_for_status()
                     current_issue = await response.json()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to get current issue details: {e}") from e
 
             fields = {}
@@ -299,7 +299,7 @@ class SetJiraFieldsTool(Tool[SetJiraFieldsToolInput, ToolRunOptions, StringToolO
                     headers=get_jira_auth_headers(),
                 ) as response:
                     response.raise_for_status()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to set the specified fields: {e}") from e
 
         return StringToolOutput(result=f"Successfully updated {issue_key}")
@@ -365,7 +365,7 @@ class AddJiraCommentTool(Tool[AddJiraCommentToolInput, ToolRunOptions, StringToo
                     headers=get_jira_auth_headers(),
                 ) as response:
                     response.raise_for_status()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to add the specified comment: {e}") from e
         return StringToolOutput(result=f"Successfully added the specified comment to {issue_key}")
 
@@ -516,7 +516,7 @@ class CheckCveTriageEligibilityTool(
                 ) as response:
                     response.raise_for_status()
                     jira_data = await response.json()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to get Jira data: {e}") from e
 
         fields = jira_data.get("fields", {})
@@ -754,14 +754,14 @@ class ChangeJiraStatusTool(Tool[ChangeJiraStatusToolInput, ToolRunOptions, Strin
                                 "no change needed (this is expected, not an error)"
                             )
                         )
-            except aiohttp.ClientError:
+            except (aiohttp.ClientError, TimeoutError):
                 pass
 
             try:
                 async with aiohttp_get_with_retries(session, jira_url, headers=headers) as resp:
                     resp.raise_for_status()
                     transitions = (await resp.json()).get("transitions", [])
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to get available transitions for {issue_key}: {e}") from e
 
             transition = next(
@@ -780,7 +780,7 @@ class ChangeJiraStatusTool(Tool[ChangeJiraStatusToolInput, ToolRunOptions, Strin
                     headers=headers,
                 ) as resp:
                     resp.raise_for_status()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to change status of {issue_key} to {status}: {e}") from e
 
         return StringToolOutput(result=f"Successfully changed status of {issue_key} to {status}")
@@ -849,7 +849,7 @@ class EditJiraLabelsTool(Tool[EditJiraLabelsToolInput, ToolRunOptions, StringToo
                     headers=headers,
                 ) as response:
                     response.raise_for_status()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to edit labels on {issue_key}: {e}") from e
 
         return StringToolOutput(result=f"Successfully edited labels on {issue_key}.")
@@ -893,7 +893,7 @@ class VerifyIssueAuthorTool(Tool[VerifyIssueAuthorToolInput, ToolRunOptions, JSO
                 ) as response:
                     response.raise_for_status()
                     issue_data = await response.json()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to get Jira data: {e}") from e
 
             reporter = issue_data.get("fields", {}).get("reporter", {})
@@ -919,7 +919,7 @@ class VerifyIssueAuthorTool(Tool[VerifyIssueAuthorToolInput, ToolRunOptions, JSO
                 ) as user_response:
                     user_response.raise_for_status()
                     user_data = await user_response.json()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to get user groups: {e}") from e
 
             ok = any(
@@ -990,7 +990,7 @@ class SearchJiraIssuesTool(
                 ) as response:
                     response.raise_for_status()
                     data = await response.json()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to search Jira issues: {e}") from e
 
         issues = data.get("issues", [])
@@ -1026,7 +1026,7 @@ async def _fetch_dev_status_details(
             response.raise_for_status()
             issue_data = await response.json()
             issue_id = issue_data["id"]
-    except aiohttp.ClientError as e:
+    except (aiohttp.ClientError, TimeoutError) as e:
         raise ToolError(f"Failed to resolve issue ID for {issue_key}: {e}") from e
 
     summary_url = urljoin(jira_base, f"rest/dev-status/1.0/issue/summary?issueId={issue_id}")
@@ -1034,7 +1034,7 @@ async def _fetch_dev_status_details(
         async with aiohttp_get_with_retries(session, summary_url, headers=headers) as response:
             response.raise_for_status()
             summary_data = await response.json()
-    except aiohttp.ClientError as e:
+    except (aiohttp.ClientError, TimeoutError) as e:
         raise ToolError(f"Failed to get dev status summary for {issue_key}: {e}") from e
 
     app_types = list(
@@ -1052,7 +1052,7 @@ async def _fetch_dev_status_details(
             async with aiohttp_get_with_retries(session, detail_url, headers=headers) as response:
                 response.raise_for_status()
                 dev_data = await response.json()
-        except aiohttp.ClientError as e:
+        except (aiohttp.ClientError, TimeoutError) as e:
             logger.warning(
                 f"Failed to get dev-status detail for {issue_key} (applicationType={app_type}): {e}"
             )
@@ -1240,7 +1240,7 @@ class SetPreliminaryTestingTool(Tool[SetPreliminaryTestingToolInput, ToolRunOpti
             try:
                 async with session.put(url, json=body, headers=headers) as response:
                     response.raise_for_status()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to set Preliminary Testing on {issue_key}: {e}") from e
 
         return StringToolOutput(
@@ -1299,7 +1299,7 @@ class UpdateJiraCommentTool(Tool[UpdateJiraCommentToolInput, ToolRunOptions, Str
                     headers=get_jira_auth_headers(),
                 ) as response:
                     response.raise_for_status()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to update comment {comment_id} on {issue_key}: {e}") from e
 
         return StringToolOutput(result=f"Successfully updated comment {comment_id} on {issue_key}")
@@ -1375,7 +1375,7 @@ class AddJiraAttachmentsTool(Tool[AddJiraAttachmentsToolInput, ToolRunOptions, S
                     headers=headers,
                 ) as response:
                     response.raise_for_status()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to add attachments to {issue_key}: {e}") from e
 
         filenames = ", ".join(a["filename"] for a in attachments)
@@ -1420,7 +1420,7 @@ class GetJiraAttachmentTool(Tool[GetJiraAttachmentToolInput, ToolRunOptions, Str
                 async with aiohttp_get_with_retries(session, issue_url, headers=headers) as response:
                     response.raise_for_status()
                     issue_data = await response.json()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to get issue {issue_key}: {e}") from e
 
             attachments = issue_data.get("fields", {}).get("attachment", [])
@@ -1436,7 +1436,7 @@ class GetJiraAttachmentTool(Tool[GetJiraAttachmentToolInput, ToolRunOptions, Str
                 async with aiohttp_get_with_retries(session, content_url, headers=headers) as response:
                     response.raise_for_status()
                     content = await response.read()
-            except aiohttp.ClientError as e:
+            except (aiohttp.ClientError, TimeoutError) as e:
                 raise ToolError(f"Failed to download attachment {filename}: {e}") from e
 
         try:

--- a/ymir/tools/pyproject.toml
+++ b/ymir/tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-tools"
-version = "0.6.0"
+version = "0.6.1"
 description = "Ymir MCP tools for AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]

--- a/ymir/tools/unprivileged/greenwave.py
+++ b/ymir/tools/unprivileged/greenwave.py
@@ -72,7 +72,7 @@ class FetchGreenWaveTool(Tool[FetchGreenWaveInput, ToolRunOptions, StringToolOut
                 return StringToolOutput(
                     result=f"Failed to fetch GreenWave gating status (HTTP {response.status}): {text}"
                 )
-        except aiohttp.ClientError as e:
+        except (aiohttp.ClientError, TimeoutError) as e:
             # Here we handle ClientError as ToolError, because it signals
             # networking issues. Error statuses are handled above by StringToolOutput
             raise ToolError(f"Failed to fetch GreenWave gating status: {e}") from e

--- a/ymir/tools/unprivileged/read_logfile.py
+++ b/ymir/tools/unprivileged/read_logfile.py
@@ -42,7 +42,7 @@ class ReadLogfileTool(Tool[ReadLogfileInput, ToolRunOptions, StringToolOutput]):
                     return StringToolOutput(
                         result=await response.text(),
                     )
-        except aiohttp.ClientError as e:
+        except (aiohttp.ClientError, TimeoutError) as e:
             raise ToolError(f"Failed to read logfile from {input.logfile_url}: {e}") from e
 
         return StringToolOutput(result=f"Failed to read logfile from {input.logfile_url}")

--- a/ymir/tools/unprivileged/read_readme.py
+++ b/ymir/tools/unprivileged/read_readme.py
@@ -52,7 +52,7 @@ class ReadReadmeTool(Tool[ReadReadmeInput, ToolRunOptions, StringToolOutput]):
                                 return StringToolOutput(
                                     result=await response.text(),
                                 )
-                    except aiohttp.ClientError:
+                    except (aiohttp.ClientError, TimeoutError):
                         pass
 
         return StringToolOutput(result=f"Failed to find README.md for {input.repo_url}")

--- a/ymir/tools/unprivileged/search_resultsdb.py
+++ b/ymir/tools/unprivileged/search_resultsdb.py
@@ -148,7 +148,7 @@ class SearchResultsdbTool(Tool[SearchResultsdbInput, ToolRunOptions, SearchResul
             return SearchResultsdbOutput(
                 results=await search_resultsdb(input.package_nvr, input.name_pattern)
             )
-        except aiohttp.ClientError as e:
+        except (aiohttp.ClientError, TimeoutError) as e:
             raise ToolError(f"Failed to fetch resultsdb data: {e}") from e
         except ValueError as e:
             raise ToolError(f"Error parsing resultsdb data: {e}") from e

--- a/ymir/tools/unprivileged/upstream_tools.py
+++ b/ymir/tools/unprivileged/upstream_tools.py
@@ -132,7 +132,7 @@ class ExtractUpstreamRepositoryTool(
                         # Extract commit hash from API response
                         commit_hash = data["head"]["sha"] if pr_match else data["sha"]
 
-                except (aiohttp.ClientError, KeyError) as e:
+                except (aiohttp.ClientError, TimeoutError, KeyError) as e:
                     raise ToolError(
                         f"Failed to fetch PR/MR information from {api_url}. "
                         f"The PR/MR might be private, deleted, or the API is unavailable. Error: {e}"
@@ -206,7 +206,7 @@ class ExtractUpstreamRepositoryTool(
                                 commits = list(reversed(commits))
                         # Use the last commit (newest) as the commit_hash
                         commit_hash = commits[-1] if commits else target_ref
-                except (aiohttp.ClientError, KeyError):
+                except (aiohttp.ClientError, TimeoutError, KeyError):
                     # If API fails, fall back to using target_ref as commit_hash
                     # This allows the tool to still work even if API is unavailable
                     commit_hash = target_ref


### PR DESCRIPTION
**Triage agent prompt improvements:**
- Tightened the definition of "follow-up commits" — the agent now only includes follow-ups that are strictly necessary for the fix to be correct (e.g. regression fixes), and explicitly excludes nice-to-have hardening, test-only, or refactoring commits
- Added guidance to use commits from the target branch (e.g. `main`) rather than PR source/fork branch hashes, which differ after rebase/squash merges
- Added instructions about identifying rebased commits
- Moved the output schema definition and examples directly into the prompt template instead of duplicating it in `triage_agent.py` as a verbose `expected_output` string — the agent now gets the schema once, in context, reducing token waste and eliminating the prior workaround for models struggling with nested JSON

**Backport agent prompt improvements:**
- Improved CVE patch identification: the agent must now inspect comments above `Patch` tags (not just filenames) to detect CVE-related patches and determine the naming convention
- Added critical guidance for conflict resolution: when resolving cherry-pick conflicts, the agent must distinguish the actual fix from unrelated upstream evolution on the "theirs" side, preserving HEAD-side code for anything not part of the original commit

**Timeout handling:**
- All `aiohttp.ClientError` exception handlers across Jira, GitLab, GreenWave, ResultsDB, upstream tools, logfile reader, and README reader now also catch `TimeoutError`, so network timeouts surface as clear `ToolError` messages in agent spans rather than unhandled exceptions

**DRY_RUN support for fork creation:**
- `ForkRepositoryTool` now respects `DRY_RUN=true` by returning the original repo URL instead of creating an actual fork

**Test infrastructure:**
- Added `slow` marker support for backport e2e tests — tests tagged `slow: true` in their fixture config are skipped by default and only run when `RUN_SLOW_TESTS=true` is set
- Added three new triage e2e test cases: memcached (RHEL-179083), qt6-qtdeclarative (RHEL-173494), nginx (RHEL-178684)
- Removed an incorrect expected follow-up patch from the libtiff (RHEL-112546) test case, aligning with the stricter follow-up commit definition