### PR TITLE
Stop filtering components in the jira-issue-fetcher

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -93,7 +93,7 @@ Two CronJobs run the fetcher with different JQL queries:
 | `jira-issue-fetcher` | `0 8 * * *` (daily, 8am UTC) | Main CVE batch — processes up to `MAX_ISSUES` issues from the filter in `jira-issue-fetcher-filter-env` | `jira-issue-fetcher-filter-env` |
 | `jira-issue-fetcher-todo` | `*/5 * * * *` | `labels = "ymir_todo"` | `jira-issue-fetcher-todo-env` |
 
-Both share the common knobs (`IGNORED_COMPONENTS`, `MAX_ISSUES`, `LOGLEVEL`) from `jira-issue-fetcher-env`. Each pod mounts the shared configmap plus its per-cron QUERY configmap. To target a different batch, edit `configmap-jira-issue-fetcher-filter-env.yml` and re-apply.
+Both share the common knobs (`MAX_ISSUES`, `LOGLEVEL`) from `jira-issue-fetcher-env`. Components excluded from scope are part of the Jira filter itself, maintained (with rationale per component) in the separate [`cve-scope`](https://gitlab.cee.redhat.com/jotnar-project/cve-scope) repo — not in a configmap or env var. The `ymir_todo` fetcher uses its own JQL (`labels = "ymir_todo"`) and is not filtered by component, so it processes any issue a maintainer tags regardless of scope exclusions. Each pod mounts the shared configmap plus its per-cron QUERY configmap. To target a different batch, edit `configmap-jira-issue-fetcher-filter-env.yml` and re-apply.
 
 Both CronJobs ship with `suspend: false` and run on their schedules out of the box. Pause or resume either one:
 

--- a/openshift/configmap-jira-issue-fetcher-env.yml
+++ b/openshift/configmap-jira-issue-fetcher-env.yml
@@ -1,6 +1,5 @@
 apiVersion: v1
 data:
-  IGNORED_COMPONENTS: "firefox,thunderbird,firefox-flatpak-container,thunderbird-flatpak-container,webkit2gtk3,openjdk,postfix,xorg-x11-server,xorg-x11-server-Xwayland,OpenEXR,tigervnc"
   MAX_ISSUES: "40"
   LOGLEVEL: "INFO"
 immutable: false

--- a/templates/jira-issue-fetcher.env
+++ b/templates/jira-issue-fetcher.env
@@ -17,9 +17,8 @@ REDIS_URL=redis://localhost:6379
 # Optional: Custom JQL query (override the default)
 #QUERY='project=RHEL and assignee = jotnar-project'
 
-
-# Optional: Comma-separated list of Jira components to ignore
-#IGNORED_COMPONENTS=component-a,component-b
+# Components excluded from scope are part of the Jira filter the QUERY points at,
+# maintained in https://gitlab.cee.redhat.com/jotnar-project/cve-scope -- not via env var.
 
 # Optional: Maximum number of issues to fetch
 #MAX_ISSUES=100

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -62,12 +62,11 @@ class JiraIssueFetcher:
         self.jira_url = os.environ["JIRA_URL"]
         self.redis_url = os.environ["REDIS_URL"]
 
-        # Allow query override from environment
+        # Allow query override from environment. Component exclusions live in the
+        # Jira filter the QUERY points at (maintained in the cve-scope repo:
+        # https://gitlab.cee.redhat.com/jotnar-project/cve-scope),
+        # not here. ymir_todo bypasses the filter and processes any component.
         self.query = os.getenv("QUERY", self.DEFAULT_QUERY)
-
-        # Optional: comma-separated list of components to ignore
-        ignored = os.getenv("IGNORED_COMPONENTS", "")
-        self.ignored_components: set[str] = {c.strip().lower() for c in ignored.split(",") if c.strip()}
 
         # Optional: maximum number of issues to fetch
         max_issues_str = os.getenv("MAX_ISSUES", "")
@@ -508,7 +507,6 @@ class JiraIssueFetcher:
 
             pushed_count = 0
             skipped_count = 0
-            ignored_count = 0
             modular_count = 0
 
             for issue in issues:
@@ -525,18 +523,6 @@ class JiraIssueFetcher:
                         logger.info(f"Skipping issue {issue_key} - modular issue: {downstream_component}")
                         modular_count += 1
                         continue
-
-                    if self.ignored_components:
-                        components = {
-                            name.lower() for c in (fields.get("components") or []) if (name := c.get("name"))
-                        }
-                        if components & self.ignored_components:
-                            logger.info(
-                                f"Skipping issue {issue_key} - has ignored component(s):"
-                                f" {components & self.ignored_components}"
-                            )
-                            ignored_count += 1
-                            continue
 
                     if issue_key in existing_keys and issue_key not in remove_issues_for_retry:
                         logger.debug(f"Skipping issue {issue_key} - already exists in triage_queue")
@@ -606,8 +592,6 @@ class JiraIssueFetcher:
             logger.info(f"Successfully pushed {pushed_count}/{len(issues)} issues to triage_queue")
             if skipped_count > 0:
                 logger.info(f"Skipped {skipped_count} issues that already exist in queue")
-            if ignored_count > 0:
-                logger.info(f"Skipped {ignored_count} issues due to ignored components")
             if modular_count > 0:
                 logger.info(f"Skipped {modular_count} modular issues")
             return pushed_count


### PR DESCRIPTION
Component scope now lives entirely in the Jira filter the fetcher queries (maintained in the separate cve-scope repo), so the fetcher no longer needs its own copy. Remove the IGNORED_COMPONENTS env var and the Python-side exclusion pass, which had drifted from the filter's list anyway. As a result ymir_todo issues are no longer filtered by component, which is the desired behaviour: the label is a manual force-process lane. The modular-component skip stays (it is not expressible in JQL).

Assisted-by: Claude Opus 4.8

Related to https://gitlab.cee.redhat.com/jotnar-project/cve-scope/-/merge_requests/1