### PR TITLE
Remove FuSa label functionality from agents and workflows

### DIFF
--- a/README-agents.md
+++ b/README-agents.md
@@ -162,10 +162,6 @@ Issues can be re-triggered through the workflow in two ways:
    - Package maintainers who have made changes (e.g., updated some fields, added links, commented)
    - Ymir team members after production code updates to resolve issues
 
-### FuSa (Functional Safety) Packages
-
-The `ymir_fusa` label will be automatically added by the triage agent to JIRA issues involving FuSa packages. Related merge requests will need to be reviewed and approved by subject matter experts before merging.
-
 ## Troubleshooting
 
 ### Phoenix: Alembic migration failure after version rollback

--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -286,13 +286,6 @@ Save `merge_request_url` and whether it was newly created.
 
 If this fails, set `success=false` with the error but continue to Step 9 (then Step 10).
 
-### Step 9: Add FuSa Label
-
-If the package is a FuSa (Functional Safety) package on a FuSa branch (c9s or rhel-9.N.0 where N is 1-10):
-1. If `dry_run` is false:
-   - Add the `fusa` label to the JIRA issue using `set_jira_labels`.
-   - Add the `fusa` label to the MR using `add_merge_request_labels`.
-
 ### Step 10: Comment in JIRA
 
 If `dry_run` is true, end the workflow.

--- a/agents_as_skills/rebase/SKILL.md
+++ b/agents_as_skills/rebase/SKILL.md
@@ -235,13 +235,6 @@ Save `merge_request_url` and whether it was newly created.
 
 If this fails, set `success=false` with the error but continue to Step 9 (via Step 9a).
 
-### Step 9a: Add FuSa Label
-
-If the package is a FuSa (Functional Safety) package on a FuSa branch (c9s or rhel-9.N.0 where N is 1-10):
-1. If `dry_run` is false:
-   - Add the `fusa` label to the JIRA issue using `set_jira_labels`.
-   - Add the `fusa` label to the MR using `add_merge_request_labels`.
-
 ### Step 9: Comment in JIRA
 
 If `dry_run` is true, end the workflow.

--- a/jira_label_workflow_routing.md
+++ b/jira_label_workflow_routing.md
@@ -92,7 +92,6 @@ flowchart TD
 |-------|---------|--------|
 | `ymir_retry_needed` | Trigger retry | Forces reprocessing |
 | `ymir_triaged` | Triage completed, no automated follow-up | Terminal state |
-| `ymir_fusa` | Functional Safety | Requires maintainer review |
 | `ymir_todo` | Maintainer-facing trigger for an e2e run | Fetcher swaps it for `ymir_triage_in_progress` on enqueue; only honored when the changelog shows the label was added by a member of the `Red Hat Employee` Jira group (verified per-issue, not via JQL). The triage run posts an ack comment and a result comment so the requester gets feedback. Default is silent — without `ymir_todo`, no comments are posted. |
 
 ## Queue Types Summary

--- a/monitoring.md
+++ b/monitoring.md
@@ -46,7 +46,7 @@ The team primarily tracks these items using Jira dashboards:
 ### Manual Review Focus
 - **Quality**: Incorrect patches, incomplete fixes, spec file errors, backwards compatibility issues
 - **Patterns**: Repeated failures by package type or upstream source, declining success rates
-- **Edge Cases**: RHIVOS/FuSa packages, modules, embargoed CVEs
+- **Edge Cases**: Modules, embargoed CVEs
 
 ## Escalation Process
 
