### PR TITLE
Pre-fetch internal RHEL build version for CVE triage

### DIFF
--- a/ymir/agents/prompts/triage/prompt.j2
+++ b/ymir/agents/prompts/triage/prompt.j2
@@ -244,6 +244,15 @@ You must decide between one of the following actions. Follow these guidelines to
 
    2.4. Decide the Outcome
    {% if not is_older_zstream %}
+   {% if internal_build_version %}
+   * **IMPORTANT — Internal RHEL build version**: The latest build of this
+     package on the internal RHEL branch is version **{{ internal_build_version }}**,
+     which may be newer than the CentOS Stream version. Use
+     {{ internal_build_version }} as the downstream version when checking
+     whether the fix is already included. If this version already contains
+     the fix, the correct resolution is "not-affected" with justification
+     category "Vulnerable Code not Present".
+   {% endif %}
    * **CRITICAL — Check if the fix belongs to the package or a dependency:**
      Before deciding on backport, verify that the patch you found modifies the package's OWN source
      code, not the source code of a dependency. Watch for these signs that the fix is in a DEPENDENCY:

--- a/ymir/agents/tests/unit/test_jinja2_templates.py
+++ b/ymir/agents/tests/unit/test_jinja2_templates.py
@@ -87,6 +87,7 @@ except ImportError:
     class TriageInputSchema(BaseModel):  # type: ignore[no-redef]
         issue: str
         is_older_zstream: bool = False
+        internal_build_version: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -208,9 +208,16 @@ async def _map_version_to_branch(
 # All schemas are now imported from ymir.common.models
 
 
-async def render_prompt(input: InputSchema, fix_version: str | None = None) -> str:
+async def render_prompt(
+    input: InputSchema,
+    fix_version: str | None = None,
+    internal_build_version: str | None = None,
+) -> str:
     older_zstream = bool(fix_version and await is_older_zstream(fix_version))
-    input_with_flag = input.model_copy(update={"is_older_zstream": older_zstream})
+    updates: dict = {"is_older_zstream": older_zstream}
+    if internal_build_version:
+        updates["internal_build_version"] = internal_build_version
+    input_with_flag = input.model_copy(update=updates)
     return render_template("triage/prompt.j2", input_with_flag)
 
 
@@ -387,6 +394,7 @@ async def run_workflow(
 
             # Pre-fetch JIRA fix version to determine z-stream prompt variant
             fix_version_name = None
+            jira_details = None
             try:
                 jira_details = await run_tool(
                     "get_jira_details",
@@ -399,9 +407,40 @@ async def run_workflow(
             except Exception as e:
                 logger.warning(f"Failed to pre-fetch fix version for prompt selection: {e}")
 
+            # When the CVE needs an internal RHEL fix, the triage agent will
+            # check CentOS Stream for the downstream version — but the internal
+            # branch may already carry a newer build.  Pre-fetch the latest
+            # Brew candidate build version so the prompt can steer the agent.
+            internal_build_version = None
+            if (
+                state.cve_eligibility_result
+                and state.cve_eligibility_result.needs_internal_fix
+                and fix_version_name
+                and jira_details
+            ):
+                try:
+                    components = jira_details.get("fields", {}).get("components", [])
+                    component_name = components[0].get("name", "") if components else ""
+                    parsed = parse_rhel_version(fix_version_name)
+                    if component_name and parsed:
+                        major, minor, _ = parsed
+                        branch = construct_internal_branch_name(major, minor)
+                        evr, _ = await get_latest_candidate_build(component_name, branch)
+                        internal_build_version = evr.version
+                        logger.info(
+                            f"Latest internal build for {component_name} "
+                            f"on {branch}: {internal_build_version}"
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to pre-fetch internal build version: {e}")
+
             input_data = InputSchema(issue=state.jira_issue)
             response = await triage_agent.run(
-                await render_prompt(input_data, fix_version=fix_version_name),
+                await render_prompt(
+                    input_data,
+                    fix_version=fix_version_name,
+                    internal_build_version=internal_build_version,
+                ),
                 expected_output=render_template("triage/output_format.j2"),
                 **get_agent_execution_config(),
             )

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -62,6 +62,10 @@ class TriageInputSchema(BaseModel):
         default=False,
         description="Whether the issue targets an older Z-stream",
     )
+    internal_build_version: str | None = Field(
+        default=None,
+        description="Latest build version on the internal RHEL branch (from Brew), if known",
+    )
 
 
 class Task(BaseModel):


### PR DESCRIPTION
When a Z-stream CVE needs an internal RHEL fix, the triage agent checks CentOS Stream for the downstream version — but the internal branch may already carry a newer build (e.g. a security update). This causes the agent to propose unnecessary backports for already-fixed packages.

Query Brew for the latest candidate build on the internal RHEL branch before triage runs and inject the version into the prompt so the agent uses the correct downstream version.

