### PR TITLE
Skip triage for already-closed Jira issues

### DIFF
--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -380,7 +380,6 @@ async def get_jira_issue_metadata(jira_issue: str) -> tuple[list[str], str | Non
         return [], None
 
 
-
 # Intermediate "_failed" labels (transient retry-state) are suppressed for
 # non-user-triggered runs — they're noise for maintainers and a retry will
 # follow. Terminal "_errored" labels are kept regardless: they are the only

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -363,7 +363,8 @@ async def change_jira_status(
     )
 
 
-async def get_jira_labels(jira_issue: str) -> list[str]:
+async def get_jira_issue_metadata(jira_issue: str) -> tuple[list[str], str | None]:
+    """Fetch labels and status for a Jira issue in a single API call."""
     try:
         async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
             details = await run_tool(
@@ -371,10 +372,13 @@ async def get_jira_labels(jira_issue: str) -> list[str]:
                 issue_key=jira_issue,
                 available_tools=gateway_tools,
             )
-            return details.get("fields", {}).get("labels", [])
+            labels = details.get("fields", {}).get("labels", [])
+            status = details.get("fields", {}).get("status", {}).get("name")
+            return labels, status
     except Exception as e:
-        logger.warning(f"Failed to get labels for {jira_issue}: {e}")
-        return []
+        logger.warning(f"Failed to get metadata for {jira_issue}: {e}")
+        return [], None
+
 
 
 # Intermediate "_failed" labels (transient retry-state) are suppressed for

--- a/ymir/agents/tests/unit/test_tasks.py
+++ b/ymir/agents/tests/unit/test_tasks.py
@@ -3,7 +3,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from ymir.agents.tasks import change_jira_status, fork_and_prepare_dist_git, post_user_ack_once
+from ymir.agents.tasks import (
+    change_jira_status,
+    fork_and_prepare_dist_git,
+    get_jira_issue_metadata,
+    post_user_ack_once,
+)
 from ymir.common.models import Task
 
 
@@ -193,3 +198,48 @@ async def test_post_user_ack_once_does_not_persist_on_failure():
 
     mock_comment.assert_awaited_once()
     assert "ack_posted" not in task.metadata
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status_name, expected_status",
+    [
+        ("Closed", "Closed"),
+        ("Done", "Done"),
+        ("In Progress", "In Progress"),
+        ("New", "New"),
+    ],
+)
+async def test_get_jira_issue_metadata_returns_labels_and_status(status_name, expected_status):
+    """get_jira_issue_metadata extracts both labels and status from one API call."""
+    fake_details = {
+        "fields": {
+            "labels": ["ymir_todo", "SecurityTracking"],
+            "status": {"name": status_name},
+        }
+    }
+    with (
+        patch("ymir.agents.tasks.mcp_tools", _fake_mcp_tools),
+        patch("ymir.agents.tasks.run_tool", new_callable=AsyncMock, return_value=fake_details),
+    ):
+        labels, status = await get_jira_issue_metadata("RHEL-99999")
+
+    assert labels == ["ymir_todo", "SecurityTracking"]
+    assert status == expected_status
+
+
+@pytest.mark.asyncio
+async def test_get_jira_issue_metadata_returns_defaults_on_failure():
+    """On MCP/network failure, return empty labels and None status."""
+    with (
+        patch("ymir.agents.tasks.mcp_tools", _fake_mcp_tools),
+        patch(
+            "ymir.agents.tasks.run_tool",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("connection refused"),
+        ),
+    ):
+        labels, status = await get_jira_issue_metadata("RHEL-99999")
+
+    assert labels == []
+    assert status is None

