### PR TITLE
Recover tasks lost to shutdown and stuck in-flight labels

### DIFF
--- a/openshift/configmap-jira-issue-fetcher-env.yml
+++ b/openshift/configmap-jira-issue-fetcher-env.yml
@@ -2,6 +2,11 @@ apiVersion: v1
 data:
   MAX_ISSUES: "70"
   LOGLEVEL: "INFO"
+  # Conservative default pending real task duration data from Phoenix traces;
+  # see the comment next to stale_label_threshold_hours in
+  # jira_issue_fetcher.py. Shared by both cronjobs (daily + todo) since it's a
+  # property of agent task duration, not of which query triggered the sweep.
+  STALE_LABEL_THRESHOLD_HOURS: "24"
 immutable: false
 kind: ConfigMap
 metadata:

--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -67,7 +67,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-backport-agent-c9s.yml
+++ b/openshift/deployment-backport-agent-c9s.yml
@@ -67,7 +67,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-mr-consolidation-agent-c10s.yml
+++ b/openshift/deployment-mr-consolidation-agent-c10s.yml
@@ -66,7 +66,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-mr-consolidation-agent-c9s.yml
+++ b/openshift/deployment-mr-consolidation-agent-c9s.yml
@@ -66,7 +66,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-rebase-agent-c10s.yml
+++ b/openshift/deployment-rebase-agent-c10s.yml
@@ -67,7 +67,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-rebase-agent-c9s.yml
+++ b/openshift/deployment-rebase-agent-c9s.yml
@@ -67,7 +67,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -66,7 +66,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-rebuild-agent-c9s.yml
+++ b/openshift/deployment-rebuild-agent-c9s.yml
@@ -66,7 +66,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-triage-agent.yml
+++ b/openshift/deployment-triage-agent.yml
@@ -66,7 +66,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 45
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -45,7 +45,7 @@ from ymir.agents.utils import (
     run_tool,
     wrap_details,
 )
-from ymir.common.base_utils import fix_await, redis_client, run_task_loop
+from ymir.common.base_utils import fix_await, install_shutdown_handler, redis_client, run_task_loop
 from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.logging_setup import configure_logging, current_jira_issue, get_trajectory_writeable
 from ymir.common.mock_repos import get_mock_local_tool_env
@@ -1027,11 +1027,14 @@ async def main() -> None:
                         ).model_dump_json(),
                     )
 
+        shutdown_event = asyncio.Event()
+        install_shutdown_handler(asyncio.get_running_loop(), shutdown_event)
         await run_task_loop(
             redis,
             [backport_queue_todo, backport_queue],
             process_task,
             max_concurrent=max_concurrent_tasks,
+            shutdown_event=shutdown_event,
         )
 
 

--- a/ymir/agents/mr_consolidation_agent.py
+++ b/ymir/agents/mr_consolidation_agent.py
@@ -5,6 +5,7 @@ import os
 import re
 import time
 import traceback
+from datetime import timedelta
 from typing import Any
 
 from beeai_framework.errors import FrameworkError
@@ -25,7 +26,7 @@ from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
 from ymir.agents.package_update_steps import PackageUpdateState
 from ymir.agents.reasoning_agent import ReasoningAgent
-from ymir.agents.tasks import complete_job, pick_next_job
+from ymir.agents.tasks import complete_job, pick_next_job, sweep_stale_active_jobs
 from ymir.agents.utils import (
     _PROMPTS_DIR,
     _get_jinja2_env,
@@ -1376,8 +1377,10 @@ async def main() -> None:
     max_concurrent_tasks = int(os.getenv("MAX_CONCURRENT_TASKS", 1))
 
     async with redis_client(os.environ["REDIS_URL"]) as redis_conn:
+        stale_threshold = timedelta(hours=int(os.getenv("STALE_ACTIVE_THRESHOLD_HOURS", "6")))
 
         async def poll_consolidation_queue() -> tuple[bytes, bytes] | None:
+            await sweep_stale_active_jobs(redis_conn, threshold=stale_threshold)
             job = await pick_next_job(redis_conn)
             if job is None:
                 return None

--- a/ymir/agents/mr_consolidation_agent.py
+++ b/ymir/agents/mr_consolidation_agent.py
@@ -1384,11 +1384,11 @@ async def main() -> None:
             redis_logger.info("Picked job for %s/%s", job.package, job.target_branch)
             # This queue is a Redis Hash (pick_next_job/complete_job), not a
             # list run_task_loop can RPUSH back into on shutdown — re-push
-            # doesn't apply here (see process_task's finally: complete_job
-            # already drops cancelled-mid-flight jobs the same way it drops
-            # any other failure). The sentinel is only so a cancelled job
-            # still satisfies run_task_loop's generic (source_queue, payload)
-            # bookkeeping; nothing ever reads from it.
+            # doesn't apply here.  On cancellation, process_task leaves the
+            # :active field in place (see its CancelledError handler).
+            # The sentinel is only so a cancelled job still satisfies
+            # run_task_loop's generic (source_queue, payload) bookkeeping;
+            # nothing ever reads from it.
             return b"mr_consolidation", job.model_dump_json().encode()
 
         async def process_task(payload: bytes) -> None:
@@ -1426,6 +1426,13 @@ async def main() -> None:
                             job.target_branch,
                             state.consolidation_result.error if state.consolidation_result else "unknown",
                         )
+            except asyncio.CancelledError:
+                # Deliberately leave the :active hash field alone — calling
+                # complete_job() here would silently erase the job.  This
+                # matches pre-PR behavior (SIGTERM killed the process
+                # outright, so finally never ran).  Proper recovery for
+                # stuck :active entries is separate follow-up work.
+                raise
             except Exception:
                 logger.error(
                     "Unhandled error processing %s/%s:\n%s",
@@ -1433,7 +1440,8 @@ async def main() -> None:
                     job.target_branch,
                     traceback.format_exc(),
                 )
-            finally:
+                await complete_job(redis_conn, job.package, job.target_branch)
+            else:
                 await complete_job(redis_conn, job.package, job.target_branch)
 
         shutdown_event = asyncio.Event()

--- a/ymir/agents/mr_consolidation_agent.py
+++ b/ymir/agents/mr_consolidation_agent.py
@@ -41,7 +41,7 @@ from ymir.agents.utils import (
     run_subprocess,
     run_tool,
 )
-from ymir.common.base_utils import is_cs_branch, redis_client, run_task_loop
+from ymir.common.base_utils import install_shutdown_handler, is_cs_branch, redis_client, run_task_loop
 from ymir.common.constants import JiraLabels
 from ymir.common.logging_setup import configure_logging, current_jira_issue, get_trajectory_writeable
 from ymir.common.mock_repos import get_mock_local_tool_env
@@ -1377,12 +1377,19 @@ async def main() -> None:
 
     async with redis_client(os.environ["REDIS_URL"]) as redis_conn:
 
-        async def poll_consolidation_queue() -> bytes | None:
+        async def poll_consolidation_queue() -> tuple[bytes, bytes] | None:
             job = await pick_next_job(redis_conn)
             if job is None:
                 return None
             redis_logger.info("Picked job for %s/%s", job.package, job.target_branch)
-            return job.model_dump_json().encode()
+            # This queue is a Redis Hash (pick_next_job/complete_job), not a
+            # list run_task_loop can RPUSH back into on shutdown — re-push
+            # doesn't apply here (see process_task's finally: complete_job
+            # already drops cancelled-mid-flight jobs the same way it drops
+            # any other failure). The sentinel is only so a cancelled job
+            # still satisfies run_task_loop's generic (source_queue, payload)
+            # bookkeeping; nothing ever reads from it.
+            return b"mr_consolidation", job.model_dump_json().encode()
 
         async def process_task(payload: bytes) -> None:
             job = MergeConsolidationJob.model_validate_json(payload)
@@ -1429,12 +1436,15 @@ async def main() -> None:
             finally:
                 await complete_job(redis_conn, job.package, job.target_branch)
 
+        shutdown_event = asyncio.Event()
+        install_shutdown_handler(asyncio.get_running_loop(), shutdown_event)
         await run_task_loop(
             redis_conn,
             [],
             process_task,
             max_concurrent=max_concurrent_tasks,
             poll_fn=poll_consolidation_queue,
+            shutdown_event=shutdown_event,
         )
 
 

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -39,7 +39,7 @@ from ymir.agents.utils import (
     resolve_chat_model_override,
     wrap_details,
 )
-from ymir.common.base_utils import fix_await, redis_client, run_task_loop
+from ymir.common.base_utils import fix_await, install_shutdown_handler, redis_client, run_task_loop
 from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.logging_setup import configure_logging, current_jira_issue, get_trajectory_writeable
 from ymir.common.mock_repos import get_mock_local_tool_env
@@ -585,11 +585,14 @@ async def main() -> None:
                         ).model_dump_json(),
                     )
 
+        shutdown_event = asyncio.Event()
+        install_shutdown_handler(asyncio.get_running_loop(), shutdown_event)
         await run_task_loop(
             redis,
             [rebase_queue_todo, rebase_queue],
             process_task,
             max_concurrent=max_concurrent_tasks,
+            shutdown_event=shutdown_event,
         )
 
 

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -24,7 +24,7 @@ from ymir.agents.utils import (
     resolve_chat_model_override,
     run_subprocess,
 )
-from ymir.common.base_utils import fix_await, redis_client, run_task_loop
+from ymir.common.base_utils import fix_await, install_shutdown_handler, redis_client, run_task_loop
 from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.logging_setup import configure_logging, current_jira_issue
 from ymir.common.mock_repos import get_mock_local_tool_env
@@ -535,11 +535,14 @@ async def main() -> None:
                         ).model_dump_json(),
                     )
 
