### PR TITLE
Add interactive installer script for agent skills and MCP tools

### DIFF
--- a/agents_as_skills/README.md
+++ b/agents_as_skills/README.md
@@ -19,7 +19,17 @@ Each skill is a directory containing a `SKILL.md` file that follows the [Agent S
 
 ## Installation
 
-For per-client installation instructions (skill placement paths, MCP tool configuration), see the [Skills Installation Guide](../skills_installation.md).
+Quick install with the interactive script (skills + MCP tools + credentials):
+
+```bash
+python3 agents_as_skills/install-skills.py
+```
+
+1. Choose your client (`cursor`, `claude`, or `opencode`)
+2. Enter credentials when prompted (Jira, GitLab, Kerberos/keytab)
+3. Restart the client and confirm the MCP servers are connected
+
+For manual per-client setup (skill paths, MCP config), see the [Skills Installation Guide](../skills_installation.md).
 
 ## How to use
 

--- a/agents_as_skills/install-skills.py
+++ b/agents_as_skills/install-skills.py
@@ -87,7 +87,11 @@ def prompt_choice(label: str, choices: list[str], default: str = None) -> str:
 
 def run(cmd, **kwargs):
     print(f"  $ {' '.join(str(c) for c in cmd)}")
-    result = subprocess.run(cmd, **kwargs)
+    try:
+        result = subprocess.run(cmd, **kwargs)
+    except FileNotFoundError:
+        print(f"  ERROR: command '{cmd[0]}' not found. Please ensure it is installed and in your PATH.")
+        sys.exit(1)
     if result.returncode != 0:
         print(f"  ERROR: command failed with exit code {result.returncode}")
         sys.exit(1)
@@ -120,11 +124,14 @@ def collect_credentials() -> dict:
     use_keytab = input("  Do you have a keytab file for automated kinit? [y/N]: ").strip().lower() == "y"
     if use_keytab:
         creds["KEYTAB_FILE"] = prompt_value(
-            "Keytab file path", env_var="KEYTAB_FILE", default=str(Path.home() / ".secrets" / "keytab")
-        )
-
-    krb5cc = os.environ.get("KRB5CCNAME")
-    if krb5cc:
+    try:
+        klist_result = subprocess.run(["klist"], capture_output=True)
+        if klist_result.returncode == 0:
+            print("  Kerberos ticket found (klist succeeded).")
+        else:
+            print("  WARNING: No active Kerberos ticket. Run 'kinit' before using the tools.")
+    except FileNotFoundError:
+        print("  WARNING: 'klist' command not found. Ensure Kerberos client tools are installed.")
         creds["KRB5CCNAME"] = krb5cc
         print(f"  Using KRB5CCNAME from env: {krb5cc}")
 
@@ -159,12 +166,17 @@ def install_venv():
     if not VENV_PATH.exists():
         run([python, "-m", "venv", str(VENV_PATH)])
     else:
-        print(f"  Venv already exists at {VENV_PATH}")
+    python = "python3.13"
+    try:
+        result = subprocess.run([python, "--version"], capture_output=True)
+        if result.returncode != 0:
+            python = "python3"
+    except FileNotFoundError:
+        python = "python3"
 
-    pip = str(VENV_PATH / "bin" / "pip")
-    print("\n=> Installing ymir-common...")
-    run(
-        [
+    if python == "python3":
+        print(f"  python3.13 not found, falling back to {python}")
+        print("  WARNING: BeeAI framework requires Python < 3.14. Ensure your Python is compatible.")
             pip,
             "install",
             "--upgrade",
@@ -199,11 +211,13 @@ def write_mcp_config(client: str, creds: dict):
     priv_env = {"MCP_TRANSPORT": "stdio"}
     for key in ("GITLAB_TOKEN", "JIRA_URL", "JIRA_EMAIL", "JIRA_TOKEN", "KRB5CCNAME", "KEYTAB_FILE"):
         if creds.get(key):
-            priv_env[key] = creds[key]
-
     unpriv_env = {
         "MCP_TRANSPORT": "stdio",
         "UPSTREAM_SEARCH_API_URL": "http://upstream-search.hosted.upshift.rdu2.redhat.com:80/v1",
+    }
+    ca_bundle = Path("/etc/pki/tls/certs/ca-bundle.crt")
+    if ca_bundle.exists():
+        unpriv_env["REQUESTS_CA_BUNDLE"] = str(ca_bundle)
         "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
     }
 
@@ -234,12 +248,19 @@ def write_mcp_config(client: str, creds: dict):
                 "env": unpriv_env,
             },
         }
