### PR TITLE
Smarter download_artifacts tool

### DIFF
--- a/ymir/agents/prompts/build/instructions.j2
+++ b/ymir/agents/prompts/build/instructions.j2
@@ -2,7 +2,7 @@ You are an expert on building packages in RHEL ecosystem and analyzing build fai
 
 Build a package using the `build_package` tool. If the build succeeded, your work is done.
 If the build failed, download all *.log.gz files returned in `artifacts_urls`, if any,
-using the `download_artifacts` tool to the current directory. If there are no log files,
+using the `download_artifacts` tool to a temporary directory. If there are no log files,
 just return the error message. Otherwise,
 {% if has_extract_log_snippets %}
 use the `extract_log_snippets` tool with `log_path` pointing to the location of

--- a/ymir/tools/privileged/copr.py
+++ b/ymir/tools/privileged/copr.py
@@ -2,8 +2,10 @@ import asyncio
 import gzip
 import logging
 import random
+import tempfile
 import time
 from pathlib import Path
+from shutil import rmtree
 from urllib.parse import urljoin, urlparse
 
 import aiohttp
@@ -12,7 +14,6 @@ from beeai_framework.context import RunContext
 from beeai_framework.emitter import Emitter
 from beeai_framework.tools import (
     JSONToolOutput,
-    StringToolOutput,
     ToolError,
     ToolRunOptions,
 )
@@ -324,13 +325,22 @@ class BuildPackageTool(Tool[BuildPackageToolInput, ToolRunOptions, BuildPackageT
 
 class DownloadArtifactsToolInput(BaseModel):
     artifacts_urls: list[str] = Field(description="URLs to build artifacts (logs and RPM files)")
-    target_path: AbsolutePath = Field(description="Absolute path where to download the artifacts")
 
 
-class DownloadArtifactsTool(Tool[DownloadArtifactsToolInput, ToolRunOptions, StringToolOutput]):
+class DownloadArtifactsResult(BaseModel):
+    target_path: Path = Field(description="Location of downloaded files")
+
+
+class DownloadArtifactsToolOutput(JSONToolOutput[DownloadArtifactsResult]):
+    def get_text_content(self) -> str:
+        """Return content with minimum tokens possible"""
+        return f"target_path: {self.result.target_path}"
+
+
+class DownloadArtifactsTool(Tool[DownloadArtifactsToolInput, ToolRunOptions, DownloadArtifactsToolOutput]):
     name = "download_artifacts"
     description = """
-    Downloads build artifacts to the specified location.
+    Downloads build artifacts to a temporary location.
     Any gzipped log files will be automatically decompressed,
     for example `http://example.com/builder-live.log.gz`
     will be downloaded as `builder-live.log`.
@@ -348,9 +358,9 @@ class DownloadArtifactsTool(Tool[DownloadArtifactsToolInput, ToolRunOptions, Str
         tool_input: DownloadArtifactsToolInput,
         options: ToolRunOptions | None,
         context: RunContext,
-    ) -> StringToolOutput:
+    ) -> DownloadArtifactsToolOutput:
         artifacts_urls = tool_input.artifacts_urls
-        target_path = tool_input.target_path
+        target_path = Path(tempfile.mkdtemp())
         async with aiohttp.ClientSession(
             timeout=AIOHTTP_TIMEOUT, headers={"User-Agent": YMIR_USER_AGENT}
         ) as session:
@@ -369,7 +379,9 @@ class DownloadArtifactsTool(Tool[DownloadArtifactsToolInput, ToolRunOptions, Str
                                     target = target.with_suffix("")
                             (target_path / target).write_bytes(content)
                         else:
-                            raise ToolError(f"Failed to download {url}: {response.status} {response.reason}")
-                except (aiohttp.ClientError, TimeoutError) as e:
+                            raise ValueError(f"{response.status} {response.reason}")
+                except Exception as e:
+                    # Cleanup temporary dir
+                    rmtree(target_path)
                     raise ToolError(f"Failed to download {url}: {e}") from e
-        return StringToolOutput(result="Successfully downloaded the specified build artifacts")
+        return DownloadArtifactsToolOutput(result=DownloadArtifactsResult(target_path=target_path))

--- a/ymir/tools/privileged/tests/unit/test_copr.py
+++ b/ymir/tools/privileged/tests/unit/test_copr.py
@@ -170,9 +170,8 @@ async def test_build_package(build_failure, build_timeout, exclusive_arch, dist_
     ],
 )
 @pytest.mark.asyncio
-async def test_download_artifacts(url, tmp_path):
+async def test_download_artifacts(url):
     artifacts_urls = [url]
-    target_path = tmp_path
     content = b"12345"
     content_gz = b"\x1f\x8b\x00\x00"
 
@@ -189,19 +188,12 @@ async def test_download_artifacts(url, tmp_path):
     )
     if "broken" in url:
         with pytest.raises(ToolError):
-            await DownloadArtifactsTool().run(
-                input={"artifacts_urls": artifacts_urls, "target_path": target_path}
-            )
+            await DownloadArtifactsTool().run(input={"artifacts_urls": artifacts_urls})
     else:
-        out = await DownloadArtifactsTool().run(
-            input={"artifacts_urls": artifacts_urls, "target_path": target_path}
-        )
+        out = await DownloadArtifactsTool().run(input={"artifacts_urls": artifacts_urls})
         result = out.result
-        assert result.startswith("Successfully")
-    path = target_path / url.rsplit("/", 1)[-1].removesuffix(".gz")
-    if "broken" in url:
-        assert not path.is_file()
-    else:
+        target_path = Path(result.target_path)
+        path = target_path / url.rsplit("/", 1)[-1].removesuffix(".gz")
         assert path.read_bytes() == content
 
 

--- a/ymir/tools/pyproject.toml
+++ b/ymir/tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-tools"
-version = "0.6.1"
+version = "0.7.0"
 description = "Ymir MCP tools for AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]


### PR DESCRIPTION
The tool has been rewritten to allow less space for errors. Instead of letting agent choose where to download files to, which is also a security hazard, the agent can only choose what to download. Upon invocation, the tool creates a temporary directory, and all artifacts are downloaded there.

Path to the temporary directory is returned upon successful tool run. If the tool fails, the temporary directory and all contents are removed.

The cleanup step is, arguably, an overkill. Name of the temporary dir is generated randomly, and unless the agent were to get into a particularly vicious loop, it is unlikely to run out possible names.

The tool output has been written with custom `get_text_content` method, to cut down number of tokens used. It is very much a question of taste, as we are saving handful of tokens per call at best.

Fixes

PACKIT-5157: Download artifacts failing due to nonexistent directory 

RELEASE NOTES BEGIN

The `download_artifacts` tool now uses temporary directories to store downloaded artifacts, and does not allow agent to choose where artifacts are downloaded.

RELEASE NOTES END
