### PR TITLE
Fix triage agent cloning to wrong path

### DIFF
--- a/ymir/agents/prompts/triage/prompt.j2
+++ b/ymir/agents/prompts/triage/prompt.j2
@@ -39,9 +39,11 @@ Goal: Analyze the given issue to determine the correct course of action.
    * Determine the name of the package from the issue details (usually component name)
    {% if needs_internal_fix and internal_target_branch %}
    * Use the clone_repository tool to clone `https://gitlab.com/redhat/rhel/rpms/<package_name>`
-     with branch `{{ internal_target_branch }}`.
+     with branch `{{ internal_target_branch }}` and
+     clone_path `/git-repos/{{ issue }}/<package_name>`.
      If the clone fails (branch or repo not found), fall back to cloning
-     `https://gitlab.com/redhat/centos-stream/rpms/<package_name>` using the same tool.
+     `https://gitlab.com/redhat/centos-stream/rpms/<package_name>` using the same tool
+     (keep the same clone_path).
    {% else %}
    * Confirm the package repository exists by running
      `GIT_TERMINAL_PROMPT=0 git ls-remote https://gitlab.com/redhat/centos-stream/rpms/<package_name>`

--- a/ymir/agents/tests/unit/test_jinja2_templates.py
+++ b/ymir/agents/tests/unit/test_jinja2_templates.py
@@ -467,6 +467,8 @@ class TestTriageTemplate:
         assert "redhat/rhel/rpms" in result
         assert "rhel-10.2" in result
         assert "centos-stream" in result
+        assert "clone_path" in result
+        assert "/git-repos/RHEL-189361/" in result
 
     def test_renders_needs_internal_fix_without_branch_falls_back(self):
         result = render_template(

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -432,7 +432,9 @@ class GetInternalRhelBranchesTool(
 class CloneRepositoryToolInput(BaseModel):
     repository: str = Field(description="Repository to clone")
     branch: str | None = Field(default=None, description="Branch to clone. If omitted, all refs are fetched.")
-    clone_path: AbsolutePath = Field(description="Absolute path where to clone the repository")
+    clone_path: AbsolutePath = Field(
+        description="Absolute path under the shared /git-repos volume where to clone the repository"
+    )
 
 
 class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringToolOutput]):
@@ -460,6 +462,13 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
         repository = tool_input.repository
         branch = tool_input.branch
         clone_path = tool_input.clone_path
+
+        basepath = Path(os.getenv("GIT_REPO_BASEPATH", "/git-repos")).resolve()
+        resolved = clone_path.resolve()
+        if not resolved.is_relative_to(basepath):
+            raise ToolError(f"clone_path must be under {basepath} (the shared volume). Got: {clone_path}")
+        clone_path = resolved
+
         await clean_stale_repositories()
 
         auth_args = _get_git_auth_args(repository)

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -465,7 +465,7 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
 
         basepath = Path(os.getenv("GIT_REPO_BASEPATH", "/git-repos")).resolve()
         resolved = clone_path.resolve()
-        if not resolved.is_relative_to(basepath):
+        if resolved == basepath or not resolved.is_relative_to(basepath):
             raise ToolError(f"clone_path must be under {basepath} (the shared volume). Got: {clone_path}")
         clone_path = resolved
 

--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import gitlab
 import pytest
+from beeai_framework.tools import ToolError
 from flexmock import flexmock
 from ogr.abstract import PRStatus
 from ogr.exceptions import GitlabAPIException
@@ -224,6 +225,51 @@ async def test_clone_repository(mock_git_repo_basepath):
     result = (
         await CloneRepositoryTool().run(
             input={"repository": repository, "branch": branch, "clone_path": clone_path}
+        )
+    ).result
+    assert result.startswith("Successfully")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        Path("/tmp/bash"),
+        Path("/var/lib/bash"),
+    ],
+    ids=["outside-base", "unrelated-absolute"],
+)
+async def test_clone_repository_rejects_path_outside_basepath(mock_git_repo_basepath, bad_path):
+    with pytest.raises(ToolError, match="must be under"):
+        await CloneRepositoryTool().run(
+            input={"repository": "https://gitlab.com/redhat/rhel/rpms/bash", "clone_path": bad_path}
+        )
+
+
+@pytest.mark.asyncio
+async def test_clone_repository_rejects_path_traversal(mock_git_repo_basepath):
+    traversal_path = mock_git_repo_basepath / ".." / "tmp" / "bash"
+    with pytest.raises(ToolError, match="must be under"):
+        await CloneRepositoryTool().run(
+            input={"repository": "https://gitlab.com/redhat/rhel/rpms/bash", "clone_path": traversal_path}
+        )
+
+
+@pytest.mark.asyncio
+async def test_clone_repository_accepts_path_inside_basepath(mock_git_repo_basepath):
+    valid_path = mock_git_repo_basepath / "RHEL-12345" / "bash"
+
+    async def create_subprocess_exec(cmd, *args, **kwargs):
+        async def wait():
+            return 0
+
+        return flexmock(wait=wait)
+
+    flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)
+
+    result = (
+        await CloneRepositoryTool().run(
+            input={"repository": "https://gitlab.com/redhat/rhel/rpms/bash", "clone_path": valid_path}
         )
     ).result
     assert result.startswith("Successfully")

--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -256,6 +256,17 @@ async def test_clone_repository_rejects_path_traversal(mock_git_repo_basepath):
 
 
 @pytest.mark.asyncio
+async def test_clone_repository_rejects_basepath_root(mock_git_repo_basepath):
+    with pytest.raises(ToolError, match="must be under"):
+        await CloneRepositoryTool().run(
+            input={
+                "repository": "https://gitlab.com/redhat/rhel/rpms/bash",
+                "clone_path": mock_git_repo_basepath,
+            }
+        )
+
+
+@pytest.mark.asyncio
 async def test_clone_repository_accepts_path_inside_basepath(mock_git_repo_basepath):
     valid_path = mock_git_repo_basepath / "RHEL-12345" / "bash"
 


### PR DESCRIPTION
The triage agent's `clone_repository` calls occasionally clone repos into `/tmp` inside the MCP gateway container. Since `/tmp` is not shared between the gateway and agent containers (only `/git-repos` is a shared PVC), the agent can't see the cloned repo and fails with "file not found" errors, wasting LLM tokens on recovery attempts.

Two-layer fix — prompt guidance (soft) + runtime guard (hard):
- **Prompt**: Updated `triage/prompt.j2` to explicitly instruct the LLM to pass `clone_path=/git-repos/<issue>/<package>` when calling `clone_repository`, matching the convention already used by the backport agent.
- **Tool guard**: Added a resolved-path validation in `CloneRepositoryTool._run()` that rejects any `clone_path` outside `GIT_REPO_BASEPATH` with a clear `ToolError`. Uses `Path.resolve()` on both sides to block `..` traversal. Runs before `clean_stale_repositories()` to skip unnecessary I/O on invalid requests.
- **Field description**: Updated `clone_path` schema description to mention the `/git-repos` constraint, giving the LLM an additional signal via the tool schema.
