### PR TITLE
Add VEX Not Affected Justifications guide link to Jira comments

### DIFF
--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -568,8 +568,14 @@ class TriageOutputSchema(BaseModel):
 
             case NotAffectedData():
                 category = self.data.justification_category or "Not Affected"
+                vex_guide = (
+                    "\n\n_See [VEX Not Affected Justifications|"
+                    "https://redhat.atlassian.net/wiki/spaces/PRODSEC/pages/289223326]"
+                    " for justification category definitions._"
+                )
                 return (
-                    f"*Recommendation: Not a Bug / {category}*\n\n{self.data.explanation}{TRIAGE_DISCLAIMER}"
+                    f"*Recommendation: Not a Bug / {category}*\n\n"
+                    f"{self.data.explanation}{vex_guide}{TRIAGE_DISCLAIMER}"
                 )
 
             case ErrorData():

--- a/ymir/common/tests/unit/test_models.py
+++ b/ymir/common/tests/unit/test_models.py
@@ -238,10 +238,14 @@ def test_not_affected_formatting():
     )
     result = TriageOutputSchema(resolution=Resolution.NOT_AFFECTED, data=data)
 
-    assert result.format_for_comment() == (
+    comment = result.format_for_comment()
+    assert comment == (
         "*Recommendation: Not a Bug / Vulnerable Code not Present*\n\n"
         "The vulnerable function foo_parse() was introduced in version 3.2. "
         "This package ships version 3.1, which does not contain the affected code path."
+        "\n\n_See [VEX Not Affected Justifications|"
+        "https://redhat.atlassian.net/wiki/spaces/PRODSEC/pages/289223326]"
+        " for justification category definitions._"
         f"{TRIAGE_DISCLAIMER}"
     )
 


### PR DESCRIPTION
Include a link to the ProdSec Confluence page explaining VEX justification categories in the not-affected triage comment posted to Jira issues.

Assisted-by: Claude Opus 4.6