@@ -58,7 +58,6 @@ The team primarily tracks these items using Jira dashboards:
 | **4. Anonymous** | [Feedback form](https://docs.google.com/forms/d/1bqPhabn5M_D6qBNW0nAoucdlbU0TNl48AJmgptJQ8hI/viewform) | Sensitive concerns |
 
 ### Special Cases
-- **RHIVOS/FuSa** (24 packages): Maintainer approval required before merge
 - **Embargoed CVEs**: NOT handled by agents; escalate if urgent
 
 ## Key Performance Metrics
@@ -89,7 +88,6 @@ The team reviews agent results during weekly sessions, identifies failing use ca
 | `ymir_needs_attention` | Requires team review | Weekly priority |
 | `ymir_*_errored` | Workflow failed | Review if >3 attempts |
 | `ymir_cant_do` | Agent cannot handle | Human takeover |
-| `ymir_fusa` | RHIVOS FuSa package | Maintainer approval |
 
 ### Links
 - [Skald Role](https://github.com/packit/agile/issues/972)

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -28,7 +28,7 @@ from ymir.agents.constants import I_AM_YMIR, mr_description_footer
 from ymir.agents.log_agent import create_log_agent
 from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
-from ymir.agents.package_update_steps import PackageUpdateState, PackageUpdateStep
+from ymir.agents.package_update_steps import PackageUpdateState
 from ymir.agents.reasoning_agent import ReasoningAgent
 from ymir.agents.utils import (
     check_subprocess,
@@ -703,15 +703,7 @@ async def run_workflow(
                 state.merge_request_url = None
                 state.backport_result.success = False
                 state.backport_result.error = f"Could not commit and open MR: {e}"
-            return "add_fusa_label"
-
-        async def add_fusa_label(state):
-            return await PackageUpdateStep.add_fusa_label(
-                state,
-                "comment_in_jira",
-                dry_run=dry_run,
-                gateway_tools=gateway_tools,
-            )
+            return "comment_in_jira"
 
         async def comment_in_jira(state):
             if dry_run:
@@ -744,7 +736,6 @@ async def run_workflow(
         workflow.add_step("stage_changes", stage_changes)
         workflow.add_step("run_log_agent", run_log_agent)
         workflow.add_step("commit_push_and_open_mr", commit_push_and_open_mr)
-        workflow.add_step("add_fusa_label", add_fusa_label)
         workflow.add_step("comment_in_jira", comment_in_jira)
 
         response = await workflow.run(

--- a/ymir/agents/package_update_steps.py
+++ b/ymir/agents/package_update_steps.py
@@ -1,12 +1,8 @@
 import logging
-import re
 from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-import ymir.agents.tasks as tasks
-from ymir.common.config import load_rhel_config
-from ymir.common.constants import JiraLabels
 from ymir.common.models import LogOutputSchema
 
 logger = logging.getLogger(__name__)
@@ -31,60 +27,3 @@ class PackageUpdateStep:
 
     A place where to share common steps between backport and rebase workflows.
     """
-
-    @staticmethod
-    async def add_fusa_label(state, next_step, dry_run, gateway_tools):
-        """Add FuSa label to Jira and GitLab merge request for FuSa packages on FuSa branches.
-
-        Args:
-            state: The state of the workflow.
-            next_step: The next step to run.
-            dry_run: Whether to run the workflow in dry-run mode.
-            gateway_tools: The gateway tools to use.
-
-        Returns:
-            The next step to run.
-        """
-        target_branch = state.dist_git_branch
-
-        config = await load_rhel_config()
-        fusa_packages = config.get("fusa_packages", [])
-
-        is_fusa_package = state.package in fusa_packages
-        if not is_fusa_package:
-            logger.info(f"Skipping FuSa label for non-FuSa package: {state.package}")
-            return next_step
-
-        # Only add FuSa labels for c9s or rhel9-[1-10] branches
-        is_fusa_branch = target_branch == "c9s" or re.match(r"^rhel-9\.([0-9]|10)\.0$", target_branch)
-        if not is_fusa_branch:
-            logger.info(f"Skipping FuSa label for non-FuSa branch: {target_branch}")
-            return next_step
-
-        if dry_run:
-            logger.info(
-                f"Skipping FuSa label for FuSa package: {state.package}, "
-                f"FuSa branch: {target_branch}, because running in dry-run mode"
-            )
-            return next_step
-
-        # Add FuSa label to Jira
-        await tasks.set_jira_labels(
-            jira_issue=state.jira_issue,
-            labels_to_add=[JiraLabels.FUSA.value],
-            dry_run=dry_run,
-        )
-
-        # Add FuSa label to GitLab merge request if it exists
-        if state.merge_request_url:
-            try:
-                await tasks.run_tool(
-                    "add_merge_request_labels",
-                    merge_request_url=state.merge_request_url,
-                    labels=[JiraLabels.FUSA.value],
-                    available_tools=gateway_tools,
-                )
-            except Exception as e:
-                logger.warning(f"Failed to add FuSa label to GitLab MR: {e}")
-
-        return next_step

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -25,7 +25,7 @@ from ymir.agents.constants import I_AM_YMIR, mr_description_footer
 from ymir.agents.log_agent import create_log_agent
 from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
-from ymir.agents.package_update_steps import PackageUpdateState, PackageUpdateStep
+from ymir.agents.package_update_steps import PackageUpdateState
 from ymir.agents.reasoning_agent import ReasoningAgent
 from ymir.agents.utils import (
     format_mr_triage_details,
@@ -352,15 +352,7 @@ async def main() -> None:
                     state.merge_request_url = None
                     state.rebase_result.success = False
                     state.rebase_result.error = f"Could not commit and open MR: {e}"
-                return "add_fusa_label"
-
-            async def add_fusa_label(state):
-                return await PackageUpdateStep.add_fusa_label(
-                    state,
-                    "comment_in_jira",
-                    dry_run=dry_run,
-                    gateway_tools=gateway_tools,
-                )
+                return "comment_in_jira"
 
             async def comment_in_jira(state):
                 if dry_run:
@@ -391,7 +383,6 @@ async def main() -> None:
             workflow.add_step("stage_changes", stage_changes)
             workflow.add_step("run_log_agent", run_log_agent)
             workflow.add_step("commit_push_and_open_mr", commit_push_and_open_mr)
-            workflow.add_step("add_fusa_label", add_fusa_label)
             workflow.add_step("comment_in_jira", comment_in_jira)
 
             response = await workflow.run(

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -907,14 +907,19 @@ async def main() -> None:
             # retries, not Jira-write retries — set_jira_labels already retries
             # the write internally) and skip processing this iteration.
             try:
+                # Remove all ymir_* labels currently on the issue (including any
+                # deprecated labels like ymir_fusa), except the in-progress anchor
+                # we're about to add. This ensures cleanup of unknown/legacy labels
+                # without requiring hardcoded references.
+                labels_to_remove = [
+                    label
+                    for label in current_labels
+                    if label.startswith("ymir_") and label != JiraLabels.TRIAGE_IN_PROGRESS.value
+                ]
                 await tasks.set_jira_labels(
                     jira_issue=input.issue,
                     labels_to_add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
-                    labels_to_remove=[
-                        label
-                        for label in JiraLabels.all_labels()
-                        if label != JiraLabels.TRIAGE_IN_PROGRESS.value
-                    ],
+                    labels_to_remove=labels_to_remove,
                     dry_run=dry_run,
                     user_triggered=user_triggered,
                     critical=True,

--- a/ymir/common/constants.py
+++ b/ymir/common/constants.py
@@ -160,7 +160,6 @@ class JiraLabels(Enum):
     TRIAGED_NOT_AFFECTED = "ymir_triaged_not_affected"
 
     RETRY_NEEDED = "ymir_retry_needed"
-    FUSA = "ymir_fusa"
 
     # Maintainer-facing trigger: when a Red Hat Employee adds this label to a CVE
     # issue, the fetcher enqueues it for an e2e run and swaps the label for

--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -271,12 +271,12 @@ async def test_push_to_remote_repository():
 )
 @pytest.mark.asyncio
 async def test_add_merge_request_labels(merge_request_url, expected_project_path):
-    labels = ["ymir_fusa", "test-label"]
+    labels = ["test-label-1", "test-label-2"]
 
     # Mock the merge request object
     mr_mock = flexmock()
-    mr_mock.should_receive("add_label").with_args("ymir_fusa").once()
-    mr_mock.should_receive("add_label").with_args("test-label").once()
+    mr_mock.should_receive("add_label").with_args("test-label-1").once()
+    mr_mock.should_receive("add_label").with_args("test-label-2").once()
 
     # Mock the project object
     project_mock = flexmock()


### PR DESCRIPTION
The FuSa (Functional Safety) label is no longer needed, since now all Ymir created MR are supposed to be approved and merged by the package maintainers. Removed all references and workflow steps related to FuSa label handling from:
- Backport and rebase agents (workflow step removal)
- Package update steps (removed add_fusa_label method)
- JiraLabels enum constant
- Agent skill documentation
- Monitoring and routing documentation

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>