### PR TITLE
Use authenticated clone for internal RHEL branch triage

### DIFF
--- a/ymir/agents/prompts/triage/prompt.j2
+++ b/ymir/agents/prompts/triage/prompt.j2
@@ -37,9 +37,16 @@ Goal: Analyze the given issue to determine the correct course of action.
 
 2. Identify the package name that must be updated:
    * Determine the name of the package from the issue details (usually component name)
+   {% if needs_internal_fix and internal_target_branch %}
+   * Use the clone_repository tool to clone `https://gitlab.com/redhat/rhel/rpms/<package_name>`
+     with branch `{{ internal_target_branch }}`.
+     If the clone fails (branch or repo not found), fall back to cloning
+     `https://gitlab.com/redhat/centos-stream/rpms/<package_name>` using the same tool.
+   {% else %}
    * Confirm the package repository exists by running
      `GIT_TERMINAL_PROMPT=0 git ls-remote https://gitlab.com/redhat/centos-stream/rpms/<package_name>`
-   * A successful command (exit code 0) confirms the package exists
+     A successful command (exit code 0) confirms the package exists.
+   {% endif %}
    * If the package does not exist, re-examine the Jira issue
      for the correct package name and if it is not found,
      return error and explicitly state the reason

--- a/ymir/agents/tests/unit/test_jinja2_templates.py
+++ b/ymir/agents/tests/unit/test_jinja2_templates.py
@@ -87,6 +87,8 @@ except ImportError:
     class TriageInputSchema(BaseModel):  # type: ignore[no-redef]
         issue: str
         is_older_zstream: bool = False
+        needs_internal_fix: bool = False
+        internal_target_branch: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -395,6 +397,8 @@ class TestTriageTemplate:
         assert "RHEL-12345" in result
         assert "Fedora" in result
         assert "zstream_search" not in result
+        assert "centos-stream" in result
+        assert "redhat/rhel/rpms" not in result
 
     def test_renders_older_zstream(self):
         result = render_template(
@@ -404,6 +408,33 @@ class TestTriageTemplate:
         assert "RHEL-12345" in result
         assert "zstream_search" in result
         assert "Do not use upstream patches for older z-streams" in result
+
+    def test_renders_needs_internal_fix(self):
+        result = render_template(
+            "triage/prompt.j2",
+            TriageInputSchema(
+                issue="RHEL-189361",
+                needs_internal_fix=True,
+                internal_target_branch="rhel-10.2",
+            ),
+        )
+        assert "RHEL-189361" in result
+        assert "clone_repository" in result
+        assert "redhat/rhel/rpms" in result
+        assert "rhel-10.2" in result
+        assert "centos-stream" in result
+
+    def test_renders_needs_internal_fix_without_branch_falls_back(self):
+        result = render_template(
+            "triage/prompt.j2",
+            TriageInputSchema(
+                issue="RHEL-12345",
+                needs_internal_fix=True,
+                internal_target_branch=None,
+            ),
+        )
+        assert "centos-stream" in result
+        assert "redhat/rhel/rpms" not in result
 
 
 # Lightweight stand-in models to avoid importing modules with heavy deps (nitrate)

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -208,9 +208,25 @@ async def _map_version_to_branch(
 # All schemas are now imported from ymir.common.models
 
 
-async def render_prompt(input: InputSchema, fix_version: str | None = None) -> str:
+async def render_prompt(
+    input: InputSchema,
+    fix_version: str | None = None,
+    cve_eligibility_result: CVEEligibilityResult | None = None,
+) -> str:
     older_zstream = bool(fix_version and await is_older_zstream(fix_version))
-    input_with_flag = input.model_copy(update={"is_older_zstream": older_zstream})
+
+    updates: dict = {"is_older_zstream": older_zstream}
+
+    cve_needs_internal_fix = (
+        cve_eligibility_result and cve_eligibility_result.is_cve and cve_eligibility_result.needs_internal_fix
+    )
+    if cve_needs_internal_fix and fix_version:
+        internal_branch = await _map_version_to_branch(fix_version, cve_needs_internal_fix=True)
+        if internal_branch and not internal_branch.startswith("c"):
+            updates["needs_internal_fix"] = True
+            updates["internal_target_branch"] = internal_branch
+
+    input_with_flag = input.model_copy(update=updates)
     return render_template("triage/prompt.j2", input_with_flag)
 
 
@@ -247,6 +263,7 @@ def create_triage_agent(gateway_tools, local_tool_options=None) -> ReasoningAgen
                 "search_jira_issues",
                 "zstream_search",
                 "get_maintainer_rules",
+                "clone_repository",
             ]
         ],
         memory=UnconstrainedMemory(),
@@ -264,6 +281,7 @@ def create_triage_agent(gateway_tools, local_tool_options=None) -> ReasoningAgen
             ConditionalRequirement("set_jira_fields", only_after=["get_jira_details"]),
             ConditionalRequirement("search_jira_issues", only_after=["get_jira_details"]),
             ConditionalRequirement("zstream_search", only_after=["get_jira_details"]),
+            ConditionalRequirement("clone_repository", only_after=["get_jira_details"]),
         ],
         middlewares=[GlobalTrajectoryMiddleware(pretty=True, target=get_trajectory_writeable())],
         role="Red Hat Enterprise Linux developer",
@@ -401,7 +419,11 @@ async def run_workflow(
 
             input_data = InputSchema(issue=state.jira_issue)
             response = await triage_agent.run(
-                await render_prompt(input_data, fix_version=fix_version_name),
+                await render_prompt(
+                    input_data,
+                    fix_version=fix_version_name,
+                    cve_eligibility_result=state.cve_eligibility_result,
+                ),
                 expected_output=render_template("triage/output_format.j2"),
                 **get_agent_execution_config(),
             )

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -62,6 +62,15 @@ class TriageInputSchema(BaseModel):
         default=False,
         description="Whether the issue targets an older Z-stream",
     )
+    needs_internal_fix: bool = Field(
+        default=False,
+        description="Whether the CVE needs an internal RHEL fix (SecurityTracking label, Z-stream)",
+    )
+    internal_target_branch: str | None = Field(
+        default=None,
+        description="Pre-computed internal RHEL branch to inspect (e.g. 'rhel-10.2') "
+        "when needs_internal_fix is true",
+    )
 
 
 class Task(BaseModel):


### PR DESCRIPTION
Use authenticated clone for internal RHEL branch triage

Previously the triage agent always inspected the CentOS Stream
branch (e.g. c10s), missing newer versions on the internal RHEL
branch and proposing unnecessary backports.

Pre-compute the internal target branch from fix_version and CVE
eligibility, pass it to the triage prompt, and instruct the agent
to use the authenticated clone_repository tool for the RHEL
namespace with a CentOS Stream fallback when the branch does not
exist.

Assisted-by: Cursor (Claude)