### PR TITLE
chore(firewall): add the domains spotted in Sentry

### DIFF
--- a/openshift/tenant-egress.yml
+++ b/openshift/tenant-egress.yml
@@ -107,6 +107,16 @@ spec:
     - type: Allow
       to:
         dnsName: sourceware.org
+    # Upstream git forges
+    - type: Allow
+      to:
+        dnsName: gitlab.freedesktop.org
+    - type: Allow
+      to:
+        dnsName: gitlab.gnome.org
+    - type: Allow
+      to:
+        dnsName: git.postgresql.org
     # Sentry monitoring
     - type: Allow
       to:


### PR DESCRIPTION
I noticed these reoccurring errors in Sentry for fetching upstream patches. They represent majority of the captured events in the last 7 days.