### PR TITLE
Fix buildroot check for c8s z-stream rebuilds

### DIFF
--- a/ymir/common/utils.py
+++ b/ymir/common/utils.py
@@ -27,7 +27,11 @@ from specfile.utils import EVR
 from ymir.common.base_utils import is_cs_branch
 from ymir.common.constants import BREWHUB_URL, CENTOS_STREAM_KOJIHUB_URL
 from ymir.common.logging_setup import get_trajectory_writeable
-from ymir.common.version_utils import construct_internal_branch_name, parse_rhel_version
+from ymir.common.version_utils import (
+    construct_internal_branch_name,
+    get_maintenance_majors,
+    parse_rhel_version,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -222,23 +226,32 @@ async def get_latest_candidate_build(package: str, dist_git_branch: str) -> tupl
     return evr, source_ref
 
 
-def _resolve_buildroot_checks(target_branch: str, fix_version: str) -> list[tuple[str, str]]:
+def _resolve_buildroot_checks(
+    target_branch: str, fix_version: str, rhel_config: dict | None = None
+) -> list[tuple[str, str]]:
     """Return a list of (koji_hub_url, build_tag) pairs to verify.
 
     For CS branches with a Z-stream fix_version, both the CS Koji
     buildroot and the Brew Z-stream buildroot are checked (CS-first
-    approach produces two builds).  For internal RHEL branches with
-    a Z-stream fix_version, only the Brew Z-stream buildroot is checked.
+    approach produces two builds).  CS branches in maintenance phase
+    (z-stream only, no y-stream) are an exception: only the Brew
+    Z-stream buildroot is checked since CentOS Stream Koji is stale.
+    For internal RHEL branches with a Z-stream fix_version, only the
+    Brew Z-stream buildroot is checked.
     """
     is_zstream = fix_version.lower().endswith(".z")
 
     if is_cs_branch(target_branch):
-        checks = [(CENTOS_STREAM_KOJIHUB_URL, f"{target_branch}-build")]
         if is_zstream and (parsed := parse_rhel_version(fix_version)):
             major, minor, _ = parsed
             rhel_branch = construct_internal_branch_name(major, minor)
-            checks.append((BREWHUB_URL, f"{rhel_branch}-z-build"))
-        return checks
+            if rhel_config and major in get_maintenance_majors(rhel_config):
+                return [(BREWHUB_URL, f"{rhel_branch}-z-build")]
+            return [
+                (CENTOS_STREAM_KOJIHUB_URL, f"{target_branch}-build"),
+                (BREWHUB_URL, f"{rhel_branch}-z-build"),
+            ]
+        return [(CENTOS_STREAM_KOJIHUB_URL, f"{target_branch}-build")]
 
     suffix = "-z-build" if is_zstream else "-build"
     return [(BREWHUB_URL, f"{target_branch}{suffix}")]
@@ -254,9 +267,13 @@ async def check_build_in_buildroot(
 
     Queries the appropriate Koji instance(s) based on ``target_branch`` and
     ``fix_version``.  For CS Z-stream fixes, both the CS Koji and Brew
-    Z-stream buildroots are checked.
+    Z-stream buildroots are checked (unless the major version is in
+    maintenance, in which case only Brew is checked).
     """
-    checks = _resolve_buildroot_checks(target_branch, fix_version)
+    from ymir.common.config import load_rhel_config
+
+    rhel_config = await load_rhel_config()
+    checks = _resolve_buildroot_checks(target_branch, fix_version, rhel_config)
 
     # Always resolve the fixed build's epoch from Brew — the NVR in
     # Jira's "Fixed in Build" is a Brew NVR (e.g. .el9_8) and may

--- a/ymir/common/version_utils.py
+++ b/ymir/common/version_utils.py
@@ -118,6 +118,13 @@ def normalize_fix_version(fix_version: str, rhel_config: dict) -> str:
     return f"rhel-{major}.{minor}.z"
 
 
+def get_maintenance_majors(rhel_config: dict) -> set[str]:
+    """Major versions with a Z-stream but no Y-stream (maintenance phase)."""
+    current_z_streams = rhel_config.get("current_z_streams", {})
+    current_y_streams = rhel_config.get("current_y_streams", {})
+    return set(current_z_streams.keys()) - set(current_y_streams.keys())
+
+
 def get_fix_version_variants(fix_version: str) -> list[str]:
     """
     Return both Y-stream and Z-stream forms for a given fixVersion.

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field
 from ymir.common import CVEEligibilityResult, TriageEligibility, load_rhel_config
 from ymir.common.base_utils import get_jira_auth_headers
 from ymir.common.constants import JIRA_SEARCH_PATH
-from ymir.common.version_utils import get_fix_version_variants, normalize_fix_version
+from ymir.common.version_utils import get_fix_version_variants, get_maintenance_majors, normalize_fix_version
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT
 from ymir.tools.http import aiohttp_get_with_retries
@@ -370,13 +370,6 @@ class AddJiraCommentTool(Tool[AddJiraCommentToolInput, ToolRunOptions, StringToo
         return StringToolOutput(result=f"Successfully added the specified comment to {issue_key}")
 
 
-def _get_maintenance_majors(rhel_config: dict) -> set[str]:
-    """Major versions with a Z-stream but no Y-stream (maintenance phase)."""
-    current_z_streams = rhel_config.get("current_z_streams", {})
-    current_y_streams = rhel_config.get("current_y_streams", {})
-    return set(current_z_streams.keys()) - set(current_y_streams.keys())
-
-
 CVE_ID_PATTERN = re.compile(r"(CVE-\d{4}-\d{4,})")
 
 
@@ -411,7 +404,7 @@ async def _check_zstream_clones_shipped(
     rhel_config = await load_rhel_config()
     current_z_streams = rhel_config.get("current_z_streams", {})
     upcoming_z_streams = rhel_config.get("upcoming_z_streams", {})
-    maintenance_majors = _get_maintenance_majors(rhel_config)
+    maintenance_majors = get_maintenance_majors(rhel_config)
     if maintenance_majors:
         logger.info(f"Maintenance-phase major versions (excluded): {sorted(maintenance_majors)}")
 


### PR DESCRIPTION
c8s is EOL — builds always go to Brew, never CentOS Stream Koji. Skip the stale c8s-build tag check and only verify the Brew z-stream buildroot (rhel-8.10.0-z-build).

Assisted-by: Claude (Cursor)