-        config_key = "mcpServers"
-
     existing_config = {}
     if config_path.exists():
         try:
-            existing_config = json.loads(config_path.read_text())
+            content = config_path.read_text()
+            if content.strip():
+                existing_config = json.loads(content)
+        except json.JSONDecodeError as e:
+            print(f"  ERROR: Failed to parse existing config at {config_path}: {e}")
+            print("  Please fix the JSON syntax or backup and remove the file before running again.")
+            sys.exit(1)
+        except OSError as e:
+            print(f"  ERROR: Failed to read existing config at {config_path}: {e}")
+            sys.exit(1)
         except (json.JSONDecodeError, OSError):
             pass
 

--- a/agents_as_skills/install-skills.py
+++ b/agents_as_skills/install-skills.py
@@ -44,7 +44,9 @@ CLIENT_MCP_CONFIG_PATHS = {
 }
 
 
-def prompt_value(label: str, env_var: str = None, default: str = None, secret: bool = False) -> str:
+def prompt_value(
+    label: str, env_var: str | None = None, default: str | None = None, secret: bool = False
+) -> str:
     existing = os.environ.get(env_var) if env_var else None
     if existing:
         masked = existing[:4] + "..." if secret and len(existing) > 4 else existing
@@ -57,15 +59,12 @@ def prompt_value(label: str, env_var: str = None, default: str = None, secret: b
         prompt_text += f" [{default}]"
     prompt_text += ": "
 
-    if secret:
-        value = getpass.getpass(prompt_text)
-    else:
-        value = input(prompt_text)
+    value = getpass.getpass(prompt_text) if secret else input(prompt_text)
 
     return value.strip() or default or ""
 
 
-def prompt_choice(label: str, choices: list[str], default: str = None) -> str:
+def prompt_choice(label: str, choices: list[str], default: str | None = None) -> str:
     print(f"\n  {label}")
     for i, choice in enumerate(choices, 1):
         marker = " (default)" if choice == default else ""
@@ -115,15 +114,6 @@ def collect_credentials() -> dict:
     creds["GITLAB_TOKEN"] = prompt_value("GitLab personal access token", env_var="GITLAB_TOKEN", secret=True)
 
     print("\n  Kerberos configuration:")
-    klist_result = subprocess.run(["klist"], capture_output=True)
-    if klist_result.returncode == 0:
-        print("  Kerberos ticket found (klist succeeded).")
-    else:
-        print("  WARNING: No active Kerberos ticket. Run 'kinit' before using the tools.")
-
-    use_keytab = input("  Do you have a keytab file for automated kinit? [y/N]: ").strip().lower() == "y"
-    if use_keytab:
-        creds["KEYTAB_FILE"] = prompt_value(
     try:
         klist_result = subprocess.run(["klist"], capture_output=True)
         if klist_result.returncode == 0:
@@ -132,6 +122,17 @@ def collect_credentials() -> dict:
             print("  WARNING: No active Kerberos ticket. Run 'kinit' before using the tools.")
     except FileNotFoundError:
         print("  WARNING: 'klist' command not found. Ensure Kerberos client tools are installed.")
+
+    use_keytab = input("  Do you have a keytab file for automated kinit? [y/N]: ").strip().lower() == "y"
+    if use_keytab:
+        creds["KEYTAB_FILE"] = prompt_value(
+            "Keytab file path",
+            env_var="KEYTAB_FILE",
+            default=str(Path.home() / ".secrets" / "keytab"),
+        )
+
+    krb5cc = os.environ.get("KRB5CCNAME")
+    if krb5cc:
         creds["KRB5CCNAME"] = krb5cc
         print(f"  Using KRB5CCNAME from env: {krb5cc}")
 
@@ -157,16 +158,6 @@ def install_venv():
     print(f"\n=> Creating virtual environment at {VENV_PATH}")
 
     python = "python3.13"
-    result = subprocess.run([python, "--version"], capture_output=True)
-    if result.returncode != 0:
-        python = "python3"
-        print(f"  python3.13 not found, falling back to {python}")
-        print("  WARNING: BeeAI framework requires Python < 3.14. Ensure your Python is compatible.")
-
-    if not VENV_PATH.exists():
-        run([python, "-m", "venv", str(VENV_PATH)])
-    else:
-    python = "python3.13"
     try:
         result = subprocess.run([python, "--version"], capture_output=True)
         if result.returncode != 0:
@@ -177,6 +168,16 @@ def install_venv():
     if python == "python3":
         print(f"  python3.13 not found, falling back to {python}")
         print("  WARNING: BeeAI framework requires Python < 3.14. Ensure your Python is compatible.")
+
+    if not VENV_PATH.exists():
+        run([python, "-m", "venv", str(VENV_PATH)])
+    else:
+        print(f"  Venv already exists at {VENV_PATH}")
+
+    pip = str(VENV_PATH / "bin" / "pip")
+    print("\n=> Installing ymir-common...")
+    run(
+        [
             pip,
             "install",
             "--upgrade",
@@ -211,6 +212,8 @@ def write_mcp_config(client: str, creds: dict):
     priv_env = {"MCP_TRANSPORT": "stdio"}
     for key in ("GITLAB_TOKEN", "JIRA_URL", "JIRA_EMAIL", "JIRA_TOKEN", "KRB5CCNAME", "KEYTAB_FILE"):
         if creds.get(key):
+            priv_env[key] = creds[key]
+
     unpriv_env = {
         "MCP_TRANSPORT": "stdio",
         "UPSTREAM_SEARCH_API_URL": "http://upstream-search.hosted.upshift.rdu2.redhat.com:80/v1",
@@ -218,8 +221,6 @@ def write_mcp_config(client: str, creds: dict):
     ca_bundle = Path("/etc/pki/tls/certs/ca-bundle.crt")
     if ca_bundle.exists():
         unpriv_env["REQUESTS_CA_BUNDLE"] = str(ca_bundle)
-        "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
-    }
 
     config_path = CLIENT_MCP_CONFIG_PATHS[client]
 
@@ -248,6 +249,8 @@ def write_mcp_config(client: str, creds: dict):
                 "env": unpriv_env,
             },
         }
+        config_key = "mcpServers"
+
     existing_config = {}
     if config_path.exists():
         try:
@@ -261,8 +264,6 @@ def write_mcp_config(client: str, creds: dict):
         except OSError as e:
             print(f"  ERROR: Failed to read existing config at {config_path}: {e}")
             sys.exit(1)
-        except (json.JSONDecodeError, OSError):
-            pass
 
     if config_key not in existing_config:
         existing_config[config_key] = {}

--- a/agents_as_skills/install-skills.py
+++ b/agents_as_skills/install-skills.py
@@ -102,22 +102,13 @@ def collect_credentials() -> dict:
 
     creds = {}
 
-    creds["JIRA_URL"] = prompt_value(
-        "Jira URL", env_var="JIRA_URL",
-        default="https://redhat.atlassian.net"
-    )
+    creds["JIRA_URL"] = prompt_value("Jira URL", env_var="JIRA_URL", default="https://redhat.atlassian.net")
 
-    creds["JIRA_EMAIL"] = prompt_value(
-        "Jira email", env_var="JIRA_EMAIL"
-    )
+    creds["JIRA_EMAIL"] = prompt_value("Jira email", env_var="JIRA_EMAIL")
 
-    creds["JIRA_TOKEN"] = prompt_value(
-        "Jira API token", env_var="JIRA_TOKEN", secret=True
-    )
+    creds["JIRA_TOKEN"] = prompt_value("Jira API token", env_var="JIRA_TOKEN", secret=True)
 
-    creds["GITLAB_TOKEN"] = prompt_value(
-        "GitLab personal access token", env_var="GITLAB_TOKEN", secret=True
-    )
+    creds["GITLAB_TOKEN"] = prompt_value("GitLab personal access token", env_var="GITLAB_TOKEN", secret=True)
 
     print("\n  Kerberos configuration:")
     klist_result = subprocess.run(["klist"], capture_output=True)
@@ -129,8 +120,7 @@ def collect_credentials() -> dict:
     use_keytab = input("  Do you have a keytab file for automated kinit? [y/N]: ").strip().lower() == "y"
     if use_keytab:
         creds["KEYTAB_FILE"] = prompt_value(
-            "Keytab file path", env_var="KEYTAB_FILE",
-            default=str(Path.home() / ".secrets" / "keytab")
+            "Keytab file path", env_var="KEYTAB_FILE", default=str(Path.home() / ".secrets" / "keytab")
         )
 
     krb5cc = os.environ.get("KRB5CCNAME")
@@ -173,17 +163,29 @@ def install_venv():
 
     pip = str(VENV_PATH / "bin" / "pip")
     print("\n=> Installing ymir-common...")
-    run([pip, "install", "--upgrade",
-         "git+https://github.com/packit/ai-workflows.git#subdirectory=ymir/common"])
+    run(
+        [
+            pip,
+            "install",
+            "--upgrade",
+            "git+https://github.com/packit/ai-workflows.git#subdirectory=ymir/common",
+        ]
+    )
 
     print("\n=> Installing ymir-tools...")
-    run([pip, "install", "--upgrade",
-         "git+https://github.com/packit/ai-workflows.git#subdirectory=ymir/tools"])
+    run(
+        [
+            pip,
+            "install",
+            "--upgrade",
+            "git+https://github.com/packit/ai-workflows.git#subdirectory=ymir/tools",
+        ]
+    )
 
     priv_gw = VENV_PATH / "bin" / "ymir-privileged-gateway"
     unpriv_gw = VENV_PATH / "bin" / "ymir-unprivileged-gateway"
     if priv_gw.exists() and unpriv_gw.exists():
-        print(f"\n=> Gateways installed:")
+        print("\n=> Gateways installed:")
         print(f"   Privileged:   {priv_gw}")
         print(f"   Unprivileged: {unpriv_gw}")
     else:
@@ -196,7 +198,7 @@ def write_mcp_config(client: str, creds: dict):
 
     priv_env = {"MCP_TRANSPORT": "stdio"}
     for key in ("GITLAB_TOKEN", "JIRA_URL", "JIRA_EMAIL", "JIRA_TOKEN", "KRB5CCNAME", "KEYTAB_FILE"):
-        if key in creds and creds[key]:
+        if creds.get(key):
             priv_env[key] = creds[key]
 
     unpriv_env = {
@@ -277,12 +279,12 @@ def main():
     print(f"\n  Skills:     {CLIENT_SKILLS_DIRS[client]}")
     print(f"  Venv:       {VENV_PATH}")
     print(f"  MCP config: {CLIENT_MCP_CONFIG_PATHS[client]}")
-    print(f"\n  Next steps:")
+    print("\n  Next steps:")
     if "KEYTAB_FILE" not in creds:
-        print(f"  1. Run 'kinit <your-kerberos-id>@IPA.REDHAT.COM'")
+        print("  1. Run 'kinit <your-kerberos-id>@IPA.REDHAT.COM'")
     print(f"  2. Restart your {client} client")
-    print(f"  3. Verify MCP servers are connected (in Cursor: check MCP panel)")
-    print(f"  4. Try: 'Use the triage skill with jira_issue=RHEL-12345'")
+    print("  3. Verify MCP servers are connected (in Cursor: check MCP panel)")
+    print("  4. Try: 'Use the triage skill with jira_issue=RHEL-12345'")
 
 
 if __name__ == "__main__":

--- a/agents_as_skills/install-skills.py
+++ b/agents_as_skills/install-skills.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Install Ymir agent skills and MCP tools for local use with Cursor/Claude Code.
+
+This script:
+1. Prompts for required credentials (tokens, email, etc.)
+2. Downloads SKILL.md files from the upstream repo into the client's skills directory
+3. Creates a Python 3.13 venv and installs ymir-common + ymir-tools
+4. Writes MCP server configuration directly to the client's config file
+
+Usage:
+    python3 scripts/install-skills.py
+"""
+
+import getpass
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_URL = "https://raw.githubusercontent.com/packit/ai-workflows/main/agents_as_skills"
+SKILLS = [
+    "backport",
+    "rebase",
+    "triage",
+    "rebuild",
+    "preliminary-testing",
+    "issue-verification",
+    "errata-workflow",
+]
+
+VENV_PATH = Path.home() / ".local" / "share" / "ymir-venv"
+
+CLIENT_SKILLS_DIRS = {
+    "cursor": Path.home() / ".cursor" / "skills",
+    "claude": Path.home() / ".claude" / "skills",
+    "opencode": Path.home() / ".config" / "opencode" / "skills",
+}
+
+CLIENT_MCP_CONFIG_PATHS = {
+    "cursor": Path.home() / ".cursor" / "mcp.json",
+    "claude": Path.home() / ".claude.json",
+    "opencode": Path.home() / ".config" / "opencode" / "opencode.json",
+}
+
+
+def prompt_value(label: str, env_var: str = None, default: str = None, secret: bool = False) -> str:
+    existing = os.environ.get(env_var) if env_var else None
+    if existing:
+        masked = existing[:4] + "..." if secret and len(existing) > 4 else existing
+        use_existing = input(f"  {label}: found env ${env_var} = {masked}. Use it? [Y/n]: ").strip().lower()
+        if use_existing != "n":
+            return existing
+
+    prompt_text = f"  {label}"
+    if default:
+        prompt_text += f" [{default}]"
+    prompt_text += ": "
+
+    if secret:
+        value = getpass.getpass(prompt_text)
+    else:
+        value = input(prompt_text)
+
+    return value.strip() or default or ""
+
+
+def prompt_choice(label: str, choices: list[str], default: str = None) -> str:
+    print(f"\n  {label}")
+    for i, choice in enumerate(choices, 1):
+        marker = " (default)" if choice == default else ""
+        print(f"    {i}. {choice}{marker}")
+
+    while True:
+        raw = input(f"  Choose [1-{len(choices)}]: ").strip()
+        if not raw and default:
+            return default
+        try:
+            idx = int(raw) - 1
+            if 0 <= idx < len(choices):
+                return choices[idx]
+        except ValueError:
+            if raw in choices:
+                return raw
+        print(f"  Please enter a number between 1 and {len(choices)}")
+
+
+def run(cmd, **kwargs):
+    print(f"  $ {' '.join(str(c) for c in cmd)}")
+    result = subprocess.run(cmd, **kwargs)
+    if result.returncode != 0:
+        print(f"  ERROR: command failed with exit code {result.returncode}")
+        sys.exit(1)
+    return result
+
+
+def collect_credentials() -> dict:
+    print("\n" + "=" * 60)
+    print("  Credentials Setup")
+    print("  (values are read from env vars if set, otherwise prompted)")
+    print("=" * 60)
+
+    creds = {}
+
+    creds["JIRA_URL"] = prompt_value(
+        "Jira URL", env_var="JIRA_URL",
+        default="https://redhat.atlassian.net"
+    )
+
+    creds["JIRA_EMAIL"] = prompt_value(
+        "Jira email", env_var="JIRA_EMAIL"
+    )
+
+    creds["JIRA_TOKEN"] = prompt_value(
+        "Jira API token", env_var="JIRA_TOKEN", secret=True
+    )
+
+    creds["GITLAB_TOKEN"] = prompt_value(
+        "GitLab personal access token", env_var="GITLAB_TOKEN", secret=True
+    )
+
+    print("\n  Kerberos configuration:")
+    klist_result = subprocess.run(["klist"], capture_output=True)
+    if klist_result.returncode == 0:
+        print("  Kerberos ticket found (klist succeeded).")
+    else:
+        print("  WARNING: No active Kerberos ticket. Run 'kinit' before using the tools.")
+
+    use_keytab = input("  Do you have a keytab file for automated kinit? [y/N]: ").strip().lower() == "y"
+    if use_keytab:
+        creds["KEYTAB_FILE"] = prompt_value(
+            "Keytab file path", env_var="KEYTAB_FILE",
+            default=str(Path.home() / ".secrets" / "keytab")
+        )
+
+    krb5cc = os.environ.get("KRB5CCNAME")
+    if krb5cc:
+        creds["KRB5CCNAME"] = krb5cc
+        print(f"  Using KRB5CCNAME from env: {krb5cc}")
+
+    return creds
+
+
+def install_skills(client: str):
+    skills_dir = CLIENT_SKILLS_DIRS[client]
+
+    print(f"\n=> Installing skills to {skills_dir}")
+    for skill in SKILLS:
+        skill_dir = skills_dir / skill
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        url = f"{REPO_URL}/{skill}/SKILL.md"
+        dest = skill_dir / "SKILL.md"
+        print(f"  Downloading {skill}...")
+        run(["curl", "-fsSL", url, "-o", str(dest)])
+
+    print(f"\n=> {len(SKILLS)} skills installed to {skills_dir}")
+
+
+def install_venv():
+    print(f"\n=> Creating virtual environment at {VENV_PATH}")
+
+    python = "python3.13"
+    result = subprocess.run([python, "--version"], capture_output=True)
+    if result.returncode != 0:
+        python = "python3"
+        print(f"  python3.13 not found, falling back to {python}")
+        print("  WARNING: BeeAI framework requires Python < 3.14. Ensure your Python is compatible.")
+
+    if not VENV_PATH.exists():
+        run([python, "-m", "venv", str(VENV_PATH)])
+    else:
+        print(f"  Venv already exists at {VENV_PATH}")
+
+    pip = str(VENV_PATH / "bin" / "pip")
+    print("\n=> Installing ymir-common...")
+    run([pip, "install", "--upgrade",
+         "git+https://github.com/packit/ai-workflows.git#subdirectory=ymir/common"])
+
+    print("\n=> Installing ymir-tools...")
+    run([pip, "install", "--upgrade",
+         "git+https://github.com/packit/ai-workflows.git#subdirectory=ymir/tools"])
+
+    priv_gw = VENV_PATH / "bin" / "ymir-privileged-gateway"
+    unpriv_gw = VENV_PATH / "bin" / "ymir-unprivileged-gateway"
+    if priv_gw.exists() and unpriv_gw.exists():
+        print(f"\n=> Gateways installed:")
+        print(f"   Privileged:   {priv_gw}")
+        print(f"   Unprivileged: {unpriv_gw}")
+    else:
+        print("\n  WARNING: Gateway entry points not found. Check installation logs.")
+
+
+def write_mcp_config(client: str, creds: dict):
+    priv_gw = str(VENV_PATH / "bin" / "ymir-privileged-gateway")
+    unpriv_gw = str(VENV_PATH / "bin" / "ymir-unprivileged-gateway")
+
+    priv_env = {"MCP_TRANSPORT": "stdio"}
+    for key in ("GITLAB_TOKEN", "JIRA_URL", "JIRA_EMAIL", "JIRA_TOKEN", "KRB5CCNAME", "KEYTAB_FILE"):
+        if key in creds and creds[key]:
+            priv_env[key] = creds[key]
+
+    unpriv_env = {
+        "MCP_TRANSPORT": "stdio",
+        "UPSTREAM_SEARCH_API_URL": "http://upstream-search.hosted.upshift.rdu2.redhat.com:80/v1",
+        "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
+    }
+
+    config_path = CLIENT_MCP_CONFIG_PATHS[client]
+
+    if client == "opencode":
+        new_servers = {
+            "ymir-privileged": {
+                "type": "local",
+                "command": [priv_gw],
+                "env": priv_env,
+            },
+            "ymir-unprivileged": {
+                "type": "local",
+                "command": [unpriv_gw],
+                "env": unpriv_env,
+            },
+        }
+        config_key = "mcp"
+    else:
+        new_servers = {
+            "ymir-privileged": {
+                "command": priv_gw,
+                "env": priv_env,
+            },
+            "ymir-unprivileged": {
+                "command": unpriv_gw,
+                "env": unpriv_env,
+            },
+        }
+        config_key = "mcpServers"
+
+    existing_config = {}
+    if config_path.exists():
+        try:
+            existing_config = json.loads(config_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if config_key not in existing_config:
+        existing_config[config_key] = {}
+    existing_config[config_key].update(new_servers)
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(existing_config, indent=2) + "\n")
+    print(f"\n=> MCP config written to {config_path}")
+
+
+def main():
+    print("=" * 60)
+    print("  Ymir Skills Installer")
+    print("=" * 60)
+
+    client = prompt_choice(
+        "Which agent client do you use?",
+        choices=["cursor", "claude", "opencode"],
+        default="cursor",
+    )
+
+    creds = collect_credentials()
+
+    print("\n" + "=" * 60)
+    print("  Installing...")
+    print("=" * 60)
+
+    install_skills(client)
+    install_venv()
+    write_mcp_config(client, creds)
+
+    print("\n" + "=" * 60)
+    print("  Installation complete!")
+    print("=" * 60)
+    print(f"\n  Skills:     {CLIENT_SKILLS_DIRS[client]}")
+    print(f"  Venv:       {VENV_PATH}")
+    print(f"  MCP config: {CLIENT_MCP_CONFIG_PATHS[client]}")
+    print(f"\n  Next steps:")
+    if "KEYTAB_FILE" not in creds:
+        print(f"  1. Run 'kinit <your-kerberos-id>@IPA.REDHAT.COM'")
+    print(f"  2. Restart your {client} client")
+    print(f"  3. Verify MCP servers are connected (in Cursor: check MCP panel)")
+    print(f"  4. Try: 'Use the triage skill with jira_issue=RHEL-12345'")
+
+
+if __name__ == "__main__":
+    main()

--- a/ruff.toml
+++ b/ruff.toml
@@ -35,3 +35,4 @@ ignore = [
 "**/tests/**" = ["S101", "S105", "S106", "S107", "S108", "S603", "S607"]
 # Helper scripts shell out to known binaries by name.
 "scripts/**" = ["S603", "S607"]
+"agents_as_skills/install-skills.py" = ["S603", "S607"]


### PR DESCRIPTION
Provides a guided setup experience for developers who want to run Ymir workflows locally in their IDE (Cursor, Claude Code, opencode). The script prompts for credentials, downloads skills, creates the Python venv with MCP gateways, and writes the client config file.

<!-- TODO list -->

TODO:

- [X] Write new tests or update the old ones to cover new functionality.
- [X] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`. (Not Applicable)

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
