### PR TITLE
Detect and handle duplicate CVE trackers in triage eligibility check

### DIFF
--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -344,7 +344,28 @@ async def run_workflow(
                 f"pending_zstream_issues={state.cve_eligibility_result.pending_zstream_issues}"
             )
 
+            dup_key = state.cve_eligibility_result.duplicate_of
+
             if eligibility == TriageEligibility.IMMEDIATELY:
+                if dup_key and not dry_run:
+                    logger.info(
+                        f"Issue {state.jira_issue} has a closed/rejected duplicate "
+                        f"{dup_key} — posting informational comment and proceeding"
+                    )
+                    try:
+                        await tasks.comment_in_jira(
+                            jira_issue=state.jira_issue,
+                            agent_type="Triage",
+                            comment_text=(
+                                f"An older tracker {dup_key} exists for the same CVE, "
+                                f"component, and fix version, but it was closed/rejected. "
+                                f"Proceeding with triage for this tracker."
+                            ),
+                            available_tools=gateway_tools,
+                            user_triggered=user_triggered,
+                        )
+                    except Exception as e:
+                        logger.warning(f"Failed to post duplicate info comment: {e}")
                 return "run_triage_analysis"
 
             if force_cve_triage and not state.cve_eligibility_result.error:
@@ -385,6 +406,18 @@ async def run_workflow(
                     resolution=Resolution.ERROR,
                     data=ErrorData(
                         details=f"CVE eligibility check error: {state.cve_eligibility_result.error}",
+                        jira_issue=state.jira_issue,
+                    ),
+                )
+            elif dup_key:
+                state.triage_result = OutputSchema(
+                    resolution=Resolution.OPEN_ENDED_ANALYSIS,
+                    data=OpenEndedAnalysisData(
+                        summary=(
+                            f"Duplicate tracker detected. {state.jira_issue} appears to be "
+                            f"a duplicate of {dup_key} (same CVE, component, and fix version)."
+                        ),
+                        recommendation=(f"Consider closing this issue as a duplicate of {dup_key}."),
                         jira_issue=state.jira_issue,
                     ),
                 )

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -44,6 +44,10 @@ class CVEEligibilityResult(BaseModel):
         default=None,
         description="Jira issue keys of unshipped Z-stream clones; at least one must ship before triage",
     )
