### PR TITLE
egress: drop IPv6 CIDR rules and favor IPv4 resolution

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -8,6 +8,10 @@ RUN dnf -y install epel-release \
 COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 
+# Prefer IPv4 over IPv6; cluster has no IPv6 egress routing.
+# Full table must be specified — a single precedence line discards all defaults.
+RUN printf "precedence ::1/128       50\nprecedence ::/0          40\nprecedence 2002::/16     30\nprecedence ::/96         20\nprecedence ::ffff:0:0/96 100\n" > /etc/gai.conf
+
 ARG INTERNAL_REPO_URL=""
 RUN if [ -n "$INTERNAL_REPO_URL" ]; then \
       curl -fsSL -o /etc/yum.repos.d/internal.repo "$INTERNAL_REPO_URL"; \

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -8,6 +8,10 @@ RUN dnf -y install epel-release \
 COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 
+# Prefer IPv4 over IPv6; cluster has no IPv6 egress routing.
+# Full table must be specified — a single precedence line discards all defaults.
+RUN printf "precedence ::1/128       50\nprecedence ::/0          40\nprecedence 2002::/16     30\nprecedence ::/96         20\nprecedence ::ffff:0:0/96 100\n" > /etc/gai.conf
+
 ARG INTERNAL_REPO_URL=""
 RUN if [ -n "$INTERNAL_REPO_URL" ]; then \
       curl -fsSL -o /etc/yum.repos.d/internal.repo "$INTERNAL_REPO_URL"; \

--- a/Containerfile.mcp
+++ b/Containerfile.mcp
@@ -4,6 +4,10 @@ FROM fedora:43
 COPY files/Current-IT-Root-CAs.pem /etc/pki/ca-trust/source/anchors/
 RUN update-ca-trust
 
+# Prefer IPv4 over IPv6; cluster has no IPv6 egress routing.
+# Full table must be specified — a single precedence line discards all defaults.
+RUN printf "precedence ::1/128       50\nprecedence ::/0          40\nprecedence 2002::/16     30\nprecedence ::/96         20\nprecedence ::ffff:0:0/96 100\n" > /etc/gai.conf
+
 ARG INTERNAL_REPO_URL=""
 RUN if [ -n "$INTERNAL_REPO_URL" ]; then \
       curl -fsSL -o /etc/yum.repos.d/internal.repo "$INTERNAL_REPO_URL"; \

--- a/openshift/tenant-egress.yml
+++ b/openshift/tenant-egress.yml
@@ -97,15 +97,11 @@ spec:
       to:
         dnsName: googleapis.com
     # GNU project hosting (gnu.org, ftp.gnu.org, savannah.gnu.org, savannah.nongnu.org,
-    # git.savannah.nongnu.org). IPv4: all resolve to 209.51.188.0/24; dnsName selector
-    # picks AAAA records which don't match this cluster's IPv4-only egress policy, so
-    # use CIDR instead. IPv6: savannah hosts use 2001:470:142::/48 (Hurricane Electric).
+    # git.savannah.nongnu.org). All resolve to 209.51.188.0/24; dnsName selector picks
+    # AAAA records which don't match this cluster's IPv4-only egress, so use CIDR instead.
     - type: Allow
       to:
         cidrSelector: 209.51.188.0/24
-    - type: Allow
-      to:
-        cidrSelector: 2001:470:142::/48
     # sourceware.org — upstream git for glibc, binutils, elfutils, newlib, etc.
     # Resolves to 38.145.34.32 (Cogent); not covered by existing CIDRs.
     - type: Allow
@@ -115,6 +111,9 @@ spec:
     - type: Allow
       to:
         dnsName: o490301.ingest.us.sentry.io
+    # IPv6 note: this cluster has no IPv6 egress routing. curl -6 to both allowed CIDRs
+    # (e.g. 2001:470:142::/48 for savannah) and arbitrary hosts (ipv6.google.com) time out
+    # identically — the EgressFirewall never sees IPv6 traffic. No IPv6 rules needed.
     # Catch-all deny
     - type: Deny
       to:


### PR DESCRIPTION
Verified by exec-ing into a running pod and running curl -6 against
both an explicitly allowed IPv6 CIDR (2001:470:142::/48, savannah.gnu.org)
and an arbitrary host (ipv6.google.com). Both timed out identically —
the EgressFirewall never sees IPv6 traffic on this cluster.

IPv6 rules (allow CIDRs, deny-all ::/0) are no-ops here. Dropped them
and added a comment documenting the finding so future contributors don't
add them again.

Signed-off-by: Tomas Tomecek <ttomecek@redhat.com>
Assisted-by: Claude and Gemini
