### PR TITLE
Guard against missing or malfunctioning Log Detective MCP server

### DIFF
--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -40,7 +40,7 @@ This skill uses the following tools. Do not restrict tool usage — use any tool
 - `download_artifacts` — Download build log artifacts (*.log.gz)
 - `download_sources` — Download sources for a dist-git package
 - `get_patch_from_url` — Download patch content from a URL
-- `extract_log_snippets` — Extract representative log snippets from build logs using Drain3 clustering
+- `extract_log_snippets` — Extract representative log snippets from build logs using Drain3 clustering (if it is available)
 
 **Local Tools (text, filesystem, git, specfile):**
 - `create` — Create new files
@@ -159,7 +159,7 @@ If the backport fails (success=false), skip to **Step 10: Comment in JIRA** with
 
 When analyzing build failures:
 1. Download all `*.log.gz` files returned in `artifacts_urls` (if any) using `download_artifacts`.
-2. Use `extract_log_snippets` with `log_path` pointing to `builder-live.log` to extract the most relevant snippets. If `builder-live.log` is not available, try `root.log` instead.
+2. If `extract_log_snippets` is available, use it with `log_path` pointing to `builder-live.log` to extract the most relevant snippets. Otherwise, start with `builder-live.log` and try to identify the build failure. If `builder-live.log` is not available, try `root.log` instead.
 3. Analyze the returned snippets to identify the build failure.
 4. Summarize the failure as the `build_error` for the retry.
 5. Remove the downloaded `*.log.gz` files after analysis.

--- a/agents_as_skills/rebase/SKILL.md
+++ b/agents_as_skills/rebase/SKILL.md
@@ -38,7 +38,7 @@ This skill uses the following tools. Do not restrict tool usage — use any tool
 - `get_maintainer_rules` — Get maintainer-specific rules and guidelines for a package
 - `build_package` — Build an SRPM and return results
 - `download_artifacts` — Download build log artifacts (*.log.gz)
-- `extract_log_snippets` — Extract representative log snippets from build logs using Drain3 clustering
+- `extract_log_snippets` — Extract representative log snippets from build logs using Drain3 clustering (if it is available)
 
 **Local Tools (text, filesystem, git, specfile):**
 - `create` — Create new files
@@ -135,7 +135,7 @@ If the rebase fails (success=false), skip to **Step 9: Comment in JIRA** with th
 
 When analyzing build failures:
 1. Download all `*.log.gz` files returned in `artifacts_urls` (if any) using `download_artifacts`.
-2. Use `extract_log_snippets` with `log_path` pointing to `builder-live.log` to extract the most relevant snippets. If `builder-live.log` is not available, try `root.log` instead.
+2. If `extract_log_snippets` is available, use it with `log_path` pointing to `builder-live.log` to extract the most relevant snippets. Otherwise, start with `builder-live.log` and try to identify the build failure. If `builder-live.log` is not available, try `root.log` instead.
 3. Analyze the returned snippets to identify the build failure.
 4. Summarize the failure as the `build_error` for the retry.
 5. Remove the downloaded `*.log.gz` files after analysis.

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -494,6 +494,9 @@ async def run_workflow(
                             upstream_patches=state.upstream_patches,
                             build_error=state.build_error,
                             triage_summary=state.triage_summary,
+                            has_extract_log_snippets=any(
+                                t.name == "extract_log_snippets" for t in gateway_tools
+                            ),
                         ),
                     ),
                     expected_output=BackportOutputSchema,

--- a/ymir/agents/build_agent.py
+++ b/ymir/agents/build_agent.py
@@ -17,6 +17,7 @@ from ymir.agents.utils import (
     render_template,
 )
 from ymir.common.logging_setup import get_trajectory_writeable