+    duplicate_of: str | None = Field(
+        default=None,
+        description="Jira key of an older tracker for the same CVE, component, and fix version",
+    )
 
     @property
     def is_eligible_for_triage(self) -> bool:

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -461,6 +461,91 @@ async def _check_zstream_clones_shipped(
     return (True, [])
 
 
+_REJECTED_RESOLUTIONS = frozenset({"NOTABUG", "WONTFIX", "WON'T DO", "DUPLICATE", "CANTFIX", "DROPPED"})
+
+
+class _DuplicateTrackerBlocked(Exception):
+    """Raised when a blocking duplicate tracker is found."""
+
+    def __init__(self, duplicate_of: str, reason: str) -> None:
+        super().__init__(reason)
+        self.duplicate_of = duplicate_of
+        self.reason = reason
+
+
+def _issue_number(key: str) -> int:
+    """Extract the numeric suffix from a Jira key like RHEL-12345."""
+    return int(key.rsplit("-", 1)[1])
+
+
+async def _check_duplicate_tracker(
+    cve_id: str, component: str, fix_version: str, issue_key: str
+) -> tuple[str | None, bool]:
+    """Check for duplicate CVE trackers (same CVE + component + fix version).
+
+    Returns (older_tracker_key, should_block):
+      - (None, False): no duplicate found
+      - ("RHEL-123", True): active older tracker exists, should block triage
+      - ("RHEL-123", False): older tracker exists but closed/rejected, flag only
+    """
+    project = issue_key.rsplit("-", 1)[0]
+    escaped_cve_id = cve_id.replace('"', '\\"')
+    escaped_component = component.replace('"', '\\"')
+    escaped_fix_version = fix_version.replace('"', '\\"')
+    jql = (
+        f'project = "{project}"'
+        f' AND summary ~ "{escaped_cve_id}" AND component = "{escaped_component}"'
+        f' AND fixVersion = "{escaped_fix_version}"'
+        f' AND labels = "SecurityTracking" AND key != "{issue_key}"'
+    )
+    logger.info(f"Checking for duplicate trackers with JQL: {jql}")
+
+    tool = SearchJiraIssuesTool()
+    output = await tool.run(input={"jql": jql, "fields": ["status", "resolution"], "max_results": 50})
+    issues = output.result
+
+    if not issues:
+        logger.info(f"No duplicate trackers found for {cve_id} in {component}/{fix_version}")
+        return (None, False)
+
+    current_num = _issue_number(issue_key)
+    active_older: list[str] = []
+    rejected_older: list[str] = []
+
+    for issue in issues:
+        key = issue.get("key", "")
+        try:
+            num = _issue_number(key)
+        except (ValueError, IndexError):
+            continue
+        if not key.startswith(f"{project}-") or num >= current_num:
+            continue
+
+        resolution = issue.get("fields", {}).get("resolution")
+        resolution_name = resolution.get("name", "") if isinstance(resolution, dict) else ""
+
+        if resolution_name.upper() in _REJECTED_RESOLUTIONS:
+            logger.info(f"  {key}: resolution={resolution_name} — rejected older tracker")
+            rejected_older.append(key)
+        else:
+            status_name = (issue.get("fields", {}).get("status") or {}).get("name", "")
+            logger.info(f"  {key}: status={status_name}, resolution={resolution_name} — active older tracker")
+            active_older.append(key)
+
+    if active_older:
+        oldest = min(active_older, key=_issue_number)
+        logger.info(f"Active duplicate tracker found: {oldest} (blocking {issue_key})")
+        return (oldest, True)
+
+    if rejected_older:
+        oldest = min(rejected_older, key=_issue_number)
+        logger.info(f"Rejected duplicate tracker found: {oldest} (flagging {issue_key}, not blocking)")
+        return (oldest, False)
+
+    logger.info(f"No older trackers found for {cve_id} in {component}/{fix_version}")
+    return (None, False)
+
+
 class CheckCveTriageEligibilityToolInput(BaseModel):
     issue_key: str = Field(description="Jira issue key (e.g. RHEL-12345)")
 
@@ -540,8 +625,26 @@ class CheckCveTriageEligibilityTool(
         rhel_config = await load_rhel_config()
         target_version = normalize_fix_version(target_version, rhel_config)
 
+        # --- Duplicate tracker check (runs before Y/Z-stream branching) ---
+        try:
+            duplicate_of = await self._check_for_duplicate(issue_key, fields, target_version)
+        except _DuplicateTrackerBlocked as dup:
+            return JSONToolOutput(
+                CVEEligibilityResult(
+                    is_cve=True,
+                    eligibility=TriageEligibility.NEVER,
+                    reason=dup.reason,
+                    duplicate_of=dup.duplicate_of,
+                ).model_dump()
+            )
+
         if re.match(r"^rhel-\d+\.\d+$", target_version.lower()):
-            return await self._check_ystream_eligibility(issue_key, fields, target_version)
+            return await self._check_ystream_eligibility(
+                issue_key,
+                fields,
+                target_version,
+                duplicate_of=duplicate_of,
+            )
 
         embargo = fields.get(EMBARGO_CUSTOM_FIELD, {}).get("value", "")
         if embargo == "True":
@@ -575,6 +678,7 @@ class CheckCveTriageEligibilityTool(
                 eligibility=TriageEligibility.IMMEDIATELY,
                 reason=reason,
                 needs_internal_fix=needs_internal_fix,
+                duplicate_of=duplicate_of,
             ).model_dump()
         )
 
@@ -646,11 +750,58 @@ class CheckCveTriageEligibilityTool(
             ).model_dump()
         )
 
