### PR TITLE
Adapt rebuild agent to older z-streams

### DIFF
--- a/ymir/agents/prompts/triage/output_format.j2
+++ b/ymir/agents/prompts/triage/output_format.j2
@@ -53,12 +53,15 @@ Rebuild resolution:
         "triage_summary": "Confirmed package vendors Go deps via spec BuildRequires.",
         "dependency_issue": "RHEL-67890",
         "dependency_component": "golang",
-        "fix_version": "rhel-X.Y.Z"
+        "fix_version": "rhel-X.Y.Z",
+        "side_tag": "rhel-9.4.0-z-build-sidetag-188995"
     }
 }
 ```
 Note: When the Jira issue covers multiple CVEs, include ALL CVE IDs in `cve_id`, e.g.:
 `"cve_id": "CVE-1234-98765 CVE-1234-98766"`
+Note: Include `side_tag` only for older z-stream rebuilds, when the Jira issue
+mentions a build side-tag. Do not set it otherwise.
 
 Postponed resolution (rebuild waiting for dependency):
 ```json

--- a/ymir/agents/prompts/triage/prompt.j2
+++ b/ymir/agents/prompts/triage/prompt.j2
@@ -343,6 +343,13 @@ You must decide between one of the following actions. Follow these guidelines to
    3.3. You must provide a clear justification explaining why a rebuild is needed
         and how it addresses the issue.
    3.4. If rebuild: set Jira fields as per the instructions below.
+   {% if is_older_zstream %}
+   3.5. Check the Jira issue description and comments for any mention of a build
+        side-tag. A side-tag is a Koji build tag name that the build pipeline
+        needs when building packages for this z-stream (e.g.,
+        "rhel-9.4.0-z-build-sidetag-188995"). If a side-tag is mentioned, set
+        the `side_tag` field in your output to the exact side-tag name.
+   {% endif %}
 
 4. **Open-Ended Analysis**
    This is the catch-all for issues that are NOT bugs or CVEs

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -63,6 +63,7 @@ async def main() -> None:
         dependency_component: str | None = Field(default=None)
         consolidated_issues: list[ConsolidatedIssue] = Field(default_factory=list)
         consolidation_summary: str | None = Field(default=None)
+        side_tag: str | None = Field(default=None)
 
     async def run_workflow(
         package,
@@ -74,6 +75,7 @@ async def main() -> None:
         dependency_component=None,
         consolidated_issues=None,
         consolidation_summary=None,
+        side_tag=None,
         user_triggered=False,
     ):
         local_tool_options["working_directory"] = None
@@ -115,7 +117,7 @@ async def main() -> None:
                     state.rebuild_success = False
                     state.rebuild_error = f"Could not update release: {e}"
                     return "comment_in_jira"
-                return "run_log_agent"
+                return "stage_changes"
 
             def _all_dependency_components(state):
                 components = set()
@@ -176,7 +178,9 @@ async def main() -> None:
                     state.rebuild_success = False
                     state.rebuild_error = f"Could not stage changes: {e}"
                     return "comment_in_jira"
-                return "commit_push_and_open_mr"
+                if state.log_result:
+                    return "commit_push_and_open_mr"
+                return "run_log_agent"
 
             async def commit_push_and_open_mr(state):
                 try:
@@ -206,6 +210,8 @@ async def main() -> None:
                     all_issues = [state.jira_issue] + [ci.issue_key for ci in state.consolidated_issues]
                     resolves_text = "Resolves: " + ", ".join(all_issues)
 
+                    side_tag_text = f"\nside-tag: {state.side_tag}\n" if state.side_tag else ""
+
                     consolidation_text = ""
                     if state.consolidation_summary:
                         consolidation_text = (
@@ -233,10 +239,11 @@ async def main() -> None:
                         mr_title=state.log_result.title,
                         mr_description=(
                             f"{state.log_result.description}\n\n"
-                            f"{triage_details_text}"
                             f"{dep_text}"
                             f"{dep_issues_text}"
                             f"{resolves_text}\n"
+                            f"{side_tag_text}\n"
+                            f"{triage_details_text}"
                             f"{consolidation_text}"
                             f"\n\n{mr_description_footer(state.package)}"
                         ),
@@ -285,8 +292,8 @@ async def main() -> None:
 
             workflow.add_step("fork_and_prepare_dist_git", fork_and_prepare_dist_git)
             workflow.add_step("update_release", update_release)
-            workflow.add_step("run_log_agent", run_log_agent)
             workflow.add_step("stage_changes", stage_changes)
+            workflow.add_step("run_log_agent", run_log_agent)
             workflow.add_step("commit_push_and_open_mr", commit_push_and_open_mr)
             workflow.add_step("comment_in_jira", comment_in_jira)
 
@@ -301,6 +308,7 @@ async def main() -> None:
                     dependency_component=dependency_component,
                     consolidated_issues=consolidated_issues or [],
                     consolidation_summary=consolidation_summary,
+                    side_tag=side_tag,
                 ),
             )
             return response.state
@@ -448,6 +456,7 @@ async def main() -> None:
                         dependency_component=rebuild_data.dependency_component,
                         consolidated_issues=rebuild_data.consolidated_issues,
                         consolidation_summary=rebuild_data.consolidation_summary,
+                        side_tag=rebuild_data.side_tag,
                         user_triggered=user_triggered,
                     )
                     logger.info(

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -305,6 +305,10 @@ class RebuildData(BaseModel):
         default=None,
     )
     fix_version: str | None = Field(description="Fix version in Jira (e.g., 'rhel-9.8')", default=None)
+    side_tag: str | None = Field(
+        description="Koji build side-tag name from the Jira issue, if specified (older z-streams only)",
+        default=None,
+    )
     consolidated_issues: list[ConsolidatedIssue] = Field(
         default_factory=list,
         description="Sibling issues consolidated into this rebuild task",


### PR DESCRIPTION
We just started using the rebuild agent for older z-streams and these are the changes required to make it work for us. The inclusion of the side-tag is required so it can be propagated to MR and trigger pipeline automatic side-tag selection when building (the current requirement is that its lives on its own line in the MR description, clearly separated from everything else). The stage_changes logic requires adjustment because update_release changes need to be staged before run_log_agent makes further changes otherwise it makes a mess by updating the existing changelog entry (since its not aware of the update release changes otherwise). 