### PR TITLE
egress: allow sourceware.org and savannah IPv6 (2001:470:142::/48)

### DIFF
--- a/openshift/tenant-egress.yml
+++ b/openshift/tenant-egress.yml
@@ -96,12 +96,21 @@ spec:
     - type: Allow
       to:
         dnsName: googleapis.com
-    # GNU project hosting (gnu.org, ftp.gnu.org, savannah.gnu.org, savannah.nongnu.org)
-    # All resolve to 209.51.188.0/24; dnsName selector picks AAAA records which
-    # don't match this cluster's IPv4-only egress policy, so use CIDR instead.
+    # GNU project hosting (gnu.org, ftp.gnu.org, savannah.gnu.org, savannah.nongnu.org,
+    # git.savannah.nongnu.org). IPv4: all resolve to 209.51.188.0/24; dnsName selector
+    # picks AAAA records which don't match this cluster's IPv4-only egress policy, so
+    # use CIDR instead. IPv6: savannah hosts use 2001:470:142::/48 (Hurricane Electric).
     - type: Allow
       to:
         cidrSelector: 209.51.188.0/24
+    - type: Allow
+      to:
+        cidrSelector: 2001:470:142::/48
+    # sourceware.org — upstream git for glibc, binutils, elfutils, newlib, etc.
+    # Resolves to 38.145.34.32 (Cogent); not covered by existing CIDRs.
+    - type: Allow
+      to:
+        dnsName: sourceware.org
     # Sentry monitoring
     - type: Allow
       to:


### PR DESCRIPTION
## Summary

- Add IPv6 CIDR `2001:470:142::/48` (Hurricane Electric) for savannah.gnu.org and related GNU project hosts
- Add `dnsName: sourceware.org` egress rule — upstream git for glibc, binutils, elfutils, newlib, etc.
- Update comment to mention `git.savannah.nongnu.org` and the IPv6 range

## Test plan

- [ ] Verify agents can reach `sourceware.org` (e.g. clone glibc)
- [ ] Verify agents can reach `git.savannah.nongnu.org` over IPv6

🤖 Generated with [Claude Code](https://claude.com/claude-code)