+    async def _check_for_duplicate(
+        self,
+        issue_key: str,
+        fields: dict[str, Any],
+        target_version: str,
+    ) -> str | None:
+        """Run the duplicate tracker check and return early for blocking duplicates.
+
+        Returns the ``duplicate_of`` key (for non-blocking flagging) or *None*.
+        For blocking duplicates, returns the key directly — the caller must
+        check and short-circuit.  We intentionally return just the key here
+        so the caller can decide whether to block (NEVER) based on context;
+        the blocking decision is made by ``_check_duplicate_tracker`` already.
+        """
+        summary = fields.get("summary", "")
+        cve_id = extract_cve_id(summary)
+        components = fields.get("components", [])
+        component = components[0].get("name", "") if components else ""
+
+        if not cve_id or not component:
+            return None
+
+        try:
+            dup_key, should_block = await _check_duplicate_tracker(
+                cve_id,
+                component,
+                target_version,
+                issue_key,
+            )
+        except Exception as e:
+            logger.warning(f"Duplicate tracker check failed for {issue_key}: {e}")
+            return None
+
+        if dup_key and should_block:
+            raise _DuplicateTrackerBlocked(
+                duplicate_of=dup_key,
+                reason=(
+                    f"Duplicate tracker: {issue_key} duplicates older active tracker "
+                    f"{dup_key} (same CVE {cve_id}, component {component}, "
+                    f"fix version {target_version})"
+                ),
+            )
+
+        return dup_key
+
     async def _check_ystream_eligibility(
         self,
         issue_key: str,
         fields: dict[str, Any],
         target_version: str,
+        *,
+        duplicate_of: str | None = None,
     ) -> JSONToolOutput[dict[str, Any]]:
         logger.info(f"Y-stream CVE detected ({target_version})")
 
@@ -682,6 +833,7 @@ class CheckCveTriageEligibilityTool(
                 eligibility=TriageEligibility.IMMEDIATELY,
                 reason="Y-stream CVE: at least one Z-stream clone shipped, eligible for triage",
                 needs_internal_fix=False,
+                duplicate_of=duplicate_of,
             ).model_dump()
         )
 

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -19,6 +19,7 @@ from ymir.tools.privileged.jira import (
     SetJiraFieldsTool,
     Severity,
     VerifyIssueAuthorTool,
+    _check_duplicate_tracker,
     _check_zstream_clones_shipped,
     extract_cve_id,
 )
@@ -818,6 +819,9 @@ async def test_eligibility_ystream_any_clone_shipped():
     flexmock(jira_tools).should_receive("load_rhel_config").and_return(
         _create_async_return(RHEL_CONFIG)
     ).once()
+    flexmock(jira_tools).should_receive("_check_duplicate_tracker").and_return(
+        _create_async_return((None, False))
+    ).once()
     flexmock(jira_tools).should_receive("_check_zstream_clones_shipped").with_args(
         "CVE-2025-12345", "curl", "RHEL-12345"
     ).and_return(_create_async_return((True, []))).once()
