### PR TITLE
Improve the E2E triage tests 

### DIFF
--- a/ymir/agents/tests/e2e/conftest.py
+++ b/ymir/agents/tests/e2e/conftest.py
@@ -76,21 +76,26 @@ def pytest_runtest_makereport(item, call):
         f.write(f'  result: "{result}"\n')
 
         f.write("  note:\n")
-        for note, value in (
-            ("Agent", test_case.metrics.get("agent_name", None)),
-            ("Tool Calls", test_case.metrics.get("tool_calls", None)),
-            ("Prompt Tokens", test_case.metrics.get("prompt_tokens", None)),
-            ("Completion Tokens", test_case.metrics.get("completion_tokens", None)),
-        ):
-            if value is None:
-                continue
-            f.write(f'    - "{note}: {value}"\n')
+        if test_case.metrics is not None:
+            for note, value in (
+                ("Agent", test_case.metrics.get("agent_name", None)),
+                ("Tool Calls", test_case.metrics.get("tool_calls", None)),
+                ("Prompt Tokens", test_case.metrics.get("prompt_tokens", None)),
+                ("Completion Tokens", test_case.metrics.get("completion_tokens", None)),
+            ):
+                if value is None:
+                    continue
+                f.write(f'    - "{note}: {value}"\n')
+
+        # Add additional note, if the test was skipped
+        if test_case.skip_reason is not None:
+            f.write(f'    - "Skipped because {test_case.skip_reason}"\n')
 
         f.write("  log:\n")
         for log in (f"{test_case.input}.html", f"{test_case.input}.json"):
             f.write(f"    - {log}\n")
 
-        minutes, seconds = divmod(int(test_case.metrics.get("duration", 0)), 60)
+        minutes, seconds = divmod(int((test_case.metrics or {}).get("duration", 0)), 60)
         hours, minutes = divmod(minutes, 60)
         f.write(f"  duration: {hours:02d}:{minutes:02d}:{seconds:02d}\n")
 

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -32,8 +32,12 @@ class TriageAgentTestCase:
     finished_state: TriageState | None = None
     error: BaseException | None = None
     zstream_override: dict[str, str] | None = None
+    skip_reason: str | None = None
 
     async def run(self) -> None:
+        if self.skip_reason is not None:
+            return
+
         if self.zstream_override:
             apply_zstream_override(self.zstream_override)
 
@@ -56,24 +60,7 @@ class TriageAgentTestCase:
         return hash(self.input)
 
 
-"""
-# These cases are not ready yet to be enabled. They are kept here for reference.
-    TriageAgentTestCase(
-        input="RHEL-61943",
-        expected_output=TriageOutputSchema(
-            resolution=Resolution.BACKPORT,
-            data=BackportData(
-                package="dnsmasq",
-                patch_urls=[
-                    "http://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=patch;h=eb1fe15ca80b6bc43cd6bfdf309ec6c590aff811"
-                ],
-                justification="not-implemented",
-                jira_issue="RHEL-61943",
-                cve_id=None,
-                fix_version="rhel-8.10.z",
-            ),
-        ),
-    ),
+test_cases = [
     TriageAgentTestCase(
         input="RHEL-29712",
         expected_output=TriageOutputSchema(
@@ -89,10 +76,8 @@ class TriageAgentTestCase:
                 fix_version="rhel-8.10.z",
             ),
         ),
+        skip_reason="it requires agent to debug / reproduce the problem",
     ),
-"""
-
-test_cases = [
     TriageAgentTestCase(
         input="RHEL-15216",
         expected_output=TriageOutputSchema(
@@ -107,6 +92,27 @@ test_cases = [
                 cve_id=None,
                 fix_version="rhel-8.10.z",
             ),
+        ),
+        skip_reason="dnsmasq (upstream) requires auth to avoid AI scraping…",
+    ),
+    TriageAgentTestCase(
+        input="RHEL-61943",
+        expected_output=TriageOutputSchema(
+            resolution=Resolution.BACKPORT,
+            data=BackportData(
+                package="dnsmasq",
+                patch_urls=[
+                    "https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=patch;h=eb1fe15ca80b6bc43cd6bfdf309ec6c590aff811"
+                ],
+                justification="not-implemented",
+                jira_issue="RHEL-61943",
+                cve_id=None,
+                fix_version="rhel-8.10.z",
+            ),
+        ),
+        skip_reason=(
+            "dnsmasq (upstream) requires auth to avoid AI scraping"
+            " and also requires agent to debug / reproduce the problem"
         ),
     ),
     TriageAgentTestCase(
@@ -345,6 +351,9 @@ def run_test_cases_concurrently(request, mock_centos_stream_repos):
     (pytest.param(test_case, id=test_case.input) for test_case in test_cases),
 )
 def test_triage_agent(test_case: TriageAgentTestCase, observability_fixture):
+    if test_case.skip_reason is not None:
+        pytest.skip(test_case.skip_reason)
+
     if test_case.error is not None:
         raise test_case.error
 

--- a/ymir/agents/tests/e2e/test_triage.py
+++ b/ymir/agents/tests/e2e/test_triage.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -23,14 +24,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_FIXTURES_DIR = Path(__file__).parent / "mock_repos" / "triage"
 
 
+@dataclass
 class TriageAgentTestCase:
-    def __init__(self, input: str, expected_output: TriageOutputSchema):
-        self.input: str = input
-        self.expected_output: TriageOutputSchema = expected_output
-        self.metrics: dict = None
-        self.finished_state: TriageState | None = None
-        self.error: BaseException | None = None
-        self.zstream_override: dict[str, str] | None = None
+    input: str
+    expected_output: TriageOutputSchema
+    metrics: dict | None = None
+    finished_state: TriageState | None = None
+    error: BaseException | None = None
+    zstream_override: dict[str, str] | None = None
 
     async def run(self) -> None:
         if self.zstream_override:
@@ -50,6 +51,9 @@ class TriageAgentTestCase:
             self.error = e
         finally:
             self.metrics = metrics_middleware.get_metrics()
+
+    def __hash__(self) -> int:
+        return hash(self.input)
 
 
 """


### PR DESCRIPTION
- Convert the triage test case class to a dataclass — has always been…
- Add a mechanism for skipping the tests

TODO:
- [ ] Judging from what I see in the tests, the triaging agent is able to find the patches on someone’s dnsmasq mirror on GitHub… do you think it would make sense to check just for the commit SHA (that aligns with the expected one)?