### PR TITLE
fix(sentry): ignore LLM logging and use Sentry logs

### DIFF
--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -241,5 +241,7 @@ def init_sentry() -> None:
             LiteLLMIntegration(),
         ],
     )
-    ignore_logger("agent.redis")
-    ignore_logger_for_sentry_logs("agent.redis")
+
+    for ignored_logger in ("agent.redis", "agent.task_loop", "agent.trajectory"):
+        ignore_logger(ignored_logger)
+        ignore_logger_for_sentry_logs(ignored_logger)


### PR DESCRIPTION
Based on the changes in the later mentioned PR, the current logging outputs logged strings line-by-line which causes issues with the Sentry logging integration as, for example, the dumped JSONs produce entries even for closing tokens such as `}`.

Therefore adjust the setup to ignore the logging from the affected logger and log explicitly via Sentry SDK, so that it is formatted properly.

Related to #630