@@ -839,6 +843,9 @@ async def test_eligibility_ystream_clones_pending():
     flexmock(aiohttp.ClientSession).should_receive("get").replace_with(_mock_jira_get(issue))
     flexmock(jira_tools).should_receive("load_rhel_config").and_return(
         _create_async_return(RHEL_CONFIG)
+    ).once()
+    flexmock(jira_tools).should_receive("_check_duplicate_tracker").and_return(
+        _create_async_return((None, False))
     ).once()
     flexmock(jira_tools).should_receive("_check_zstream_clones_shipped").with_args(
         "CVE-2025-12345", "curl", "RHEL-12345"
@@ -862,6 +869,9 @@ async def test_eligibility_ystream_low_moderate_skipped(severity):
     flexmock(aiohttp.ClientSession).should_receive("get").replace_with(_mock_jira_get(issue))
     flexmock(jira_tools).should_receive("load_rhel_config").and_return(
         _create_async_return(RHEL_CONFIG)
+    ).once()
+    flexmock(jira_tools).should_receive("_check_duplicate_tracker").and_return(
+        _create_async_return((None, False))
     ).once()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
@@ -956,8 +966,327 @@ async def test_eligibility_maintenance_zstream_no_dependency_check():
     flexmock(jira_tools).should_receive("load_rhel_config").and_return(
         _create_async_return(RHEL_CONFIG)
     ).once()
+    flexmock(jira_tools).should_receive("_check_duplicate_tracker").and_return(
+        _create_async_return((None, False))
+    ).once()
     flexmock(jira_tools).should_receive("_check_zstream_clones_shipped").never()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
     assert result["eligibility"] == TriageEligibility.IMMEDIATELY
     assert result["needs_internal_fix"] is True
+
+
+# --- Duplicate tracker check tests ---
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_no_duplicates():
+    """No other trackers found — no duplicate."""
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=[]))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key is None
+    assert should_block is False
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_active_older_tracker():
+    """Older tracker is open — should block the newer one."""
+    search_result = [
+        {
+            "key": "RHEL-100",
+            "fields": {
+                "status": {"name": "New"},
+                "resolution": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key == "RHEL-100"
+    assert should_block is True
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_closed_rejected_older_tracker():
+    """Older tracker closed as WONTFIX — flag but don't block."""
+    search_result = [
+        {
+            "key": "RHEL-100",
+            "fields": {
+                "status": {"name": "Closed"},
+                "resolution": {"name": "WONTFIX"},
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key == "RHEL-100"
+    assert should_block is False
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_only_newer_trackers():
+    """Only newer trackers found — current issue is the original, no duplicate."""
+    search_result = [
+        {
+            "key": "RHEL-600",
+            "fields": {
+                "status": {"name": "New"},
+                "resolution": None,
+            },
+        },
+        {
+            "key": "RHEL-700",
+            "fields": {
+                "status": {"name": "In Progress"},
+                "resolution": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key is None
+    assert should_block is False
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_mixed_older_active_and_rejected():
+    """One older tracker rejected, another older tracker active — should block."""
+    search_result = [
+        {
+            "key": "RHEL-100",
+            "fields": {
+                "status": {"name": "Closed"},
+                "resolution": {"name": "NOTABUG"},
+            },
+        },
+        {
+            "key": "RHEL-200",
+            "fields": {
+                "status": {"name": "In Progress"},
+                "resolution": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key == "RHEL-200"
+    assert should_block is True
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_multiple_rejected_picks_oldest():
+    """Multiple rejected older trackers — returns the oldest one."""
+    search_result = [
+        {
+            "key": "RHEL-300",
+            "fields": {
+                "status": {"name": "Closed"},
+                "resolution": {"name": "DUPLICATE"},
+            },
+        },
+        {
+            "key": "RHEL-100",
+            "fields": {
+                "status": {"name": "Closed"},
+                "resolution": {"name": "WONTFIX"},
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key == "RHEL-100"
+    assert should_block is False
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_older_closed_done_errata_blocks():
+    """Older tracker closed as Done-Errata (shipped) is an active resolution — should block."""
+    search_result = [
+        {
+            "key": "RHEL-100",
+            "fields": {
+                "status": {"name": "Closed"},
+                "resolution": {"name": "Done-Errata"},
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key == "RHEL-100"
+    assert should_block is True
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_cross_project_ignored():
+    """Issues from a different project are not treated as duplicates."""
+    search_result = [
+        {
+            "key": "FOO-100",
+            "fields": {
+                "status": {"name": "New"},
+                "resolution": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key is None
+    assert should_block is False
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_done_wontfix_not_blocked():
+    """Older tracker with status Done and resolution WONTFIX is rejected, not active."""
+    search_result = [
+        {
+            "key": "RHEL-100",
+            "fields": {
+                "status": {"name": "Done"},
+                "resolution": {"name": "WONTFIX"},
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key == "RHEL-100"
+    assert should_block is False
+
+
+@pytest.mark.asyncio
+async def test_check_duplicate_wont_do_not_blocked():
+    """Older tracker with Jira Cloud 'Won't Do' resolution is rejected, not active."""
+    search_result = [
+        {
+            "key": "RHEL-100",
+            "fields": {
+                "status": {"name": "Done"},
+                "resolution": {"name": "Won't Do"},
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker("CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-500")
+    assert dup_key == "RHEL-100"
+    assert should_block is False
+
+
+# --- Eligibility tool: duplicate tracker integration tests ---
+
+
+@pytest.mark.asyncio
+async def test_eligibility_zstream_blocking_duplicate():
+    """Z-stream CVE with an active duplicate — eligibility is NEVER with duplicate_of set."""
+    issue = _make_jira_issue(
+        labels=["SecurityTracking"],
+        fix_versions=[{"name": "rhel-9.6.z"}],
+        summary="CVE-2025-12345 buffer overflow in curl [rhel-9.6.z]",
+        severity="moderate",
+        components=[{"name": "curl"}],
+    )
+    flexmock(aiohttp.ClientSession).should_receive("get").replace_with(_mock_jira_get(issue))
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(
+            {
+                "current_y_streams": {"9": "rhel-9.8"},
+                "current_z_streams": {"9": "rhel-9.6.z"},
+                "upcoming_z_streams": {},
+            }
+        )
+    ).once()
+    flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
+        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345"
+    ).and_return(_create_async_return(("RHEL-100", True))).once()
+
+    result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
+    assert result["eligibility"] == TriageEligibility.NEVER
+    assert result["duplicate_of"] == "RHEL-100"
+    assert "duplicate" in result["reason"].lower()
+
+
+@pytest.mark.asyncio
+async def test_eligibility_zstream_nonblocking_duplicate():
+    """Z-stream CVE with a closed/rejected duplicate — eligible with duplicate_of set."""
+    issue = _make_jira_issue(
+        labels=["SecurityTracking"],
+        fix_versions=[{"name": "rhel-9.6.z"}],
+        summary="CVE-2025-12345 buffer overflow in curl [rhel-9.6.z]",
+        severity="moderate",
+        components=[{"name": "curl"}],
+    )
+    flexmock(aiohttp.ClientSession).should_receive("get").replace_with(_mock_jira_get(issue))
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(
+            {
+                "current_y_streams": {"9": "rhel-9.8"},
+                "current_z_streams": {"9": "rhel-9.6.z"},
+                "upcoming_z_streams": {},
+            }
+        )
+    ).once()
+    flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
+        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345"
+    ).and_return(_create_async_return(("RHEL-100", False))).once()
+
+    result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
+    assert result["eligibility"] == TriageEligibility.IMMEDIATELY
+    assert result["duplicate_of"] == "RHEL-100"
+
+
+@pytest.mark.asyncio
+async def test_eligibility_no_duplicate():
+    """Z-stream CVE with no duplicates — eligible without duplicate_of."""
+    issue = _make_jira_issue(
+        labels=["SecurityTracking"],
+        fix_versions=[{"name": "rhel-9.6.z"}],
+        summary="CVE-2025-12345 buffer overflow in curl [rhel-9.6.z]",
+        severity="moderate",
+        components=[{"name": "curl"}],
+    )
+    flexmock(aiohttp.ClientSession).should_receive("get").replace_with(_mock_jira_get(issue))
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(
+            {
+                "current_y_streams": {"9": "rhel-9.8"},
+                "current_z_streams": {"9": "rhel-9.6.z"},
+                "upcoming_z_streams": {},
+            }
+        )
+    ).once()
+    flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
+        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345"
+    ).and_return(_create_async_return((None, False))).once()
+
+    result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
+    assert result["eligibility"] == TriageEligibility.IMMEDIATELY
+    assert result["duplicate_of"] is None


### PR DESCRIPTION
ProdSec sometimes creates duplicate SecurityTracking trackers for the same CVE in the same release and component. This adds a deterministic duplicate check inside `CheckCveTriageEligibilityTool`, before any LLM work runs.
The check queries Jira for other SecurityTracking issues matching the same CVE ID + component + fix version (scoped to the same project). It compares issue numbers to determine which tracker is older:
- **Active older tracker exists** — block triage for the newer one (`eligibility=NEVER`), post a Jira comment suggesting closure as a duplicate
- **Older tracker exists but was closed/rejected** (WONTFIX, NOTABUG, etc.) — post an informational comment noting the situation, proceed with triage normally
- **No older tracker** — no effect
No prompt changes, no new resolution types, no downstream agent changes. The check runs once before Y-stream/Z-stream branching so both paths are covered.