+from ymir.common.models import BuildInstructionsInput
 from ymir.tools.unprivileged.commands import RunShellCommandTool
 from ymir.tools.unprivileged.filesystem import GetCWDTool
 from ymir.tools.unprivileged.text import (
@@ -29,8 +30,11 @@ from ymir.tools.unprivileged.text import (
 )
 
 
-def get_instructions() -> str:
-    return render_template("build/instructions.j2")
+def get_instructions(*, has_extract_log_snippets: bool = False) -> str:
+    return render_template(
+        "build/instructions.j2",
+        BuildInstructionsInput(has_extract_log_snippets=has_extract_log_snippets),
+    )
 
 
 def get_prompt() -> str:
@@ -38,6 +42,28 @@ def get_prompt() -> str:
 
 
 def create_build_agent(mcp_tools: list[Tool], local_tool_options: dict[str, Any]) -> ReasoningAgent:
+    filtered_mcp_tools = [
+        t for t in mcp_tools if t.name in ["build_package", "download_artifacts", "extract_log_snippets"]
+    ]
+    available_tool_names = {t.name for t in filtered_mcp_tools}
+    has_extract_log_snippets = "extract_log_snippets" in available_tool_names
+
+    requirements = [
+        ConditionalRequirement(
+            ThinkTool,
+            force_at_step=1,
+            force_after=Tool,
+            consecutive_allowed=False,
+            only_success_invocations=False,
+        ),
+        ConditionalRequirement("build_package", min_invocations=1),
+        ConditionalRequirement("download_artifacts", only_after=["build_package"]),
+    ]
+    if "extract_log_snippets" in available_tool_names:
+        requirements.append(
+            ConditionalRequirement("extract_log_snippets", only_after=["download_artifacts"]),
+        )
+
     return ReasoningAgent(
         name="BuildAgent",
         llm=get_chat_model(),
@@ -54,22 +80,11 @@ def create_build_agent(mcp_tools: list[Tool], local_tool_options: dict[str, Any]
             StrReplaceTool(options=local_tool_options),
             SearchTextTool(options=local_tool_options),
             GetCWDTool(options=local_tool_options),
-        ]
-        + [t for t in mcp_tools if t.name in ["build_package", "download_artifacts", "extract_log_snippets"]],
-        memory=UnconstrainedMemory(),
-        requirements=[
-            ConditionalRequirement(
-                ThinkTool,
-                force_at_step=1,
-                force_after=Tool,
-                consecutive_allowed=False,
-                only_success_invocations=False,
-            ),
-            ConditionalRequirement("build_package", min_invocations=1),
-            ConditionalRequirement("download_artifacts", only_after=["build_package"]),
-            ConditionalRequirement("extract_log_snippets", only_after=["download_artifacts"]),
+            *filtered_mcp_tools,
         ],
+        memory=UnconstrainedMemory(),
+        requirements=requirements,
         middlewares=[GlobalTrajectoryMiddleware(pretty=True, target=get_trajectory_writeable())],
         role="Red Hat Enterprise Linux developer",
-        instructions=get_instructions(),
+        instructions=get_instructions(has_extract_log_snippets=has_extract_log_snippets),
     )

--- a/ymir/agents/prompts/backport/prompt_fix_build_error.j2
+++ b/ymir/agents/prompts/backport/prompt_fix_build_error.j2
@@ -60,10 +60,12 @@ SPECIAL CONSIDERATIONS FOR TEST FAILURES:
    - Use the `run_package_prep` tool to verify patches apply cleanly
    - Use the `build_srpm` tool to generate a SRPM
    - Call `build_package` with the SRPM path, dist_git_branch, and jira_issue
-   - If build fails: use `download_artifacts` to get logs, then use
-     `extract_log_snippets` with `log_path` pointing to `builder-live.log`
+   - If build fails: use `download_artifacts` to get logs and identify the new error
+{% if has_extract_log_snippets %}
+   - Use `extract_log_snippets` with `log_path` pointing to `builder-live.log`
      (or `root.log` if unavailable) to extract the most relevant snippets
      and identify the new error
+{% endif %}
 
 6. Append a summary to {{ local_clone }}-upstream/build-logs/fix-attempts.md documenting:
    - What you identified as the root cause

--- a/ymir/agents/prompts/build/instructions.j2
+++ b/ymir/agents/prompts/build/instructions.j2
@@ -3,9 +3,14 @@ You are an expert on building packages in RHEL ecosystem and analyzing build fai
 Build a package using the `build_package` tool. If the build succeeded, your work is done.
 If the build failed, download all *.log.gz files returned in `artifacts_urls`, if any,
 using the `download_artifacts` tool to the current directory. If there are no log files,
-just return the error message. Otherwise, use the `extract_log_snippets` tool with
-`log_path` pointing to the location of `builder-live.log` and try to identify
-the build failure. If not found, try the same with `root.log`. Summarize the findings
+just return the error message. Otherwise,
+{% if has_extract_log_snippets %}
+use the `extract_log_snippets` tool with `log_path` pointing to the location of
+`builder-live.log` and try to identify the build failure.
+{% else %}
+start with `builder-live.log` and try to identify the build failure.
+{% endif %}
+If the failure is not found, try the same with `root.log`. Summarize the findings
 and return them as `error`. Set `is_timeout` to the value of the `is_timeout` field
 from the `build_package` tool output. If the build_package tool itself returned an error (e.g. Copr API error,
 project setup failure, or build submission failure) rather than a build failure with logs,

--- a/ymir/agents/tests/unit/test_jinja2_templates.py
+++ b/ymir/agents/tests/unit/test_jinja2_templates.py
@@ -33,6 +33,7 @@ try:
     from ymir.common.models import (
         BackportInputSchema,
         BuildInputSchema,
+        BuildInstructionsInput,
         LogInputSchema,
         MergeRequestInputSchema,
         RebaseInputSchema,
@@ -40,6 +41,9 @@ try:
     )
 except ImportError:
     # Fallback stand-in schemas when ymir.common is not importable
+
+    class BuildInstructionsInput(BaseModel):  # type: ignore[no-redef]
+        has_extract_log_snippets: bool = False
 
     class BuildInputSchema(BaseModel):  # type: ignore[no-redef]
         srpm_path: Path
@@ -61,6 +65,7 @@ except ImportError:
         upstream_patches: list[str] = Field(default_factory=list)
         build_error: str | None = None
         triage_summary: str | None = None
+        has_extract_log_snippets: bool = False
 
     class RebaseInputSchema(BaseModel):  # type: ignore[no-redef]
         local_clone: Path
@@ -97,11 +102,27 @@ except ImportError:
 
 
 class TestBuildInstructions:
-    def test_loads(self):
-        result = render_template("build/instructions.j2")
+    def test_loads_with_extract_log_snippets(self):
+        result = render_template(
+            "build/instructions.j2",
+            BuildInstructionsInput(has_extract_log_snippets=True),
+        )
         assert "expert on building packages" in result
         assert "build_package" in result
         assert "builder-live.log" in result
+        assert "extract_log_snippets" in result
+        assert "start with" not in result
+
+    def test_loads_without_extract_log_snippets(self):
+        result = render_template(
+            "build/instructions.j2",
+            BuildInstructionsInput(has_extract_log_snippets=False),
+        )
+        assert "expert on building packages" in result
+        assert "build_package" in result
+        assert "builder-live.log" in result
+        assert "extract_log_snippets" not in result
+        assert "start with" in result
 
 
 class TestLogInstructions:
@@ -275,7 +296,7 @@ class TestBackportTemplate:
 
 
 class TestBackportFixBuildErrorTemplate:
-    def test_renders(self):
+    def test_renders_with_extract_log_snippets(self):
         result = render_template(
             "backport/prompt_fix_build_error.j2",
             BackportInputSchema(
@@ -286,11 +307,34 @@ class TestBackportFixBuildErrorTemplate:
                 jira_issue="RHEL-12345",
                 upstream_patches=["https://example.com/p1.patch"],
                 build_error="undefined reference to 'bar'",
+                has_extract_log_snippets=True,
             ),
         )
         assert "cherry-pick workflow succeeded but the build failed" in result
         assert "undefined reference" in result
         assert "fix-attempts.md" in result
+        assert "extract_log_snippets" in result
+        assert "start with" not in result
+
+    def test_renders_without_extract_log_snippets(self):
+        result = render_template(
+            "backport/prompt_fix_build_error.j2",
+            BackportInputSchema(
+                local_clone=Path("/tmp/clone"),
+                unpacked_sources=Path("/tmp/sources"),
+                package="libfoo",
+                dist_git_branch="c9s",
+                jira_issue="RHEL-12345",
+                upstream_patches=["https://example.com/p1.patch"],
+                build_error="undefined reference to 'bar'",
+                has_extract_log_snippets=False,
+            ),
+        )
+        assert "cherry-pick workflow succeeded but the build failed" in result
+        assert "undefined reference" in result
+        assert "fix-attempts.md" in result
+        assert "extract_log_snippets" not in result
+        assert "get logs and identify the new error" in result
 
 
 class TestRebaseTemplate:

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -162,6 +162,10 @@ class BackportInputSchema(BaseModel):
         default=None,
         description="Triage context: what was investigated and guidance on how the backport should be done",
     )