--- a/ymir/agents/tests/unit/test_triage_agent.py
+++ b/ymir/agents/tests/unit/test_triage_agent.py
@@ -1,7 +1,9 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from ymir.agents.triage_agent import _should_update_jira
-from ymir.common.models import Resolution
+from ymir.common.models import Resolution, Task
 
 
 @pytest.mark.parametrize(
@@ -54,3 +56,110 @@ def test_non_user_triggered_still_posts_when_no_mr_will_open(resolution):
 def test_non_user_triggered_error_does_not_post():
     """ERROR is handled by separate error-path machinery, not this helper."""
     assert _should_update_jira(resolution=Resolution.ERROR, user_triggered=False) is False
+
+
+def _make_payload(issue: str = "RHEL-99999", user_triggered: bool = False) -> bytes:
+    task = Task.from_issue(issue, user_triggered=user_triggered)
+    return task.model_dump_json().encode()
+
+
+async def _capture_process_task(main_fn):
+    """Run main() in queue mode, capture the process_task closure it registers."""
+    captured = {}
+
+    async def fake_run_task_loop(_redis, _queues, process_fn, **_kw):
+        captured["process_task"] = process_fn
+
+    with (
+        patch("ymir.agents.triage_agent.init_sentry"),
+        patch("ymir.agents.triage_agent.configure_logging"),
+        patch("ymir.agents.triage_agent.resolve_chat_model_override"),
+        patch("ymir.agents.triage_agent.setup_observability", return_value=MagicMock()),
+        patch("ymir.agents.triage_agent.run_task_loop", side_effect=fake_run_task_loop),
+        patch("ymir.agents.triage_agent.redis_client") as mock_redis_ctx,
+        patch.dict(
+            "os.environ",
+            {
+                "COLLECTOR_ENDPOINT": "http://localhost:6006",
+                "REDIS_URL": "redis://localhost",
+                "MCP_GATEWAY_URL": "http://mcp-gateway:8000/sse",
+                "DRY_RUN": "true",
+            },
+            clear=False,
+        ),
+    ):
+        mock_redis_ctx.return_value.__aenter__ = AsyncMock()
+        mock_redis_ctx.return_value.__aexit__ = AsyncMock()
+        await main_fn()
+
+    return captured["process_task"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["Closed", "Done"])
+async def test_process_task_skips_closed_issues(status):
+    """Closed/Done issues are skipped without calling run_workflow."""
+    from ymir.agents.triage_agent import main
+
+    process_task = await _capture_process_task(main)
+
+    with (
+        patch(
+            "ymir.agents.tasks.get_jira_issue_metadata",
+            new_callable=AsyncMock,
+            return_value=([], status),
+        ),
+        patch("ymir.agents.triage_agent.run_workflow", new_callable=AsyncMock) as mock_workflow,
+    ):
+        await process_task(_make_payload())
+
+    mock_workflow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_task_skips_closed_user_triggered_with_cleanup():
+    """User-triggered run on a closed issue removes ymir_todo and posts ack."""
+    from ymir.agents.triage_agent import main
+
+    process_task = await _capture_process_task(main)
+
+    with (
+        patch(
+            "ymir.agents.tasks.get_jira_issue_metadata",
+            new_callable=AsyncMock,
+            return_value=(["ymir_todo"], "Closed"),
+        ),
+        patch("ymir.agents.triage_agent.run_workflow", new_callable=AsyncMock) as mock_workflow,
+        patch("ymir.agents.tasks.set_jira_labels", new_callable=AsyncMock) as mock_labels,
+        patch("ymir.agents.tasks.post_user_ack_once", new_callable=AsyncMock) as mock_ack,
+    ):
+        await process_task(_make_payload(user_triggered=True))
+
+    mock_workflow.assert_not_awaited()
+    mock_labels.assert_awaited_once()
+    _, kwargs = mock_labels.call_args
+    assert kwargs["labels_to_remove"] == ["ymir_todo"]
+    assert kwargs["dry_run"] is True
+    mock_ack.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_process_task_proceeds_for_open_issues():
+    """An open issue (e.g. New) is not blocked by the closed-issue check."""
+    from ymir.agents.triage_agent import main
+
+    process_task = await _capture_process_task(main)
+
+    with (
+        patch(
+            "ymir.agents.tasks.get_jira_issue_metadata",
+            new_callable=AsyncMock,
+            return_value=([], "New"),
+        ),
+        patch("ymir.agents.tasks.set_jira_labels", new_callable=AsyncMock),
+        patch("ymir.agents.tasks.post_user_ack_once", new_callable=AsyncMock),
+        patch("ymir.agents.triage_agent.run_workflow", new_callable=AsyncMock) as mock_workflow,
+    ):
+        await process_task(_make_payload())
+
+    mock_workflow.assert_awaited_once()

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -902,7 +902,7 @@ async def main() -> None:
                         task,
                         input.issue,
                         "triage",
-                        f"Issue is already **{current_status}** — skipping triage.",
+                        f"Issue is already **{current_status}** — skipping processing.",
                         user_triggered=True,
                         dry_run=dry_run,
                     )

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -44,6 +44,7 @@ from ymir.common.models import (
     ClarificationNeededData,
     CVEEligibilityResult,
     ErrorData,
+    IssueStatus,
     NotAffectedData,
     OpenEndedAnalysisData,
     PostponedData,
@@ -869,7 +870,7 @@ async def main() -> None:
             # retries do not re-post the ack after it has already been
             # delivered.
 
-            current_labels = await tasks.get_jira_labels(input.issue)
+            current_labels, current_status = await tasks.get_jira_issue_metadata(input.issue)
             all_labels = JiraLabels.all_labels()
             terminal_ymir_labels = [
                 label
@@ -886,6 +887,25 @@ async def main() -> None:
                     f"Skipping duplicate triage for {input.issue} — "
                     f"already has labels: {terminal_ymir_labels}"
                 )
+                return
+
+            if current_status in (IssueStatus.CLOSED.value, IssueStatus.DONE.value):
+                logger.info(f"Skipping triage for {input.issue} — issue is already {current_status}")
+                if user_triggered:
+                    await tasks.set_jira_labels(
+                        jira_issue=input.issue,
+                        labels_to_remove=["ymir_todo"],
+                        dry_run=dry_run,
+                        user_triggered=True,
+                    )
+                    await tasks.post_user_ack_once(
+                        task,
+                        input.issue,
+                        "triage",
+                        f"Issue is already **{current_status}** — skipping triage.",
+                        user_triggered=True,
+                        dry_run=dry_run,
+                    )
                 return
 
             async def retry(task, error, input=input, user_triggered=user_triggered):


### PR DESCRIPTION
### Problem
When the triage queue is long, a Jira issue can be closed externally before the triage agent picks it up. The agent has no status check and burns LLM tokens triaging a resolved issue.
### Solution
Add a deterministic pre-check in `process_task` that skips already-closed issues before any LLM work, by piggybacking on the existing `get_jira_details` API call (zero additional Jira round-trips).
### Changes
- **`tasks.py`**: Replace `get_jira_labels` with `get_jira_issue_metadata` that extracts both labels and status from the same `get_jira_details` response. Returns `([], None)` on failure so triage proceeds safely.
- **`triage_agent.py`**: After the existing label dedup check, return early if issue status is `Closed` or `Done`. For user-triggered runs (`ymir_todo`), remove the label and post a comment explaining the skip. Both actions respect `dry_run`.
- **`test_tasks.py`**: Tests for the new metadata helper covering status extraction and failure defaults.
- **`test_triage_agent.py`**: Tests verifying `process_task` skips closed issues, cleans up `ymir_todo` on user-triggered runs, and proceeds normally for open issues.

