### PR TITLE
Pin pydantic-ai-slim version for phoenix

### DIFF
--- a/Containerfile.phoenix
+++ b/Containerfile.phoenix
@@ -2,7 +2,7 @@
 FROM fedora:44
 RUN dnf install -y python3-pip python3-numpy python3-scipy \
     && dnf clean all \
-    && pip3 install --no-cache-dir 'arize-phoenix<16' \
+    && pip3 install --no-cache-dir 'arize-phoenix<16' 'pydantic-ai-slim<2' \
     && useradd -u 1001 -g 0 -m -s /sbin/nologin phoenix
 USER 1001
 EXPOSE 6006 4317


### PR DESCRIPTION
To fix Phoenix startup after pydantic-ai v2.0 removal of MCPServerStreamableHTTP

Phoenix started to fail yesterday with this error:
```
from pydantic_ai.mcp import MCPServerStreamableHTTP
ImportError: cannot import name 'MCPServerStreamableHTTP' from 'pydantic_ai.mcp' (/usr/local/lib/python3.14/site-packages/pydantic_ai/mcp.py)
```

Turns out pydantic_aiv2 has removed MCPServerStreamableHTTP