### PR TITLE
Allow egress to release-assets.githubusercontent.com

### DIFF
--- a/openshift/tenant-egress.yml
+++ b/openshift/tenant-egress.yml
@@ -50,6 +50,9 @@ spec:
     - type: Allow
       to:
         dnsName: api.github.com
+    - type: Allow
+      to:
+        dnsName: release-assets.githubusercontent.com
     # Fedora package repository
     - type: Allow
       to:


### PR DESCRIPTION
## Summary

- GitHub release asset downloads were hanging indefinitely after `github.com` issued a 302 redirect to `release-assets.githubusercontent.com`, which was blocked by the egress policy
- Added `release-assets.githubusercontent.com` to the `TenantEgress` allowlist alongside the existing `github.com` and `api.github.com` entries

Fixes PACKIT-5143.

## Test plan

- [x] Applied the updated `TenantEgress` to the `jotnar-ymir--jotnar-ymir` namespace
- [x] Verified with `oc exec deployment/rebase-agent-c10s -- curl -Lv -o /tmp/test.tar.xz https://github.com/redhatinsights/yggdrasil/releases/download/v0.4.9.1/yggdrasil-0.4.9.1.tar.xz` — download followed the redirect and completed successfully (HTTP 200, 2.8 MB transferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)