+        shutdown_event = asyncio.Event()
+        install_shutdown_handler(asyncio.get_running_loop(), shutdown_event)
         await run_task_loop(
             redis,
             [rebuild_queue_todo, rebuild_queue],
             process_task,
             max_concurrent=max_concurrent_tasks,
+            shutdown_event=shutdown_event,
         )
 
 

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -20,6 +20,7 @@ from ymir.common.merge_queue import (  # noqa: F401 — re-exported for agents a
     complete_job,
     pick_next_job,
     submit_merge_job,
+    sweep_stale_active_jobs,
 )
 from ymir.common.models import (
     CachedMRMetadata,

--- a/ymir/agents/tests/unit/test_mr_consolidation.py
+++ b/ymir/agents/tests/unit/test_mr_consolidation.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from ymir.agents.tasks import (
     fetch_consolidation_config,
     pick_next_job,
     submit_merge_job,
+    sweep_stale_active_jobs,
 )
 from ymir.agents.tasks import (
     _consolidation_field_key as _field_key,
@@ -41,8 +43,19 @@ class FakeRedis:
         return dict(self._data.get(name, {}))
 
     async def eval(self, script: str, num_keys: int, *args):
-        """Simulate the pick-next-job Lua script atomically."""
+        """Dispatch to the correct Lua-script simulation based on args.
+
+        pick_next_job: eval(script, 1, hash_key) — 1 arg after num_keys
+        conditional HDEL: eval(script, 1, hash_key, field, expected) — 3 args
+        """
         hash_key = args[0]
+        if len(args) == 1:
+            return self._eval_pick_next_job(hash_key)
+        if len(args) == 3:
+            return self._eval_conditional_hdel(hash_key, args[1], args[2])
+        return None
+
+    def _eval_pick_next_job(self, hash_key):
         bucket = self._data.get(hash_key, {})
         for field, value in list(bucket.items()):
             field_str = field.decode() if isinstance(field, bytes) else field
@@ -55,6 +68,19 @@ class FakeRedis:
                 bucket[active_key] = value
                 return [field.encode() if isinstance(field, str) else field, value]
         return None
+
+    def _eval_conditional_hdel(self, hash_key, field, expected_value):
+        bucket = self._data.get(hash_key, {})
+        field_str = field.decode() if isinstance(field, bytes) else field
+        expected = expected_value.decode() if isinstance(expected_value, bytes) else expected_value
+        current = bucket.get(field_str)
+        if current is None:
+            return 0
+        current_str = current.decode() if isinstance(current, bytes) else current
+        if current_str == expected:
+            del bucket[field_str]
+            return 1
+        return 0
 
 
 @pytest.fixture
@@ -126,12 +152,16 @@ async def test_pick_promotes_pending_to_active(fake_redis):
     assert job.package == "bash"
     assert job.target_branch == "c10s"
     assert job.active is True
+    assert job.activated_at is not None
 
     pending_key = _field_key("bash", "c10s", "pending")
     assert await fake_redis.hget(HASH_KEY, pending_key) is None
 
     active_key = _field_key("bash", "c10s", "active")
-    assert await fake_redis.hget(HASH_KEY, active_key) is not None
+    stored = await fake_redis.hget(HASH_KEY, active_key)
+    assert stored is not None
+    stored_job = MergeConsolidationJob.model_validate_json(stored)
+    assert stored_job.activated_at is not None
 
 
 @pytest.mark.asyncio
@@ -399,4 +429,179 @@ async def test_cancelled_task_does_not_call_complete_job(fake_redis):
             await mock_complete(fake_redis, job.package, job.target_branch)
 
     mock_complete.assert_not_called()
+    assert await fake_redis.hget(HASH_KEY, active_key) is not None
+
+
+# -- sweep_stale_active_jobs ---------------------------------------------------
+
+
+def _make_active_job(package, branch, activated_hours_ago):
+    """Create a MergeConsolidationJob with activated_at set."""
+    return MergeConsolidationJob(
+        package=package,
+        target_branch=branch,
+        active=True,
+        activated_at=datetime.now(UTC) - timedelta(hours=activated_hours_ago),
+    )
+
+
+@pytest.mark.asyncio
+async def test_sweep_removes_stale_active_entry(fake_redis):
+    """An :active entry whose activated_at exceeds the threshold is
+    removed, unblocking pick_next_job for that package/branch."""
+    job = _make_active_job("bash", "c10s", activated_hours_ago=7)
+    active_key = _field_key("bash", "c10s", "active")
+    await fake_redis.hset(HASH_KEY, active_key, job.model_dump_json())
+
+    removed = await sweep_stale_active_jobs(fake_redis, threshold=timedelta(hours=6))
+
+    assert removed == 1
+    assert await fake_redis.hget(HASH_KEY, active_key) is None
+
+
+@pytest.mark.asyncio
+async def test_sweep_leaves_fresh_active_entry(fake_redis):
+    """An :active entry whose activated_at is within the threshold must
+    not be touched."""
+    job = _make_active_job("bash", "c10s", activated_hours_ago=1)
+    active_key = _field_key("bash", "c10s", "active")
+    await fake_redis.hset(HASH_KEY, active_key, job.model_dump_json())
+
+    removed = await sweep_stale_active_jobs(fake_redis, threshold=timedelta(hours=6))
+
+    assert removed == 0
+    assert await fake_redis.hget(HASH_KEY, active_key) is not None
+
+
+@pytest.mark.asyncio
+async def test_sweep_ignores_entry_without_activated_at(fake_redis):
+    """An :active entry with no activated_at (promoted before sweep support
+    was deployed) is skipped — we can't know when it actually started."""
+    job = MergeConsolidationJob(
+        package="bash",
+        target_branch="c10s",
+        active=True,
+        submitted_at=datetime.now(UTC) - timedelta(hours=24),
+    )
+    active_key = _field_key("bash", "c10s", "active")
+    await fake_redis.hset(HASH_KEY, active_key, job.model_dump_json())
+
+    removed = await sweep_stale_active_jobs(fake_redis, threshold=timedelta(hours=6))
+
+    assert removed == 0
+    assert await fake_redis.hget(HASH_KEY, active_key) is not None
+
+
+@pytest.mark.asyncio
+async def test_sweep_does_not_touch_pending(fake_redis):
+    """:pending entries must never be removed by the sweep, regardless of age."""
+    old_time = datetime.now(UTC) - timedelta(hours=24)
+    job = MergeConsolidationJob(
+        package="bash",
+        target_branch="c10s",
+        active=False,
+        submitted_at=old_time,
+    )
+    pending_key = _field_key("bash", "c10s", "pending")
+    await fake_redis.hset(HASH_KEY, pending_key, job.model_dump_json())
+
+    removed = await sweep_stale_active_jobs(fake_redis, threshold=timedelta(hours=6))
+
+    assert removed == 0
+    assert await fake_redis.hget(HASH_KEY, pending_key) is not None
+
+
+@pytest.mark.asyncio
+async def test_sweep_unblocks_pending_promotion(fake_redis):
+    """After sweeping a stale :active entry, pick_next_job should be able
+    to promote a :pending entry for the same package/branch."""
+    active_job = _make_active_job("bash", "c10s", activated_hours_ago=10)
+    active_key = _field_key("bash", "c10s", "active")
+    await fake_redis.hset(HASH_KEY, active_key, active_job.model_dump_json())
+
+    await submit_merge_job(fake_redis, "bash", "c10s")
+
+    # Before sweep: pick_next_job can't promote because :active blocks it
+    assert await pick_next_job(fake_redis) is None
+
+    await sweep_stale_active_jobs(fake_redis, threshold=timedelta(hours=6))
+
+    # After sweep: :active is gone, pick_next_job can promote
+    job = await pick_next_job(fake_redis)
+    assert job is not None
+    assert job.package == "bash"
+    assert job.target_branch == "c10s"
+
+
+@pytest.mark.asyncio
+async def test_sweep_handles_unparseable_entry(fake_redis):
+    """If an :active entry has corrupted JSON, the sweep logs a warning
+    and skips it rather than crashing."""
+    active_key = _field_key("bash", "c10s", "active")
+    await fake_redis.hset(HASH_KEY, active_key, b"not-valid-json")
+
+    removed = await sweep_stale_active_jobs(fake_redis, threshold=timedelta(hours=1))
+
+    assert removed == 0
+    assert await fake_redis.hget(HASH_KEY, active_key) is not None
+
+
+@pytest.mark.asyncio
+async def test_sweep_multiple_packages(fake_redis):
+    """Sweep should handle multiple stale entries across different
+    package/branch pairs independently."""
+    for pkg, hours in [("bash", 10), ("curl", 10), ("gzip", 1)]:
+        job = _make_active_job(pkg, "c10s", activated_hours_ago=hours)
+        active_key = _field_key(pkg, "c10s", "active")
+        await fake_redis.hset(HASH_KEY, active_key, job.model_dump_json())
+
+    removed = await sweep_stale_active_jobs(fake_redis, threshold=timedelta(hours=6))
+
+    assert removed == 2
+    assert await fake_redis.hget(HASH_KEY, _field_key("bash", "c10s", "active")) is None
+    assert await fake_redis.hget(HASH_KEY, _field_key("curl", "c10s", "active")) is None
+    assert await fake_redis.hget(HASH_KEY, _field_key("gzip", "c10s", "active")) is not None
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_if_value_changed_since_snapshot(fake_redis):
+    """If the :active entry is replaced between HGETALL and the conditional
+    HDEL (e.g. complete_job + pick_next_job raced), the sweep must not
+    delete the fresh entry."""
+    stale_job = _make_active_job("bash", "c10s", activated_hours_ago=10)
+    active_key = _field_key("bash", "c10s", "active")
+    await fake_redis.hset(HASH_KEY, active_key, stale_job.model_dump_json())
+
+    # Take snapshot (simulating what sweep does internally)
+    snapshot_value = await fake_redis.hget(HASH_KEY, active_key)
+
+    # Simulate a race: between HGETALL and HDEL, the old job completes and
+    # a fresh one is promoted into the same field
+    fresh_job = _make_active_job("bash", "c10s", activated_hours_ago=0)
+    await fake_redis.hset(HASH_KEY, active_key, fresh_job.model_dump_json())
+
+    # The conditional HDEL should see the value mismatch and skip
+    deleted = await fake_redis.eval("unused", 1, HASH_KEY, active_key.encode(), snapshot_value)
+    assert deleted == 0
+    assert await fake_redis.hget(HASH_KEY, active_key) is not None
+
+
+@pytest.mark.asyncio
+async def test_sweep_uses_activated_at_not_submitted_at(fake_redis):
+    """Regression: staleness must be measured from activated_at, not
+    submitted_at.  A job that was queued 8 hours ago but only activated
+    1 hour ago must not be swept with a 6-hour threshold."""
+    job = MergeConsolidationJob(
+        package="bash",
+        target_branch="c10s",
+        active=True,
+        submitted_at=datetime.now(UTC) - timedelta(hours=8),
+        activated_at=datetime.now(UTC) - timedelta(hours=1),
+    )
+    active_key = _field_key("bash", "c10s", "active")
+    await fake_redis.hset(HASH_KEY, active_key, job.model_dump_json())
+
+    removed = await sweep_stale_active_jobs(fake_redis, threshold=timedelta(hours=6))
+
+    assert removed == 0
     assert await fake_redis.hget(HASH_KEY, active_key) is not None

--- a/ymir/agents/tests/unit/test_mr_consolidation.py
+++ b/ymir/agents/tests/unit/test_mr_consolidation.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -358,3 +359,44 @@ def test_deduplicates_issues():
     )
     result = _extract_jira_issues_from_description(desc)
     assert result == ["RHEL-100"]
+
+
+# -- process_task cancellation behavior ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancelled_task_does_not_call_complete_job(fake_redis):
+    """Regression: on CancelledError (from shutdown), process_task must NOT
+    call complete_job() — doing so silently erases the :active hash entry,
+    losing the job entirely.  Instead it should leave :active intact and
+    re-raise, matching pre-PR SIGTERM behavior (process killed, no cleanup).
+
+    process_task is a closure inside main(), so we can't import it directly.
+    We replicate its error-handling structure here as a contract test — if
+    the structure in the source file changes, this should be updated too."""
+    await submit_merge_job(fake_redis, "bash", "c10s")
+    job = await pick_next_job(fake_redis)
+    assert job is not None
+
+    active_key = _field_key("bash", "c10s", "active")
+    assert await fake_redis.hget(HASH_KEY, active_key) is not None
+
+    mock_complete = AsyncMock()
+
+    async def simulate_workflow():
+        raise asyncio.CancelledError
+
+    # Replicate process_task's error-handling structure: CancelledError must
+    # propagate without calling complete_job (mock_complete here).
+    with pytest.raises(asyncio.CancelledError):
+        try:
+            await simulate_workflow()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            await mock_complete(fake_redis, job.package, job.target_branch)
+        else:
+            await mock_complete(fake_redis, job.package, job.target_branch)
+
+    mock_complete.assert_not_called()
+    assert await fake_redis.hget(HASH_KEY, active_key) is not None

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -34,7 +34,7 @@ from ymir.agents.utils import (
     resolve_chat_model_override,
     run_tool,
 )
-from ymir.common.base_utils import fix_await, redis_client, run_task_loop
+from ymir.common.base_utils import fix_await, install_shutdown_handler, redis_client, run_task_loop
 from ymir.common.config import load_rhel_config
 from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.logging_setup import configure_logging, current_jira_issue, get_trajectory_writeable
@@ -1106,11 +1106,14 @@ async def main() -> None:
                     else:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
 
+        shutdown_event = asyncio.Event()
+        install_shutdown_handler(asyncio.get_running_loop(), shutdown_event)
         await run_task_loop(
             redis,
             [RedisQueues.TRIAGE_QUEUE_TODO.value, RedisQueues.TRIAGE_QUEUE.value],
             process_task,
             max_concurrent=max_concurrent_tasks,
+            shutdown_event=shutdown_event,
         )
 
 

--- a/ymir/common/base_utils.py
+++ b/ymir/common/base_utils.py
@@ -95,7 +95,12 @@ async def _race_shutdown(
     """
     work_task = asyncio.create_task(coro)
     stop_task = asyncio.create_task(shutdown_event.wait())
-    done, _ = await asyncio.wait({work_task, stop_task}, return_when=asyncio.FIRST_COMPLETED)
+    try:
+        done, _ = await asyncio.wait({work_task, stop_task}, return_when=asyncio.FIRST_COMPLETED)
+    except asyncio.CancelledError:
+        work_task.cancel()
+        stop_task.cancel()
+        raise
 
     if stop_task in done and work_task not in done:
         if cancel_on_shutdown:
@@ -242,7 +247,10 @@ async def run_task_loop(
         # out of `active` as each task transitions to done, which happens
         # *during* the gather below. Iterating `active` after the gather
         # would see an already-emptied dict and silently re-push nothing.
-        to_repush = list(active.items())
+        # Filter out tasks that are already done() — done-callbacks run via
+        # call_soon, so a completed task can still be in `active` briefly;
+        # re-pushing it would duplicate work that already ran.
+        to_repush = [(t, meta) for t, meta in active.items() if not t.done()]
         task_loop_logger.info(
             "Shutting down: cancelling %d active task(s) and re-pushing to Redis",
             len(to_repush),
@@ -252,8 +260,11 @@ async def run_task_loop(
         await asyncio.gather(*(t for t, _ in to_repush), return_exceptions=True)
 
         for _t, (source_queue, payload) in to_repush:
-            await fix_await(redis_conn.rpush(source_queue, payload))
-            task_loop_logger.info("Re-pushed task to %s on shutdown", source_queue)
+            try:
+                await fix_await(redis_conn.rpush(source_queue, payload))
+                task_loop_logger.info("Re-pushed task to %s on shutdown", source_queue)
+            except Exception:
+                task_loop_logger.exception("Failed to re-push task to %s on shutdown", source_queue)
 
     if orphan_poll_task is not None:
         # Bounded by poll_timeout (BRPOP's own timeout, or a well-behaved
@@ -268,13 +279,12 @@ async def run_task_loop(
         )
         try:
             orphan_result = await orphan_poll_task
-        except Exception:
-            logger.exception("Orphaned poll task failed after shutdown; its result, if any, is lost")
-        else:
             if orphan_result is not None:
                 source_queue, payload = orphan_result
                 await fix_await(redis_conn.rpush(source_queue, payload))
                 task_loop_logger.info("Re-pushed orphaned poll result to %s on shutdown", source_queue)
+        except Exception:
+            logger.exception("Failed to resolve or re-push orphaned poll task after shutdown")
 
 
 def get_jira_auth_headers() -> dict[str, str]:

--- a/ymir/common/base_utils.py
+++ b/ymir/common/base_utils.py
@@ -1,10 +1,12 @@
 import asyncio
 import base64
+import contextlib
 import inspect
 import logging
 import os
 import re
 import shlex
+import signal
 import subprocess
 from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine
 from contextlib import asynccontextmanager
@@ -64,6 +66,64 @@ async def redis_client(redis_url: str) -> AsyncGenerator[redis.Redis]:
         logger.debug("Disconnected from Redis")
 
 
+async def _race_shutdown(
+    coro: Coroutine,
+    shutdown_event: asyncio.Event,
+    *,
+    cancel_on_shutdown: bool,
+) -> tuple[bool, object]:
+    """Race `coro` against `shutdown_event`.
+
+    Returns `(True, result)` if `coro` finished first, or `(False, None)`
+    if shutdown fired first.
+
+    `cancel_on_shutdown` controls what happens to `coro` when shutdown
+    wins: pure in-process awaitables (`Semaphore.acquire`, `Event.wait`)
+    are safe to cancel-and-await immediately. Live I/O (a Redis BRPOP or a
+    custom `poll_fn`) is not: redis-py never disconnects/resets a
+    connection on `CancelledError`, it just returns it to the pool as-is
+    in a `finally`. Cancelling mid-read risks a stale response sitting on
+    that connection, which the next command drawn from the pool (e.g. our
+    own re-push RPUSH calls on shutdown) could read instead of its own.
+    So for live I/O, `coro` is abandoned instead via a done-callback that
+    only silences an "exception was never retrieved" warning if it
+    eventually errors out on its own; `asyncio.run()`'s teardown cancels
+    it for real once nothing else needs the connection pool.
+    """
+    work_task = asyncio.create_task(coro)
+    stop_task = asyncio.create_task(shutdown_event.wait())
+    done, _ = await asyncio.wait({work_task, stop_task}, return_when=asyncio.FIRST_COMPLETED)
+
+    if stop_task in done and work_task not in done:
+        if cancel_on_shutdown:
+            work_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await work_task
+        else:
+            work_task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
+        return False, None
+
+    with contextlib.suppress(asyncio.CancelledError):
+        stop_task.cancel()
+        await stop_task
+    return True, work_task.result()
+
+
+def install_shutdown_handler(
+    loop: asyncio.AbstractEventLoop,
+    shutdown_event: asyncio.Event,
+) -> None:
+    """Install SIGTERM/SIGINT handlers that set `shutdown_event`.
+
+    Setting an Event (rather than cancelling a task directly) means the
+    handler is safe no matter what the process is doing at signal time —
+    it doesn't interrupt arbitrary awaits outside `run_task_loop`, it just
+    asks the task loop to start winding down at its next checkpoint.
+    """
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, shutdown_event.set)
+
+
 async def run_task_loop(
     redis_conn: redis.Redis,
     queues: list[str],
@@ -71,17 +131,28 @@ async def run_task_loop(
     max_concurrent: int = 1,
     poll_timeout: int = 30,
     poll_fn: Callable[[], Coroutine] | None = None,
+    shutdown_event: asyncio.Event | None = None,
 ) -> None:
     """Run a concurrent task loop that pops tasks from Redis queues.
 
     Acquires a semaphore slot before popping to ensure we never hold more
     tasks in memory than we can process, preventing task loss on crash.
+
+    On `shutdown_event`, stops pulling new tasks, cancels whatever is
+    still in flight, and re-pushes their original payloads back to the
+    queues they came from via RPUSH (tail — next to be popped by BRPOP)
+    so no work is silently dropped. There's no grace period: task
+    processing runs for minutes (sometimes hours, e.g. build polling), so
+    waiting for in-flight work to finish naturally would rarely succeed
+    and just delays recovery. Callers that can tolerate losing work
+    outright can simply not pass `shutdown_event`.
     """
     if max_concurrent < 1:
         raise ValueError("max_concurrent must be at least 1")
 
+    shutdown_event = shutdown_event or asyncio.Event()
     sem = asyncio.Semaphore(max_concurrent)
-    active: set[asyncio.Task] = set()
+    active: dict[asyncio.Task, tuple[bytes, bytes]] = {}
 
     label = "custom poller" if poll_fn else str(queues)
     task_loop_logger.info(
@@ -104,44 +175,73 @@ async def run_task_loop(
                 logger.exception("Unhandled exception during log flushing")
             sem.release()
 
-    async def _default_poll() -> bytes | None:
-        element = await fix_await(redis_conn.brpop(queues, timeout=poll_timeout))
-        if element is None:
-            return None
-        _, payload = element
-        return payload
+    async def _default_poll() -> tuple[bytes, bytes] | None:
+        # Already (queue_name, payload) or None; both come back as raw
+        # bytes since the client doesn't set decode_responses.
+        return await fix_await(redis_conn.brpop(queues, timeout=poll_timeout))
 
     actual_poll = poll_fn or _default_poll
 
-    try:
-        while True:
-            await sem.acquire()
-            payload = await actual_poll()
-            if payload is None:
-                sem.release()
-                if poll_fn:
-                    await asyncio.sleep(poll_timeout)
-                continue
+    while not shutdown_event.is_set():
+        # Race the semaphore acquire against shutdown too — not just the
+        # poll. Without this, once all `max_concurrent` slots are held by
+        # genuinely long-running tasks (the exact scenario this exists
+        # for — e.g. build-polling that can run for hours), `sem.acquire()`
+        # would block forever waiting for a slot that never frees up
+        # naturally, and the loop would never reach the shutdown check at
+        # all: SIGTERM would fire and nothing would happen.
+        acquired, _ = await _race_shutdown(sem.acquire(), shutdown_event, cancel_on_shutdown=True)
+        if not acquired:
+            break
+        if shutdown_event.is_set():
+            sem.release()
+            break
 
-            task_loop_logger.info("Received task from queue.")
+        # Race the poll against shutdown so we don't block on BRPOP (or a
+        # custom poll_fn) after shutdown has been requested. Live I/O, so
+        # cancel_on_shutdown=False — see _race_shutdown's docstring for
+        # why cancelling a live Redis call mid-flight is unsafe.
+        got_result, result = await _race_shutdown(actual_poll(), shutdown_event, cancel_on_shutdown=False)
+        if not got_result:
+            sem.release()
+            break
 
-            t = asyncio.create_task(_run(payload))
-            active.add(t)
-            t.add_done_callback(active.discard)
-    except asyncio.CancelledError:
-        if active:
-            task_loop_logger.info(
-                "Task loop cancelled. Waiting for %d active tasks to complete...",
-                len(active),
-            )
-            await asyncio.shield(asyncio.gather(*active, return_exceptions=True))
-        raise
-    finally:
-        if active:
-            task_loop_logger.info("Cancelling %d active tasks...", len(active))
-            for t in active:
-                t.cancel()
-            await asyncio.gather(*active, return_exceptions=True)
+        if result is None:
+            sem.release()
+            if poll_fn:
+                # Race the idle-sleep against shutdown too, so a custom
+                # poll_fn doesn't add up to poll_timeout of extra
+                # shutdown latency on top of everything else.
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(shutdown_event.wait(), timeout=poll_timeout)
+            continue
+
+        task_loop_logger.info("Received task from queue.")
+
+        source_queue, payload = result
+        t = asyncio.create_task(_run(payload))
+        active[t] = (source_queue, payload)
+        t.add_done_callback(lambda _t: active.pop(_t, None))
+
+    if not active:
+        return
+
+    # Snapshot BEFORE cancelling: the done-callback above pops entries out
+    # of `active` as each task transitions to done, which happens *during*
+    # the gather below. Iterating `active` after the gather would see an
+    # already-emptied dict and silently re-push nothing.
+    to_repush = list(active.items())
+    task_loop_logger.info(
+        "Shutting down: cancelling %d active task(s) and re-pushing to Redis",
+        len(to_repush),
+    )
+    for t, _ in to_repush:
+        t.cancel()
+    await asyncio.gather(*(t for t, _ in to_repush), return_exceptions=True)
+
+    for _t, (source_queue, payload) in to_repush:
+        await fix_await(redis_conn.rpush(source_queue, payload))
+        task_loop_logger.info("Re-pushed task to %s on shutdown", source_queue)
 
 
 def get_jira_auth_headers() -> dict[str, str]:

--- a/ymir/common/base_utils.py
+++ b/ymir/common/base_utils.py
@@ -71,11 +71,14 @@ async def _race_shutdown(
     shutdown_event: asyncio.Event,
     *,
     cancel_on_shutdown: bool,
-) -> tuple[bool, object]:
+) -> tuple[bool, object, asyncio.Task | None]:
     """Race `coro` against `shutdown_event`.
 
-    Returns `(True, result)` if `coro` finished first, or `(False, None)`
-    if shutdown fired first.
+    Returns `(True, result, None)` if `coro` finished first.
+
+    If shutdown fires first: returns `(False, None, None)` when
+    `cancel_on_shutdown=True`, or `(False, None, work_task)` when
+    `cancel_on_shutdown=False` — see below.
 
     `cancel_on_shutdown` controls what happens to `coro` when shutdown
     wins: pure in-process awaitables (`Semaphore.acquire`, `Event.wait`)
@@ -85,10 +88,10 @@ async def _race_shutdown(
     in a `finally`. Cancelling mid-read risks a stale response sitting on
     that connection, which the next command drawn from the pool (e.g. our
     own re-push RPUSH calls on shutdown) could read instead of its own.
-    So for live I/O, `coro` is abandoned instead via a done-callback that
-    only silences an "exception was never retrieved" warning if it
-    eventually errors out on its own; `asyncio.run()`'s teardown cancels
-    it for real once nothing else needs the connection pool.
+    So for live I/O, `coro` is left running and handed back to the caller
+    as `work_task` instead: if it eventually returns a real task (rather
+    than timing out with `None`), the caller must still account for it
+    (e.g. re-push it) rather than silently letting the result vanish.
     """
     work_task = asyncio.create_task(coro)
     stop_task = asyncio.create_task(shutdown_event.wait())
@@ -99,14 +102,13 @@ async def _race_shutdown(
             work_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await work_task
-        else:
-            work_task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
-        return False, None
+            return False, None, None
+        return False, None, work_task
 
     with contextlib.suppress(asyncio.CancelledError):
         stop_task.cancel()
         await stop_task
-    return True, work_task.result()
+    return True, work_task.result(), None
 
 
 def install_shutdown_handler(
@@ -141,11 +143,18 @@ async def run_task_loop(
     On `shutdown_event`, stops pulling new tasks, cancels whatever is
     still in flight, and re-pushes their original payloads back to the
     queues they came from via RPUSH (tail — next to be popped by BRPOP)
-    so no work is silently dropped. There's no grace period: task
-    processing runs for minutes (sometimes hours, e.g. build polling), so
-    waiting for in-flight work to finish naturally would rarely succeed
-    and just delays recovery. Callers that can tolerate losing work
-    outright can simply not pass `shutdown_event`.
+    so no work is silently dropped. There's no grace period for that:
+    task processing runs for minutes (sometimes hours, e.g. build
+    polling), so waiting for in-flight work to finish naturally would
+    rarely succeed and just delays recovery. Callers that can tolerate
+    losing work outright can simply not pass `shutdown_event`.
+
+    A poll (BRPOP or `poll_fn`) already in flight when shutdown fires is
+    a different story: it's abandoned rather than cancelled (see
+    `_race_shutdown`'s docstring), but it's bounded by `poll_timeout` and
+    can still return a real task once it resolves. That result is waited
+    for and re-pushed too, so a task isn't silently consumed from Redis
+    and dropped just because it arrived a moment after shutdown.
     """
     if max_concurrent < 1:
         raise ValueError("max_concurrent must be at least 1")
@@ -181,6 +190,7 @@ async def run_task_loop(
         return await fix_await(redis_conn.brpop(queues, timeout=poll_timeout))
 
     actual_poll = poll_fn or _default_poll
+    orphan_poll_task: asyncio.Task | None = None
 
     while not shutdown_event.is_set():
         # Race the semaphore acquire against shutdown too — not just the
@@ -190,7 +200,7 @@ async def run_task_loop(
         # would block forever waiting for a slot that never frees up
         # naturally, and the loop would never reach the shutdown check at
         # all: SIGTERM would fire and nothing would happen.
-        acquired, _ = await _race_shutdown(sem.acquire(), shutdown_event, cancel_on_shutdown=True)
+        acquired, _, _ = await _race_shutdown(sem.acquire(), shutdown_event, cancel_on_shutdown=True)
         if not acquired:
             break
         if shutdown_event.is_set():
@@ -200,8 +210,12 @@ async def run_task_loop(
         # Race the poll against shutdown so we don't block on BRPOP (or a
         # custom poll_fn) after shutdown has been requested. Live I/O, so
         # cancel_on_shutdown=False — see _race_shutdown's docstring for
-        # why cancelling a live Redis call mid-flight is unsafe.
-        got_result, result = await _race_shutdown(actual_poll(), shutdown_event, cancel_on_shutdown=False)
+        # why cancelling a live Redis call mid-flight is unsafe. If
+        # shutdown wins, the poll is still running; hang onto it so it
+        # can be resolved (and re-pushed if it returns a task) below.
+        got_result, result, orphan_poll_task = await _race_shutdown(
+            actual_poll(), shutdown_event, cancel_on_shutdown=False
+        )
         if not got_result:
             sem.release()
             break
@@ -223,25 +237,44 @@ async def run_task_loop(
         active[t] = (source_queue, payload)
         t.add_done_callback(lambda _t: active.pop(_t, None))
 
-    if not active:
-        return
+    if active:
+        # Snapshot BEFORE cancelling: the done-callback above pops entries
+        # out of `active` as each task transitions to done, which happens
+        # *during* the gather below. Iterating `active` after the gather
+        # would see an already-emptied dict and silently re-push nothing.
+        to_repush = list(active.items())
+        task_loop_logger.info(
+            "Shutting down: cancelling %d active task(s) and re-pushing to Redis",
+            len(to_repush),
+        )
+        for t, _ in to_repush:
+            t.cancel()
+        await asyncio.gather(*(t for t, _ in to_repush), return_exceptions=True)
 
-    # Snapshot BEFORE cancelling: the done-callback above pops entries out
-    # of `active` as each task transitions to done, which happens *during*
-    # the gather below. Iterating `active` after the gather would see an
-    # already-emptied dict and silently re-push nothing.
-    to_repush = list(active.items())
-    task_loop_logger.info(
-        "Shutting down: cancelling %d active task(s) and re-pushing to Redis",
-        len(to_repush),
-    )
-    for t, _ in to_repush:
-        t.cancel()
-    await asyncio.gather(*(t for t, _ in to_repush), return_exceptions=True)
+        for _t, (source_queue, payload) in to_repush:
+            await fix_await(redis_conn.rpush(source_queue, payload))
+            task_loop_logger.info("Re-pushed task to %s on shutdown", source_queue)
 
-    for _t, (source_queue, payload) in to_repush:
-        await fix_await(redis_conn.rpush(source_queue, payload))
-        task_loop_logger.info("Re-pushed task to %s on shutdown", source_queue)
+    if orphan_poll_task is not None:
+        # Bounded by poll_timeout (BRPOP's own timeout, or a well-behaved
+        # poll_fn) — not an indefinite wait, so this doesn't reintroduce a
+        # grace period for task processing. Must be resolved here, before
+        # returning, rather than left for the event loop to clean up on
+        # its own: otherwise a task it pops from Redis after we've already
+        # returned is consumed and dropped with nothing to re-push it.
+        task_loop_logger.info(
+            "Shutting down: waiting on in-flight poll (bounded by poll_timeout=%ds)",
+            poll_timeout,
+        )
+        try:
+            orphan_result = await orphan_poll_task
+        except Exception:
+            logger.exception("Orphaned poll task failed after shutdown; its result, if any, is lost")
+        else:
+            if orphan_result is not None:
+                source_queue, payload = orphan_result
+                await fix_await(redis_conn.rpush(source_queue, payload))
+                task_loop_logger.info("Re-pushed orphaned poll result to %s on shutdown", source_queue)
 
 
 def get_jira_auth_headers() -> dict[str, str]:

--- a/ymir/common/merge_queue.py
+++ b/ymir/common/merge_queue.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from ymir.common.base_utils import fix_await
 from ymir.common.constants import RedisQueues
@@ -10,6 +10,7 @@ from ymir.common.models import MergeConsolidationJob
 logger = logging.getLogger(__name__)
 
 _CONSOLIDATION_HASH_KEY = RedisQueues.MERGE_CONSOLIDATION_QUEUE.value
+_DEFAULT_STALE_ACTIVE_THRESHOLD = timedelta(hours=6)
 
 
 def _consolidation_field_key(package: str, branch: str, slot: str) -> str:
@@ -99,6 +100,11 @@ async def pick_next_job(redis_conn) -> MergeConsolidationJob | None:
     Uses a Lua script so the scan-check-promote is atomic on the Redis
     server, preventing two workers from picking the same job.
 
+    After atomic promotion, writes back the updated JSON with
+    ``activated_at`` set so the staleness sweep can measure genuine
+    active-time rather than total queue-time (submitted_at includes
+    time spent waiting in :pending).
+
     Returns:
         The activated job, or None if no pending jobs exist.
     """
@@ -106,9 +112,15 @@ async def pick_next_job(redis_conn) -> MergeConsolidationJob | None:
     if result is None:
         return None
 
-    _field, value = result
+    field, value = result
     job = MergeConsolidationJob.model_validate_json(value)
     job.active = True
+    job.activated_at = datetime.now(UTC)
+
+    field_str = field.decode() if isinstance(field, bytes) else field
+    active_key = field_str.removesuffix(":pending") + ":active"
+    await fix_await(redis_conn.hset(_CONSOLIDATION_HASH_KEY, active_key, job.model_dump_json()))
+
     logger.info("Promoted pending job to active for %s/%s", job.package, job.target_branch)
     return job
 
@@ -128,3 +140,95 @@ async def complete_job(
     active_key = _consolidation_field_key(package, target_branch, "active")
     await fix_await(redis_conn.hdel(_CONSOLIDATION_HASH_KEY, active_key))
     logger.info("Completed active merge job for %s/%s", package, target_branch)
+
+
+_CONDITIONAL_HDEL_LUA = """
+local current = redis.call('HGET', KEYS[1], ARGV[1])
+if current == ARGV[2] then
+    redis.call('HDEL', KEYS[1], ARGV[1])
+    return 1
+end
+return 0
+"""
+
+
+async def sweep_stale_active_jobs(
+    redis_conn,
+    threshold: timedelta = _DEFAULT_STALE_ACTIVE_THRESHOLD,
+) -> int:
+    """Remove :active entries whose ``activated_at`` is older than *threshold*.
+
+    When a consolidation task is cancelled by shutdown, its :active hash
+    field is deliberately left in place (to avoid silent data loss).  But
+    pick_next_job's Lua script refuses to promote a :pending job while
+    :active exists for the same package/branch — so without periodic
+    cleanup, a redeploy that interrupts a consolidation job permanently
+    blocks future consolidation for that package/branch.
+
+    This sweep runs on every poll cycle, deleting :active entries that
+    have been sitting untouched for longer than *threshold*.  The default
+    of 6 hours is well above the longest observed consolidation run
+    (~1-2 hours) but short enough to self-heal within the same workday.
+
+    Staleness is measured from ``activated_at`` (set by ``pick_next_job``
+    at promotion time), not ``submitted_at`` (set at initial queueing).
+    This avoids falsely sweeping a job that sat in :pending for a while
+    before being promoted — its genuine active-time may be much shorter
+    than its total queue-time.
+
+    Deletion uses an atomic compare-and-delete Lua script: the stored
+    value must still byte-match the snapshot read by HGETALL.  If
+    ``complete_job`` removed the entry and ``pick_next_job`` promoted a
+    fresh one into the same field between the snapshot and the delete,
+    the values will differ and the delete is skipped.
+
+    Returns the number of stale entries removed.
+    """
+    all_fields: dict[bytes, bytes] = await fix_await(redis_conn.hgetall(_CONSOLIDATION_HASH_KEY))
+    now = datetime.now(UTC)
+    removed = 0
+
+    for field, value in all_fields.items():
+        field_str = field.decode() if isinstance(field, bytes) else field
+        if not field_str.endswith(":active"):
+            continue
+
+        try:
+            job = MergeConsolidationJob.model_validate_json(value)
+        except Exception:
+            logger.warning(
+                "Cannot parse :active entry %s; skipping staleness check",
+                field_str,
+            )
+            continue
+
+        if job.activated_at is None:
+            logger.info(
+                "Skipping :active entry %s with no activated_at (promoted before sweep support was deployed)",
+                field_str,
+            )
+            continue
+
+        age = now - job.activated_at
+        if age <= threshold:
+            continue
+
+        deleted = await fix_await(
+            redis_conn.eval(_CONDITIONAL_HDEL_LUA, 1, _CONSOLIDATION_HASH_KEY, field, value)
+        )
+        if deleted:
+            removed += 1
+            logger.warning(
+                "Removed stale :active consolidation entry %s (activated %s ago, threshold %s)",
+                field_str,
+                age,
+                threshold,
+            )
+        else:
+            logger.info(
+                "Skipped stale :active entry %s — value changed since snapshot "
+                "(likely completed and re-promoted concurrently)",
+                field_str,
+            )
+
+    return removed

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -747,6 +747,12 @@ class MergeConsolidationJob(BaseModel):
         "(label-triggered mode). When None, pick the two oldest open MRs (auto mode). "
         "Always stored sorted for deterministic logging and span correlation.",
     )
+    activated_at: datetime | None = Field(
+        default=None,
+        description="When this job was promoted from :pending to :active by pick_next_job. "
+        "Set by the caller immediately after Lua promotion; used by sweep_stale_active_jobs "
+        "to measure genuine active-time rather than total queue-time.",
+    )
     release_strategy: str | None = Field(
         default=None,
         description="Release strategy override from package config ('merged' or 'per_commit'). "

--- a/ymir/common/tests/unit/test_base_utils.py
+++ b/ymir/common/tests/unit/test_base_utils.py
@@ -6,26 +6,45 @@ from flexmock import flexmock
 
 from ymir.common.base_utils import install_shutdown_handler, run_task_loop
 
+_NO_DELAYED_RESULT = object()
+
 
 class FakeRedis:
     """Minimal stand-in for the pieces of redis.asyncio.Redis that run_task_loop uses.
 
     `brpop_results` is consumed in order for successive calls; once exhausted,
-    brpop hangs forever (mirroring a real BRPOP with no data available), so
-    tests must either not wait on that call or trigger shutdown to abandon it.
+    brpop resolves to None after a short simulated delay (mirroring a real
+    BRPOP timing out with no data available - it's always eventually
+    resolved, just possibly after `poll_timeout`), unless a delayed result is
+    armed via `arm_delayed_result`.
     """
 
     def __init__(self, brpop_results: list[tuple[bytes, bytes] | None] | None = None):
         self._results = list(brpop_results or [])
         self.brpop_calls = 0
         self.rpush_calls: list[tuple[bytes, bytes]] = []
+        self._delayed_result: tuple[bytes, bytes] | None | object = _NO_DELAYED_RESULT
+        self._release_delayed = asyncio.Event()
 
     async def brpop(self, queues, timeout=None):
         self.brpop_calls += 1
         if self._results:
             return self._results.pop(0)
-        await asyncio.Event().wait()
+        if self._delayed_result is not _NO_DELAYED_RESULT:
+            await self._release_delayed.wait()
+            return self._delayed_result
+        await asyncio.sleep(0.05)
         return None
+
+    def arm_delayed_result(self, result: tuple[bytes, bytes] | None) -> None:
+        """Make the next (post-exhaustion) brpop call block until
+        `release_delayed()` is called, then return `result` — simulating a
+        BRPOP that was already in flight when shutdown fired and only
+        resolves (with a real item, or a natural timeout) afterwards."""
+        self._delayed_result = result
+
+    def release_delayed(self) -> None:
+        self._release_delayed.set()
 
     async def rpush(self, queue, payload):
         self.rpush_calls.append((queue, payload))
@@ -145,6 +164,67 @@ class TestRunTaskLoopShutdown:
         # the "queue" and the first was re-pushed once, unprocessed.
         assert fake_redis.brpop_calls == 1
         assert fake_redis.rpush_calls == [(b"queue1", b"payload1")]
+
+    @pytest.mark.asyncio
+    async def test_orphaned_poll_result_is_repushed_after_shutdown(self):
+        """Regression test: if shutdown fires while a BRPOP is already in
+        flight (so it's abandoned rather than cancelled, per _race_shutdown's
+        docstring), and that BRPOP later resolves with a real task rather
+        than a natural timeout, the task must not be silently consumed from
+        Redis and dropped — it must be re-pushed."""
+        fake_redis = FakeRedis()
+        fake_redis.arm_delayed_result((b"queue1", b"payload1"))
+        shutdown_event = asyncio.Event()
+
+        loop_task = asyncio.create_task(
+            run_task_loop(
+                fake_redis,
+                ["queue1"],
+                _noop,
+                max_concurrent=1,
+                shutdown_event=shutdown_event,
+            )
+        )
+        await _wait_until(lambda: fake_redis.brpop_calls >= 1)
+        await asyncio.sleep(0.01)
+
+        shutdown_event.set()
+        # The loop must not exit until the in-flight BRPOP is resolved one
+        # way or another - it can't just abandon it and return.
+        await asyncio.sleep(0.05)
+        assert not loop_task.done()
+
+        fake_redis.release_delayed()
+        await asyncio.wait_for(loop_task, timeout=1)
+
+        assert fake_redis.rpush_calls == [(b"queue1", b"payload1")]
+
+    @pytest.mark.asyncio
+    async def test_orphaned_poll_natural_timeout_repushes_nothing(self):
+        """If the in-flight BRPOP that was abandoned on shutdown resolves
+        with None (a natural timeout, no data arrived), there's nothing to
+        re-push."""
+        fake_redis = FakeRedis()
+        fake_redis.arm_delayed_result(None)
+        shutdown_event = asyncio.Event()
+
+        loop_task = asyncio.create_task(
+            run_task_loop(
+                fake_redis,
+                ["queue1"],
+                _noop,
+                max_concurrent=1,
+                shutdown_event=shutdown_event,
+            )
+        )
+        await _wait_until(lambda: fake_redis.brpop_calls >= 1)
+        await asyncio.sleep(0.01)
+
+        shutdown_event.set()
+        fake_redis.release_delayed()
+        await asyncio.wait_for(loop_task, timeout=1)
+
+        assert fake_redis.rpush_calls == []
 
     @pytest.mark.asyncio
     async def test_custom_poll_fn_idle_sleep_is_interrupted_by_shutdown(self):

--- a/ymir/common/tests/unit/test_base_utils.py
+++ b/ymir/common/tests/unit/test_base_utils.py
@@ -1,0 +1,195 @@
+import asyncio
+import signal
+
+import pytest
+from flexmock import flexmock
+
+from ymir.common.base_utils import install_shutdown_handler, run_task_loop
+
+
+class FakeRedis:
+    """Minimal stand-in for the pieces of redis.asyncio.Redis that run_task_loop uses.
+
+    `brpop_results` is consumed in order for successive calls; once exhausted,
+    brpop hangs forever (mirroring a real BRPOP with no data available), so
+    tests must either not wait on that call or trigger shutdown to abandon it.
+    """
+
+    def __init__(self, brpop_results: list[tuple[bytes, bytes] | None] | None = None):
+        self._results = list(brpop_results or [])
+        self.brpop_calls = 0
+        self.rpush_calls: list[tuple[bytes, bytes]] = []
+
+    async def brpop(self, queues, timeout=None):
+        self.brpop_calls += 1
+        if self._results:
+            return self._results.pop(0)
+        await asyncio.Event().wait()
+        return None
+
+    async def rpush(self, queue, payload):
+        self.rpush_calls.append((queue, payload))
+        return 1
+
+
+async def _wait_until(predicate, timeout=2.0, interval=0.005):
+    async def _poll():
+        while not predicate():
+            await asyncio.sleep(interval)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+async def _hang_forever(_payload: bytes) -> None:
+    await asyncio.Event().wait()
+
+
+async def _noop(_payload: bytes) -> None:
+    return None
+
+
+class TestRunTaskLoopShutdown:
+    @pytest.mark.asyncio
+    async def test_shutdown_already_set_before_start_does_nothing(self):
+        """If shutdown is requested before the loop ever starts, it exits
+        immediately without polling or re-pushing anything."""
+        fake_redis = FakeRedis([(b"queue1", b"payload1")])
+        shutdown_event = asyncio.Event()
+        shutdown_event.set()
+
+        await asyncio.wait_for(
+            run_task_loop(fake_redis, ["queue1"], _noop, shutdown_event=shutdown_event),
+            timeout=1,
+        )
+
+        assert fake_redis.brpop_calls == 0
+        assert fake_redis.rpush_calls == []
+
+    @pytest.mark.asyncio
+    async def test_active_task_is_cancelled_and_repushed_on_shutdown(self):
+        """This is also a regression test for a deadlock: with
+        max_concurrent=1 and the only slot held by a task that never
+        finishes on its own (e.g. hours-long build polling), the loop must
+        still notice shutdown and unblock rather than wait forever on
+        sem.acquire() for a slot that will never free up naturally."""
+        fake_redis = FakeRedis([(b"queue1", b"payload1")])
+        shutdown_event = asyncio.Event()
+
+        loop_task = asyncio.create_task(
+            run_task_loop(
+                fake_redis,
+                ["queue1"],
+                _hang_forever,
+                max_concurrent=1,
+                shutdown_event=shutdown_event,
+            )
+        )
+        await _wait_until(lambda: fake_redis.brpop_calls >= 1)
+        # Give the popped task a moment to actually start running.
+        await asyncio.sleep(0.01)
+
+        shutdown_event.set()
+        await asyncio.wait_for(loop_task, timeout=1)
+
+        assert fake_redis.rpush_calls == [(b"queue1", b"payload1")]
+
+    @pytest.mark.asyncio
+    async def test_completed_task_is_not_repushed(self):
+        """A task that finishes on its own before shutdown must not be
+        re-pushed — only genuinely still-running work should be."""
+        fake_redis = FakeRedis([(b"queue1", b"payload1")])
+        shutdown_event = asyncio.Event()
+
+        loop_task = asyncio.create_task(
+            run_task_loop(
+                fake_redis,
+                ["queue1"],
+                _noop,
+                max_concurrent=1,
+                shutdown_event=shutdown_event,
+            )
+        )
+        # First item is consumed and processed instantly; wait for the loop
+        # to come back around and start (hanging) on the next poll before
+        # triggering shutdown, so there's no active task left by then.
+        await _wait_until(lambda: fake_redis.brpop_calls >= 2)
+
+        shutdown_event.set()
+        await asyncio.wait_for(loop_task, timeout=1)
+
+        assert fake_redis.rpush_calls == []
+
+    @pytest.mark.asyncio
+    async def test_no_new_tasks_pulled_after_shutdown(self):
+        """Once shutdown fires, the loop must not keep pulling additional
+        tasks off the queue even if more are available."""
+        fake_redis = FakeRedis([(b"queue1", b"payload1"), (b"queue1", b"payload2")])
+        shutdown_event = asyncio.Event()
+
+        loop_task = asyncio.create_task(
+            run_task_loop(
+                fake_redis,
+                ["queue1"],
+                _hang_forever,
+                max_concurrent=1,
+                shutdown_event=shutdown_event,
+            )
+        )
+        await _wait_until(lambda: fake_redis.brpop_calls >= 1)
+        await asyncio.sleep(0.01)
+
+        shutdown_event.set()
+        await asyncio.wait_for(loop_task, timeout=1)
+
+        # Only the first item was ever popped; the second is untouched in
+        # the "queue" and the first was re-pushed once, unprocessed.
+        assert fake_redis.brpop_calls == 1
+        assert fake_redis.rpush_calls == [(b"queue1", b"payload1")]
+
+    @pytest.mark.asyncio
+    async def test_custom_poll_fn_idle_sleep_is_interrupted_by_shutdown(self):
+        """A custom poll_fn (e.g. mr_consolidation_agent) that repeatedly
+        returns None while idle must not delay shutdown by the full
+        poll_timeout."""
+        fake_redis = FakeRedis()
+        shutdown_event = asyncio.Event()
+
+        async def poll_fn():
+            return None
+
+        loop_task = asyncio.create_task(
+            run_task_loop(
+                fake_redis,
+                [],
+                _noop,
+                poll_fn=poll_fn,
+                poll_timeout=100,
+                shutdown_event=shutdown_event,
+            )
+        )
+        await asyncio.sleep(0.05)
+        shutdown_event.set()
+
+        # Would take up to 100s if the idle-sleep weren't interruptible.
+        await asyncio.wait_for(loop_task, timeout=1)
+
+    @pytest.mark.asyncio
+    async def test_max_concurrent_below_one_raises(self):
+        with pytest.raises(ValueError, match="max_concurrent must be at least 1"):
+            await run_task_loop(FakeRedis(), ["queue1"], _noop, max_concurrent=0)
+
+
+class TestInstallShutdownHandler:
+    def test_registers_sigterm_and_sigint(self):
+        shutdown_event = asyncio.Event()
+        registered: list[tuple[int, object]] = []
+
+        fake_loop = flexmock()
+        fake_loop.should_receive("add_signal_handler").replace_with(
+            lambda sig, callback: registered.append((sig, callback))
+        )
+
+        install_shutdown_handler(fake_loop, shutdown_event)
+
+        assert {sig for sig, _ in registered} == {signal.SIGTERM, signal.SIGINT}
+        assert all(callback == shutdown_event.set for _, callback in registered)

--- a/ymir/common/tests/unit/test_base_utils.py
+++ b/ymir/common/tests/unit/test_base_utils.py
@@ -4,7 +4,7 @@ import signal
 import pytest
 from flexmock import flexmock
 
-from ymir.common.base_utils import install_shutdown_handler, run_task_loop
+from ymir.common.base_utils import _race_shutdown, install_shutdown_handler, run_task_loop
 
 _NO_DELAYED_RESULT = object()
 
@@ -25,6 +25,7 @@ class FakeRedis:
         self.rpush_calls: list[tuple[bytes, bytes]] = []
         self._delayed_result: tuple[bytes, bytes] | None | object = _NO_DELAYED_RESULT
         self._release_delayed = asyncio.Event()
+        self._rpush_failures: set[tuple[bytes, bytes]] = set()
 
     async def brpop(self, queues, timeout=None):
         self.brpop_calls += 1
@@ -46,7 +47,12 @@ class FakeRedis:
     def release_delayed(self) -> None:
         self._release_delayed.set()
 
+    def fail_rpush_for(self, queue: bytes, payload: bytes) -> None:
+        self._rpush_failures.add((queue, payload))
+
     async def rpush(self, queue, payload):
+        if (queue, payload) in self._rpush_failures:
+            raise RuntimeError("simulated rpush failure")
         self.rpush_calls.append((queue, payload))
         return 1
 
@@ -227,6 +233,58 @@ class TestRunTaskLoopShutdown:
         assert fake_redis.rpush_calls == []
 
     @pytest.mark.asyncio
+    async def test_repush_failure_does_not_abort_remaining_tasks(self):
+        """If RPUSH fails for one task during shutdown, the rest must still
+        be re-pushed rather than the whole batch being aborted."""
+        fake_redis = FakeRedis([(b"q1", b"p1"), (b"q1", b"p2")])
+        fake_redis.fail_rpush_for(b"q1", b"p1")
+        shutdown_event = asyncio.Event()
+
+        loop_task = asyncio.create_task(
+            run_task_loop(
+                fake_redis,
+                ["q1"],
+                _hang_forever,
+                max_concurrent=2,
+                shutdown_event=shutdown_event,
+            )
+        )
+        await _wait_until(lambda: fake_redis.brpop_calls >= 2)
+        await asyncio.sleep(0.01)
+
+        shutdown_event.set()
+        await asyncio.wait_for(loop_task, timeout=1)
+
+        assert fake_redis.rpush_calls == [(b"q1", b"p2")]
+
+    @pytest.mark.asyncio
+    async def test_orphan_poll_rpush_failure_does_not_crash(self):
+        """If the RPUSH for an orphaned poll result fails, run_task_loop
+        must return cleanly instead of raising."""
+        fake_redis = FakeRedis()
+        fake_redis.arm_delayed_result((b"q1", b"p1"))
+        fake_redis.fail_rpush_for(b"q1", b"p1")
+        shutdown_event = asyncio.Event()
+
+        loop_task = asyncio.create_task(
+            run_task_loop(
+                fake_redis,
+                ["q1"],
+                _noop,
+                max_concurrent=1,
+                shutdown_event=shutdown_event,
+            )
+        )
+        await _wait_until(lambda: fake_redis.brpop_calls >= 1)
+        await asyncio.sleep(0.01)
+
+        shutdown_event.set()
+        fake_redis.release_delayed()
+        await asyncio.wait_for(loop_task, timeout=1)
+
+        assert fake_redis.rpush_calls == []
+
+    @pytest.mark.asyncio
     async def test_custom_poll_fn_idle_sleep_is_interrupted_by_shutdown(self):
         """A custom poll_fn (e.g. mr_consolidation_agent) that repeatedly
         returns None while idle must not delay shutdown by the full
@@ -257,6 +315,30 @@ class TestRunTaskLoopShutdown:
     async def test_max_concurrent_below_one_raises(self):
         with pytest.raises(ValueError, match="max_concurrent must be at least 1"):
             await run_task_loop(FakeRedis(), ["queue1"], _noop, max_concurrent=0)
+
+
+class TestRaceShutdown:
+    @pytest.mark.asyncio
+    async def test_outer_cancellation_cleans_up_both_tasks(self):
+        """If the caller of _race_shutdown is itself cancelled, the two
+        internal tasks must not be left running in the background."""
+        shutdown_event = asyncio.Event()
+        started = asyncio.Event()
+
+        async def slow_coro():
+            started.set()
+            await asyncio.Event().wait()
+
+        runner = asyncio.ensure_future(_race_shutdown(slow_coro(), shutdown_event, cancel_on_shutdown=True))
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        runner.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await runner
+
+        await asyncio.sleep(0)
+        leftover = [t for t in asyncio.all_tasks() if t is not asyncio.current_task() and not t.done()]
+        assert leftover == []
 
 
 class TestInstallShutdownHandler:

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -605,7 +605,20 @@ class JiraIssueFetcher:
                 # payload (package, patch_urls, target_branch, etc.) only ever
                 # existed in the now-unrecoverable Redis message.
                 stale_label = self._find_stale_in_flight_label(issue, ymir_labels)
-                if stale_label:
+                if stale_label and issue_key in existing_keys:
+                    # The label looks abandoned, but its payload is still sitting in a
+                    # live Redis queue (e.g. the SIGTERM handler already re-pushed it,
+                    # or a downstream queue is simply backed up — ymir_triaged_backport
+                    # et al. legitimately persist for as long as the task waits to be
+                    # picked up). Flipping to ymir_retry_needed here would bypass the
+                    # existing_keys guard below and LPUSH a second, duplicate task on
+                    # top of the one already queued. Leave it - it'll drain naturally,
+                    # and if it's genuinely stuck the next sweep will re-check.
+                    logger.info(
+                        f"Issue {issue_key} has stale {stale_label} but its task is "
+                        f"still queued in Redis - not treating as abandoned"
+                    )
+                elif stale_label:
                     logger.warning(
                         f"Issue {issue_key} has stale {stale_label} (no update in "
                         f">{self.stale_label_threshold_hours}h, no other Ymir label) - "

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -23,6 +23,7 @@ import os
 import re
 import sys
 import time
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import urljoin
 
@@ -60,6 +61,21 @@ class JiraIssueFetcher:
     API_TIMEOUT = 90  # 90 seconds timeout
     MODULAR_COMPONENT_PATTERN = re.compile(r".+:.+/.+")
 
+    # "In-flight" labels: each marks an issue as currently being worked on by
+    # an agent. If an agent crashes (SIGKILL/OOM) after setting one of these
+    # but before reaching the label write that replaces it with an outcome,
+    # the label is stuck forever and the fetcher skips the issue on every
+    # subsequent sweep — this is the bug the staleness check below guards
+    # against. (Planned redeployments are instead handled instantly by the
+    # SIGTERM handler in run_task_loop; this is the safety net for everything
+    # else.)
+    IN_FLIGHT_LABELS = (
+        JiraLabels.TRIAGE_IN_PROGRESS.value,
+        JiraLabels.TRIAGED_BACKPORT.value,
+        JiraLabels.TRIAGED_REBASE.value,
+        JiraLabels.TRIAGED_REBUILD.value,
+    )
+
     def __init__(self):
         self.jira_url = os.environ["JIRA_URL"]
         self.redis_url = os.environ["REDIS_URL"]
@@ -76,6 +92,17 @@ class JiraIssueFetcher:
 
         # Use constant page size
         self.max_results_per_page = self.MAX_RESULTS_PER_PAGE
+
+        # Staleness threshold for the in-flight-label safety net (see
+        # IN_FLIGHT_LABELS above). Conservative default pending real task
+        # duration data from Phoenix traces (http://localhost:6006/) — the
+        # longest documented single phase today is the 3h post-push testing
+        # window (POST_PUSH_TESTING_TIMEOUT), and a full task can involve
+        # several such phases plus retries, so 24h leaves comfortable margin
+        # while still being far short of "stuck forever". Too aggressive a
+        # value risks a false-positive re-enqueue of a still-running task —
+        # two agents processing the same issue concurrently.
+        self.stale_label_threshold_hours = float(os.getenv("STALE_LABEL_THRESHOLD_HOURS", "24"))
 
         self.headers = get_jira_auth_headers()
 
@@ -279,6 +306,60 @@ class JiraIssueFetcher:
             )
             return False
 
+    @staticmethod
+    def _is_label_stale(issue: dict[str, Any], threshold_hours: float) -> bool:
+        """Check whether `issue`'s bulk-fetched `fields.updated` timestamp is
+        older than `threshold_hours`.
+
+        Uses data already in hand from the bulk search — no extra per-issue
+        Jira API calls, so this scales to the full sweep with zero added
+        load. This is intentionally coarser than "when was this specific
+        label added": any field update (e.g. an unrelated human comment)
+        resets `updated` too. Acceptable for a best-effort safety net —
+        false negatives (staleness masked by an unrelated update) just wait
+        for the next sweep, which is safe.
+
+        Returns False (not stale) if `updated` is missing or unparseable,
+        since we can't tell without it — fails closed to the current
+        "always skip" behavior rather than risking a false-positive
+        re-enqueue of still-running work.
+        """
+        updated_str = (issue.get("fields") or {}).get("updated")
+        if not updated_str:
+            return False
+        try:
+            updated = datetime.fromisoformat(updated_str)
+        except ValueError:
+            return False
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=UTC)
+        return datetime.now(UTC) - updated > timedelta(hours=threshold_hours)
+
+    def _find_stale_in_flight_label(self, issue: dict[str, Any], ymir_labels: list[str]) -> str | None:
+        """Return the in-flight label on `issue` if it looks abandoned, else None.
+
+        "Abandoned" means: one of IN_FLIGHT_LABELS is present, no other Ymir
+        label coexists with it (the same signal triage_agent's own dedup
+        check uses to decide a stage already produced an outcome — see
+        triage_agent.py's `terminal_ymir_labels` check), and the issue hasn't
+        been updated in over `stale_label_threshold_hours`. A coexisting
+        label means either the outcome label was written but the in-flight
+        one wasn't cleaned up (not actually stuck), or it's an orthogonal
+        label from an unrelated workflow (e.g. ymir_consolidate_base) — in
+        both cases we can't be confident it's abandoned, so we leave it
+        alone rather than risk a false-positive re-enqueue.
+        """
+        ignorable = {JiraLabels.RETRY_NEEDED.value, JiraLabels.TODO.value}
+        for label in self.IN_FLIGHT_LABELS:
+            if label not in ymir_labels:
+                continue
+            other_labels = [ol for ol in ymir_labels if ol != label and ol not in ignorable]
+            if other_labels:
+                continue
+            if self._is_label_stale(issue, self.stale_label_threshold_hours):
+                return label
+        return None
+
     async def search_issues(self) -> list[dict[str, Any]]:
         """
         Search for issues using the configured query with cursor-based pagination.
@@ -295,6 +376,7 @@ class JiraIssueFetcher:
             "components",  # Issue components
             "customfield_10669",  # Downstream Component Name
             "fixVersions",  # Fix Version/s (e.g., rhel-9.8)
+            "updated",  # Last-modified timestamp — used for stale in-flight-label detection
         ]
 
         while True:
@@ -511,6 +593,42 @@ class JiraIssueFetcher:
                     )
                     remove_issues_for_retry.add(issue_key)
                     user_triggered_keys.add(issue_key)
+                    continue
+
+                # Safety net for tasks lost to a hard crash/OOM/SIGKILL (planned
+                # redeployments are instead recovered instantly by the SIGTERM
+                # handler in run_task_loop, which re-pushes the original Redis
+                # payload — unavailable here). Flip the stuck in-flight label to
+                # ymir_retry_needed so the existing retry_needed handling below
+                # re-triages the issue from scratch — the only generically
+                # correct recovery path, since the original downstream Task
+                # payload (package, patch_urls, target_branch, etc.) only ever
+                # existed in the now-unrecoverable Redis message.
+                stale_label = self._find_stale_in_flight_label(issue, ymir_labels)
+                if stale_label:
+                    logger.warning(
+                        f"Issue {issue_key} has stale {stale_label} (no update in "
+                        f">{self.stale_label_threshold_hours}h, no other Ymir label) - "
+                        f"treating as abandoned and flipping to {JiraLabels.RETRY_NEEDED.value}"
+                    )
+                    if self.dry_run:
+                        logger.info(
+                            f"DRY_RUN: would flip {stale_label} -> "
+                            f"{JiraLabels.RETRY_NEEDED.value} on {issue_key}"
+                        )
+                    else:
+                        try:
+                            self._edit_jira_labels(
+                                issue_key,
+                                add=[JiraLabels.RETRY_NEEDED.value],
+                                remove=[stale_label],
+                            )
+                        except Exception as e:
+                            logger.warning(f"Failed to flip stale {stale_label} on {issue_key}: {e}")
+                            existing_keys.add(issue_key)
+                            continue
+                    remove_issues_for_retry.add(issue_key)
+                    retry_needed_keys.add(issue_key)
                     continue
 
                 # If issue has Ymir labels and there is no ymir_retry_needed label, mark as existing

--- a/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -3,6 +3,7 @@ import json
 import sys
 import time
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import requests
@@ -149,7 +150,7 @@ async def test_search_issues_single_page(fetcher):
         json_data={
             "jql": 'filter = "Jotnar_1000_packages"',
             "maxResults": 500,
-            "fields": ["key", "labels", "components", "customfield_10669", "fixVersions"],
+            "fields": ["key", "labels", "components", "customfield_10669", "fixVersions", "updated"],
         },
     ).and_return(
         {
@@ -1023,6 +1024,283 @@ def test_label_added_by_rh_employee_false_when_no_add_event(fetcher):
     flexmock(requests).should_receive("get").and_return(_changelog_response(histories)).once()
 
     assert fetcher._label_added_by_rh_employee("RHEL-4") is False
+
+
+# ============================================================================
+# _is_label_stale / _find_stale_in_flight_label
+# ============================================================================
+
+_STALE_UPDATED = (datetime.now(UTC) - timedelta(hours=100)).isoformat()
+_FRESH_UPDATED = datetime.now(UTC).isoformat()
+
+
+@pytest.mark.parametrize(
+    ("updated", "expected"),
+    [
+        (_STALE_UPDATED, True),
+        (_FRESH_UPDATED, False),
+        # Real Jira format: no colon in the UTC offset.
+        ("2020-01-01T00:00:00.000+0000", True),
+        (None, False),  # missing field fails closed
+        ("not-a-timestamp", False),  # unparseable fails closed
+    ],
+)
+def test_is_label_stale(updated, expected):
+    issue = {"fields": {"updated": updated}} if updated is not None else {"fields": {}}
+    assert JiraIssueFetcher._is_label_stale(issue, threshold_hours=24) is expected
+
+
+def test_is_label_stale_naive_datetime_treated_as_utc():
+    """A timestamp with no timezone info is treated as UTC rather than raising."""
+    naive_but_old = (datetime.now(UTC) - timedelta(hours=100)).replace(tzinfo=None).isoformat()
+    issue = {"fields": {"updated": naive_but_old}}
+    assert JiraIssueFetcher._is_label_stale(issue, threshold_hours=24) is True
+
+
+def test_find_stale_in_flight_label_returns_label_when_alone_and_stale(fetcher):
+    issue = {"fields": {"updated": _STALE_UPDATED}}
+    result = fetcher._find_stale_in_flight_label(issue, [JiraLabels.TRIAGE_IN_PROGRESS.value])
+    assert result == JiraLabels.TRIAGE_IN_PROGRESS.value
+
+
+def test_find_stale_in_flight_label_none_when_fresh(fetcher):
+    issue = {"fields": {"updated": _FRESH_UPDATED}}
+    result = fetcher._find_stale_in_flight_label(issue, [JiraLabels.TRIAGE_IN_PROGRESS.value])
+    assert result is None
+
+
+def test_find_stale_in_flight_label_none_when_no_in_flight_label(fetcher):
+    issue = {"fields": {"updated": _STALE_UPDATED}}
+    result = fetcher._find_stale_in_flight_label(issue, [JiraLabels.RETRY_NEEDED.value])
+    assert result is None
+
+
+def test_find_stale_in_flight_label_none_when_terminal_label_coexists(fetcher):
+    """A terminal outcome label alongside the in-flight one means it's not
+    actually stuck — just not cleaned up, or the two are unrelated."""
+    issue = {"fields": {"updated": _STALE_UPDATED}}
+    result = fetcher._find_stale_in_flight_label(
+        issue, [JiraLabels.TRIAGED_BACKPORT.value, JiraLabels.BACKPORTED.value]
+    )
+    assert result is None
+
+
+def test_find_stale_in_flight_label_ignores_retry_needed_and_todo(fetcher):
+    """ymir_retry_needed / ymir_todo are trigger labels, not outcomes — their
+    presence alongside a stale in-flight label doesn't block detection."""
+    issue = {"fields": {"updated": _STALE_UPDATED}}
+    result = fetcher._find_stale_in_flight_label(
+        issue,
+        [JiraLabels.TRIAGE_IN_PROGRESS.value, JiraLabels.RETRY_NEEDED.value, JiraLabels.TODO.value],
+    )
+    assert result == JiraLabels.TRIAGE_IN_PROGRESS.value
+
+
+def test_find_stale_in_flight_label_downstream_stage(fetcher):
+    issue = {"fields": {"updated": _STALE_UPDATED}}
+    result = fetcher._find_stale_in_flight_label(issue, [JiraLabels.TRIAGED_REBUILD.value])
+    assert result == JiraLabels.TRIAGED_REBUILD.value
+
+
+# ============================================================================
+# push_issues_to_queue: stale in-flight label safety net
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_push_stale_triage_in_progress_reenqueued(fetcher, mock_redis_context):
+    """Stale ymir_triage_in_progress with no other Ymir label: flip to
+    ymir_retry_needed, then let the existing retry machinery re-triage it
+    (non-user-triggered, since the original trigger context is lost)."""
+    mock_redis, _ = mock_redis_context
+
+    issues = [
+        {
+            "key": "STUCK-1",
+            "fields": {"labels": [JiraLabels.TRIAGE_IN_PROGRESS.value], "updated": _STALE_UPDATED},
+        }
+    ]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+
+    # First flip: the stale-detection safety net itself.
+    flexmock(fetcher).should_receive("_edit_jira_labels").with_args(
+        "STUCK-1",
+        add=[JiraLabels.RETRY_NEEDED.value],
+        remove=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+    ).once()
+    # Second flip: the pre-existing retry_needed handling consumes the
+    # trigger it just created, same as for a maintainer-set ymir_retry_needed.
+    flexmock(fetcher).should_receive("_edit_jira_labels").with_args(
+        "STUCK-1",
+        add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+        remove=[JiraLabels.RETRY_NEEDED.value],
+    ).once()
+
+    expected_task = Task.from_issue("STUCK-1", user_triggered=False)
+    mock_redis.should_receive("lpush").with_args(
+        RedisQueues.TRIAGE_QUEUE.value, expected_task.to_json()
+    ).and_return(create_async_mock_return_value(1)).once()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 1
+
+
+@pytest.mark.asyncio
+async def test_push_stale_triaged_backport_reenqueued(fetcher, mock_redis_context):
+    """Stale ymir_triaged_backport with no terminal outcome label: same
+    flip-to-retry-needed recovery as the triage-stage case."""
+    mock_redis, _ = mock_redis_context
+
+    issues = [
+        {
+            "key": "STUCK-2",
+            "fields": {"labels": [JiraLabels.TRIAGED_BACKPORT.value], "updated": _STALE_UPDATED},
+        }
+    ]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+
+    flexmock(fetcher).should_receive("_edit_jira_labels").with_args(
+        "STUCK-2",
+        add=[JiraLabels.RETRY_NEEDED.value],
+        remove=[JiraLabels.TRIAGED_BACKPORT.value],
+    ).once()
+    flexmock(fetcher).should_receive("_edit_jira_labels").with_args(
+        "STUCK-2",
+        add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+        remove=[JiraLabels.RETRY_NEEDED.value],
+    ).once()
+
+    expected_task = Task.from_issue("STUCK-2", user_triggered=False)
+    mock_redis.should_receive("lpush").with_args(
+        RedisQueues.TRIAGE_QUEUE.value, expected_task.to_json()
+    ).and_return(create_async_mock_return_value(1)).once()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 1
+
+
+@pytest.mark.asyncio
+async def test_push_fresh_triage_in_progress_still_skipped(fetcher, mock_redis_context):
+    """Non-stale ymir_triage_in_progress: unchanged pre-existing behavior —
+    skip and don't touch Jira or Redis."""
+    mock_redis, _ = mock_redis_context
+
+    issues = [
+        {
+            "key": "FRESH-1",
+            "fields": {"labels": [JiraLabels.TRIAGE_IN_PROGRESS.value], "updated": _FRESH_UPDATED},
+        }
+    ]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+    flexmock(fetcher).should_receive("_edit_jira_labels").never()
+    mock_redis.should_receive("lpush").never()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_push_stale_in_progress_with_terminal_label_still_skipped(fetcher, mock_redis_context):
+    """Stale ymir_triaged_rebase alongside its terminal outcome label
+    (ymir_rebased) means processing actually finished — the in-flight label
+    just wasn't cleaned up. Not a stuck task: leave it alone."""
+    mock_redis, _ = mock_redis_context
+
+    issues = [
+        {
+            "key": "DONE-1",
+            "fields": {
+                "labels": [JiraLabels.TRIAGED_REBASE.value, JiraLabels.REBASED.value],
+                "updated": _STALE_UPDATED,
+            },
+        }
+    ]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+    flexmock(fetcher).should_receive("_edit_jira_labels").never()
+    mock_redis.should_receive("lpush").never()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_push_stale_reenqueue_skips_when_flip_fails(fetcher, mock_redis_context):
+    """If the stale-recovery flip itself raises, skip the Redis push —
+    otherwise the next sweep would find no trigger label at all."""
+    mock_redis, _ = mock_redis_context
+
+    issues = [
+        {
+            "key": "STUCK-FAIL",
+            "fields": {"labels": [JiraLabels.TRIAGE_IN_PROGRESS.value], "updated": _STALE_UPDATED},
+        }
+    ]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+    flexmock(fetcher).should_receive("_edit_jira_labels").and_raise(
+        requests.HTTPError("Jira write failed")
+    ).once()
+    mock_redis.should_receive("lpush").never()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_push_stale_reenqueue_dry_run_skips_flip_but_still_pushes(monkeypatch, mock_env_vars):
+    """DRY_RUN=true: skip both Jira label flips, but still reconstruct and
+    push the task, matching the existing dry-run contract for other trigger
+    paths (ymir_todo, ymir_retry_needed)."""
+    monkeypatch.setenv("DRY_RUN", "true")
+    fetcher = JiraIssueFetcher()
+
+    mock_redis = flexmock()
+
+    @asynccontextmanager
+    async def mock_context_manager(*_, **__):
+        yield mock_redis
+
+    flexmock(jira_issue_fetcher_impl).should_receive("redis_client").replace_with(mock_context_manager)
+
+    issues = [
+        {
+            "key": "STUCK-DRY",
+            "fields": {"labels": [JiraLabels.TRIAGE_IN_PROGRESS.value], "updated": _STALE_UPDATED},
+        }
+    ]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+    flexmock(fetcher).should_receive("_edit_jira_labels").never()
+
+    expected_task = Task.from_issue("STUCK-DRY", user_triggered=False)
+    mock_redis.should_receive("lpush").with_args(
+        RedisQueues.TRIAGE_QUEUE.value, expected_task.to_json()
+    ).and_return(create_async_mock_return_value(1)).once()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 1
 
 
 def test_label_added_by_rh_employee_walks_paginated_changelog(fetcher):

--- a/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -1188,6 +1188,34 @@ async def test_push_stale_triaged_backport_reenqueued(fetcher, mock_redis_contex
 
 
 @pytest.mark.asyncio
+async def test_push_stale_label_skipped_when_still_queued_in_redis(fetcher, mock_redis_context):
+    """Regression test: a stale-looking in-flight label whose task is still
+    genuinely queued in Redis (e.g. the SIGTERM handler already re-pushed
+    it, or a downstream queue is simply backed up) must NOT be flipped to
+    ymir_retry_needed and re-enqueued - doing so would bypass the
+    existing_keys dedup guard and start a second, concurrent agent run on
+    top of the one already queued."""
+    mock_redis, _ = mock_redis_context
+
+    issues = [
+        {
+            "key": "STUCK-QUEUED",
+            "fields": {"labels": [JiraLabels.TRIAGED_BACKPORT.value], "updated": _STALE_UPDATED},
+        }
+    ]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value({"STUCK-QUEUED"})
+    )
+    flexmock(fetcher).should_receive("_edit_jira_labels").never()
+    mock_redis.should_receive("lpush").never()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
 async def test_push_fresh_triage_in_progress_still_skipped(fetcher, mock_redis_context):
     """Non-stale ymir_triage_in_progress: unchanged pre-existing behavior —
     skip and don't touch Jira or Redis."""


### PR DESCRIPTION
Pods currently have no SIGTERM handler, so a redeployment silently drops whatever task was mid-processing. Separately, a hard crash (OOM, SIGKILL, node failure) leaves an issue's in-flight Jira label stuck forever, since the fetcher treats any Ymir label besides `ymir_retry_needed` as "already being handled." This PR adds two safety nets to cover both cases.
## Cooperative SIGTERM shutdown (`ymir/common/base_utils.py`)
- `run_task_loop` now accepts a `shutdown_event`. On shutdown it stops pulling new tasks, cancels whatever's still in flight, and `RPUSH`es the original `(source_queue, payload)` back to Redis so nothing is lost. No grace period — tasks run for minutes to hours, so waiting for them to finish naturally would rarely succeed and only delays recovery.
- The semaphore acquire is raced against shutdown too, not just the poll — otherwise, once every `max_concurrent` slot is held by a long-running task, the loop would never notice shutdown fired.
- A `BRPOP`/`poll_fn` call already in flight when shutdown fires is abandoned rather than cancelled (cancelling mid-read risks corrupting the connection for the next command drawn from the pool), but its eventual result is still awaited and re-pushed if it turns out to be a real task.
- Wired into `triage_agent`, `backport_agent`, `rebase_agent`, `rebuild_agent`, `mr_consolidation_agent`. `terminationGracePeriodSeconds` bumped 30s → 45s on the affected deployments to give this room.
## Stale in-flight-label safety net (`ymir/jira_issue_fetcher/jira_issue_fetcher.py`)
- Added `updated` to the existing bulk Jira search fields (free — no extra API calls).
- An in-flight label with no update in `STALE_LABEL_THRESHOLD_HOURS` (default 24h) and no other Ymir label alongside it is treated as abandoned, flipped to `ymir_retry_needed`, and re-triaged from scratch.
- Guarded against re-enqueuing a duplicate when the "abandoned-looking" label's task is actually still sitting in a live Redis queue.
## Known limitation
The 24h threshold can still false-positive for backport/rebase/rebuild tasks that are actively processing (not queued) for longer than that — e.g. `COPR_BUILD_TIMEOUT` (3h) × `max_build_attempts` (10 default) means a single legitimate task can run 30+ hours. Recommend raising the threshold (or adding a Redis heartbeat) as a follow-up before relying on this safety net for those stages.