+    has_extract_log_snippets: bool = Field(
+        default=False,
+        description="Whether the extract_log_snippets tool is available",
+    )
 
 
 class BackportOutputSchema(BaseModel):
@@ -583,6 +587,15 @@ class TriageOutputSchema(BaseModel):
 # ============================================================================
 # Build Agent Schemas
 # ============================================================================
+
+
+class BuildInstructionsInput(BaseModel):
+    """Input schema for the build agent instructions template."""
+
+    has_extract_log_snippets: bool = Field(
+        default=False,
+        description="Whether the extract_log_snippets tool is available",
+    )
 
 
 class BuildInputSchema(BaseModel):

--- a/ymir/tools/gateway_utils.py
+++ b/ymir/tools/gateway_utils.py
@@ -61,7 +61,17 @@ def setup_logging():
 
 
 async def get_log_detective_mcp() -> list[MCPTool]:
-    """Get MCP tools provided by Log Detective MCP server."""
-    client = stdio_client(StdioServerParameters(command="logdetective-mcp"))
+    """Get MCP tools provided by Log Detective MCP server.
 
-    return await MCPTool.from_client(client)
+    Returns an empty list if the logdetective-mcp binary is not installed
+    or the server is not accessible.
+    """
+    try:
+        client = stdio_client(StdioServerParameters(command="logdetective-mcp"))
+        return await MCPTool.from_client(client)
+    except Exception:
+        logger.warning(
+            "LogDetective MCP server is not available; extract_log_snippets tool will not be registered.",
+            exc_info=True,
+        )
+        return []

