### PR TITLE
Exclude litellm 1.92.0 (broken fastapi import in MCP handler)

### DIFF
--- a/Containerfile.c10s
+++ b/Containerfile.c10s
@@ -71,7 +71,7 @@ COPY beeai-reasoning.patch /tmp
 COPY openinference-reasoning.patch /tmp
 
 RUN pip3 install --no-cache-dir \
-      "litellm!=1.82.7,!=1.82.8" \
+      "litellm!=1.82.7,!=1.82.8,!=1.92.0" \
       beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
       google-cloud-aiplatform \
       openinference-instrumentation-beeai \

--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -74,7 +74,7 @@ COPY openinference-reasoning.patch /tmp
 RUN python3.11 -m venv --system-site-packages /opt/beeai-venv \
     && /opt/beeai-venv/bin/pip install --upgrade pip \
     && /opt/beeai-venv/bin/pip install --no-cache-dir \
-         "litellm!=1.82.7,!=1.82.8" \
+         "litellm!=1.82.7,!=1.82.8,!=1.92.0" \
          beeai-framework[vertexai,mcp,duckduckgo]==0.1.80 \
          google-cloud-aiplatform \
          openinference-instrumentation-beeai \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Dependencies specific to the root ymir package
 ymir-common
 ymir-tools
-litellm!=1.82.7,!=1.82.8
+litellm!=1.82.7,!=1.82.8,!=1.92.0
 aiohttp>=3.12.15
 arize-phoenix-otel>=0.13.0
 beautifulsoup4>=4.13.4


### PR DESCRIPTION
litellm 1.92.0 is affected by this issue:
https://github.com/BerriAI/litellm/issues/32993