--- a/ymir/tools/privileged/gateway.py
+++ b/ymir/tools/privileged/gateway.py
@@ -119,8 +119,14 @@ async def _async_main():
     tool_options: dict = {"working_directory": None}
     mcp = MCPServer(config=config)
 
-    # Get available tools from Log Detective MCP server
     log_detective_tools = await get_log_detective_mcp()
+    if log_detective_tools:
+        logger.info(
+            "LogDetective MCP tools registered: %s",
+            [t.name for t in log_detective_tools],
+        )
+    else:
+        logger.info("Gateway starting without LogDetective MCP tools.")
 
     mcp.register_many(
         [

--- a/ymir/tools/privileged/tests/unit/test_gateway.py
+++ b/ymir/tools/privileged/tests/unit/test_gateway.py
@@ -202,6 +202,15 @@ async def mock_aserve():
     pass
 
 
+def _create_async_return(value):
+    """Wrap a value in a coroutine so it can be awaited."""
+
+    async def async_return(*args, **kwargs):
+        return value
+
+    return async_return()
+
+
 class TestGatewaySharedOptions:
     def test_all_tools_share_options_dict(self):
         registered_tools = []
@@ -217,6 +226,9 @@ class TestGatewaySharedOptions:
         flexmock(gateway_module, MCPServer=lambda config: mock_server)
         flexmock(gateway_module).should_receive("setup_logging").once()
         flexmock(gateway_module).should_receive("apply_zstream_override_from_env").once()
+        flexmock(gateway_module).should_receive("get_log_detective_mcp").once().and_return(
+            _create_async_return([flexmock(name="extract_log_snippets", options=None)])
+        )
 
         gateway_module.main()
 
@@ -225,8 +237,31 @@ class TestGatewaySharedOptions:
         assert first_options is not None
         for tool in registered_tools[1:]:
             if tool.name == "extract_log_snippets":
-                # extract_log_snippets from Log Detective doesn't need shared options
                 continue
             assert tool.options is first_options, (
                 f"{type(tool).__name__} does not share the same options dict"
             )
+
+    def test_gateway_starts_without_log_detective(self):
+        """Verify gateway starts correctly when LogDetective MCP is unavailable."""
+        registered_tools = []
+
+        mock_server = flexmock()
+        mock_server.should_receive("register_many").once().replace_with(
+            lambda tools: registered_tools.extend(tools)
+        )
+        mock_server.should_receive("aserve").once().replace_with(mock_aserve)
+
+        import ymir.tools.privileged.gateway as gateway_module
+
+        flexmock(gateway_module, MCPServer=lambda config: mock_server)
+        flexmock(gateway_module).should_receive("setup_logging").once()
+        flexmock(gateway_module).should_receive("apply_zstream_override_from_env").once()
+        flexmock(gateway_module).should_receive("get_log_detective_mcp").once().and_return(
+            _create_async_return([])
+        )
+
+        gateway_module.main()
+
+        assert registered_tools, "No tools were registered"
+        assert not any(t.name == "extract_log_snippets" for t in registered_tools)

--- a/ymir/tools/privileged/tests/unit/test_gateway_utils.py
+++ b/ymir/tools/privileged/tests/unit/test_gateway_utils.py
@@ -1,5 +1,7 @@
 """Unit tests for ymir.tools.gateway_utils.get_log_detective_mcp."""
 
+import logging
+
 import pytest
 from beeai_framework.tools.mcp import MCPTool
 from flexmock import flexmock
@@ -50,12 +52,41 @@ class TestGetLogDetectiveMcp:
         await get_log_detective_mcp()
 
     @pytest.mark.asyncio
-    async def test_propagates_runtime_error(self):
+    async def test_returns_empty_list_on_runtime_error(self):
         mock_client = flexmock()
         flexmock(gateway_utils_module).should_receive("stdio_client").once().and_return(mock_client)
         flexmock(MCPTool).should_receive("from_client").with_args(mock_client).once().and_raise(
             RuntimeError("MCP Client Session has been destroyed.")
         )
 
-        with pytest.raises(RuntimeError, match="MCP Client Session has been destroyed"):
+        result = await get_log_detective_mcp()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_on_file_not_found(self):
+        flexmock(gateway_utils_module).should_receive("stdio_client").once().and_raise(
+            FileNotFoundError("logdetective-mcp")
+        )
+
+        result = await get_log_detective_mcp()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_on_os_error(self):
+        flexmock(gateway_utils_module).should_receive("stdio_client").once().and_raise(
+            OSError("Permission denied")
+        )
+
+        result = await get_log_detective_mcp()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_on_failure(self, caplog):
+        flexmock(gateway_utils_module).should_receive("stdio_client").once().and_raise(
+            FileNotFoundError("logdetective-mcp")
+        )
+
+        with caplog.at_level(logging.WARNING, logger="ymir.tools.gateway_utils"):
             await get_log_detective_mcp()
+
+        assert "LogDetective MCP server is not available" in caplog.text


### PR DESCRIPTION
Existing implementation of LD integration didn't have a fallback in case something went wrong with the server.
While it is relatively unlikely that something would happen, it still makes sense to test server presence and only let agents use it if it works.

The jinja templates of relevant agents were modified to mention `extract_log_snippets` if it is available.

Similar modification was made in skills. 

RELEASE NOTES BEGIN

Inclusion of Log Detective MPC server is now conditionally reflected in prompts.

RELEASE NOTES END
