### PR TITLE
Expand find_base_commit tag patterns and soften tag-miss error

### DIFF
--- a/ymir/tools/unprivileged/tests/unit/test_upstream_tools.py
+++ b/ymir/tools/unprivileged/tests/unit/test_upstream_tools.py
@@ -449,6 +449,8 @@ class TestFindBaseCommitTool:
         repo = tmp_path / dir_name
         repo.mkdir()
         subprocess.run(["git", "init"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
         (repo / "file.c").write_text("int main() {}\n")
         subprocess.run(["git", "add", "."], cwd=repo, check=True)
         subprocess.run(["git", "commit", "-m", "Initial"], cwd=repo, check=True)
@@ -527,7 +529,8 @@ class TestFindBaseCommitTool:
         assert "base_tag_commit" not in tool.options
 
     @pytest.mark.asyncio
-    async def test_finds_curl_style_tag(self, tool, tmp_path):
+    async def test_finds_curl_style_tag(self, tmp_path):
+        tool = FindBaseCommitTool(options={"working_directory": None})
         repo = self._make_repo(tmp_path, "curl-upstream", ["curl-7_76_1"])
         result = await tool.run(
             input=FindBaseCommitToolInput(repo_path=str(repo), version="7.76.1")
@@ -602,6 +605,18 @@ class TestFindBaseCommitTool:
         ).middleware(GlobalTrajectoryMiddleware(pretty=True))
 
         assert "v7.76.1" in result.result
+
+    @pytest.mark.asyncio
+    async def test_finds_versioned_package_tag(self, tmp_path):
+        """RHEL versioned packages like nodejs22 strip trailing digits to match tags like nodejs-20_11_0."""
+        tool = FindBaseCommitTool(options={"working_directory": None})
+        repo = self._make_repo(tmp_path, "nodejs22-upstream", ["nodejs-20_11_0"])
+        result = await tool.run(
+            input=FindBaseCommitToolInput(repo_path=str(repo), version="20.11.0")
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "nodejs-20_11_0" in result.result
+        assert "base_tag_commit" in tool.options
 
     @pytest.mark.asyncio
     async def test_no_pkg_name_without_upstream_suffix(self, tmp_path):

--- a/ymir/tools/unprivileged/tests/unit/test_upstream_tools.py
+++ b/ymir/tools/unprivileged/tests/unit/test_upstream_tools.py
@@ -443,6 +443,19 @@ class TestFindBaseCommitTool:
         subprocess.run(["git", "tag", "release-2.0.0"], cwd=repo, check=True)
         return repo
 
+    @staticmethod
+    def _make_repo(tmp_path, dir_name, tags):
+        """Create a git repo at tmp_path/dir_name with the given tags."""
+        repo = tmp_path / dir_name
+        repo.mkdir()
+        subprocess.run(["git", "init"], cwd=repo, check=True)
+        (repo / "file.c").write_text("int main() {}\n")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", "Initial"], cwd=repo, check=True)
+        for tag in tags:
+            subprocess.run(["git", "tag", tag], cwd=repo, check=True)
+        return repo
+
     @pytest.fixture
     def tool(self):
         return FindBaseCommitTool(options={"working_directory": None})
@@ -500,16 +513,107 @@ class TestFindBaseCommitTool:
         assert tool.options["base_tag_commit"] == head
 
     @pytest.mark.asyncio
-    async def test_no_matching_tag_raises_with_available_tags(self, tool, upstream_repo):
-        with pytest.raises(ToolError, match=r"Could not find tag matching version 99\.99\.99") as exc_info:
-            await tool.run(
-                input=FindBaseCommitToolInput(
-                    repo_path=str(upstream_repo),
-                    version="99.99.99",
-                )
-            ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+    async def test_no_matching_tag_returns_soft_failure(self, tool, upstream_repo):
+        result = await tool.run(
+            input=FindBaseCommitToolInput(
+                repo_path=str(upstream_repo),
+                version="99.99.99",
+            )
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
 
-        assert "v1.2.3" in exc_info.value.message
+        assert "Could not find tag matching version 99.99.99" in result.result
+        assert "v1.2.3" in result.result
+        assert "Retry with" in result.result
+        assert "base_tag_commit" not in tool.options
+
+    @pytest.mark.asyncio
+    async def test_finds_curl_style_tag(self, tool, tmp_path):
+        repo = self._make_repo(tmp_path, "curl-upstream", ["curl-7_76_1"])
+        result = await tool.run(
+            input=FindBaseCommitToolInput(repo_path=str(repo), version="7.76.1")
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "curl-7_76_1" in result.result
+        assert "base_tag_commit" in tool.options
+
+    @pytest.mark.asyncio
+    async def test_finds_openssh_style_tag(self, tmp_path):
+        tool = FindBaseCommitTool(options={"working_directory": None})
+        repo = self._make_repo(tmp_path, "openssh-upstream", ["V_9_9_P1"])
+        result = await tool.run(
+            input=FindBaseCommitToolInput(repo_path=str(repo), version="9.9p1")
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "V_9_9_P1" in result.result
+        assert "base_tag_commit" in tool.options
+
+    @pytest.mark.asyncio
+    async def test_finds_postgresql_style_tag(self, tmp_path):
+        tool = FindBaseCommitTool(options={"working_directory": None})
+        repo = self._make_repo(tmp_path, "postgresql-upstream", ["REL_16_11"])
+        result = await tool.run(
+            input=FindBaseCommitToolInput(repo_path=str(repo), version="16.11")
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "REL_16_11" in result.result
+        assert "base_tag_commit" in tool.options
+
+    @pytest.mark.asyncio
+    async def test_finds_gnutls_style_tag(self, tmp_path):
+        tool = FindBaseCommitTool(options={"working_directory": None})
+        repo = self._make_repo(tmp_path, "gnutls-upstream", ["gnutls_3_6_2"])
+        result = await tool.run(
+            input=FindBaseCommitToolInput(repo_path=str(repo), version="3.6.2")
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "gnutls_3_6_2" in result.result
+        assert "base_tag_commit" in tool.options
+
+    @pytest.mark.asyncio
+    async def test_finds_pkgname_dotted_tag(self, tmp_path):
+        tool = FindBaseCommitTool(options={"working_directory": None})
+        repo = self._make_repo(tmp_path, "mylib-upstream", ["mylib-2.0.0"])
+        result = await tool.run(
+            input=FindBaseCommitToolInput(repo_path=str(repo), version="2.0.0")
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "mylib-2.0.0" in result.result
+        assert "base_tag_commit" in tool.options
+
+    @pytest.mark.asyncio
+    async def test_smart_tag_listing_shows_relevant_tags(self, tmp_path):
+        tool = FindBaseCommitTool(options={"working_directory": None})
+        tags = ["curl-7_76_1", "curl-8_0_0", "curl-8_1_0", "unrelated-tag"]
+        repo = self._make_repo(tmp_path, "upstream", tags)
+        result = await tool.run(
+            input=FindBaseCommitToolInput(repo_path=str(repo), version="7.76.1")
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "Tags matching version components" in result.result
+        assert "curl-7_76_1" in result.result
+
+    @pytest.mark.asyncio
+    async def test_v_prefixed_tag_wins_over_pkgname_pattern(self, tmp_path):
+        """Generic patterns are tried before package-name patterns."""
+        tool = FindBaseCommitTool(options={"working_directory": None})
+        repo = self._make_repo(tmp_path, "curl-upstream", ["v7.76.1", "curl-7_76_1"])
+        result = await tool.run(
+            input=FindBaseCommitToolInput(repo_path=str(repo), version="7.76.1")
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "v7.76.1" in result.result
+
+    @pytest.mark.asyncio
+    async def test_no_pkg_name_without_upstream_suffix(self, tmp_path):
+        """Repos without -upstream suffix skip package-name patterns."""
+        tool = FindBaseCommitTool(options={"working_directory": None})
+        repo = self._make_repo(tmp_path, "somerepo", ["somerepo-1_0_0"])
+        result = await tool.run(
+            input=FindBaseCommitToolInput(repo_path=str(repo), version="1.0.0")
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "Could not find tag" in result.result
+        assert "somerepo-1_0_0" in result.result
 
     @pytest.mark.asyncio
     async def test_not_a_git_repo(self, tool, tmp_path):

--- a/ymir/tools/unprivileged/upstream_tools.py
+++ b/ymir/tools/unprivileged/upstream_tools.py
@@ -411,6 +411,10 @@ class FindBaseCommitTool(Tool[FindBaseCommitToolInput, ToolRunOptions, StringToo
             dir_name = tool_input.repo_path.name
             if dir_name.endswith("-upstream"):
                 pkg_name = dir_name.removesuffix("-upstream")
+            # RHEL versioned packages (nodejs22, python39) → strip trailing digits
+            pkg_base = re.sub(r"[-_]?\d+$", "", pkg_name) if pkg_name else None
+            if pkg_base == pkg_name:
+                pkg_base = None
 
             if tool_input.tag:
                 cmd = ["git", "rev-parse", "--verify", f"refs/tags/{tool_input.tag}"]
@@ -449,6 +453,18 @@ class FindBaseCommitTool(Tool[FindBaseCommitToolInput, ToolRunOptions, StringToo
                         ]
                     )
 
+                if pkg_base:
+                    tag_patterns.extend(
+                        [
+                            f"{pkg_base}-{ver_under}",
+                            f"{pkg_base}-{ver}",
+                            f"{pkg_base}_{ver_under}",
+                            f"{pkg_base.upper()}-{ver_under}",
+                            f"{pkg_base.upper()}_{ver_upper}",
+                        ]
+                    )
+
+                tag_patterns = list(dict.fromkeys(tag_patterns))
                 found_tag = None
                 for tag in tag_patterns:
                     cmd = ["git", "rev-parse", "--verify", f"refs/tags/{tag}"]
@@ -465,8 +481,9 @@ class FindBaseCommitTool(Tool[FindBaseCommitToolInput, ToolRunOptions, StringToo
                     )
                     all_tags = stdout.strip().split("\n") if stdout.strip() else []
 
-                    relevant = [t for t in all_tags if ver_under in t or ver in t]
-                    other = [t for t in all_tags if t not in set(relevant)]
+                    relevant = [t for t in all_tags if ver_under in t or ver in t or ver_upper in t]
+                    relevant_set = set(relevant)
+                    other = [t for t in all_tags if t not in relevant_set]
 
                     if relevant:
                         tag_info = f"Tags matching version components: {', '.join(relevant[:15])}"

--- a/ymir/tools/unprivileged/upstream_tools.py
+++ b/ymir/tools/unprivileged/upstream_tools.py
@@ -361,10 +361,13 @@ class FindBaseCommitTool(Tool[FindBaseCommitToolInput, ToolRunOptions, StringToo
     Accepts three modes (highest priority first):
     - 'commit': checkout an exact commit hash (for repos without tags)
     - 'tag': checkout an exact tag name (when you know the right tag)
-    - pattern search: tries v{version}, {version}, release-{version}, etc.
+    - pattern search: tries common tag conventions including v{version},
+      {version}, release-{version}, V_{version}, REL_{version},
+      {pkgname}-{version} (with dots and underscores), and uppercase variants.
+      The package name is inferred from the repo path (-upstream suffix).
 
-    If pattern search fails, returns available tags so you can retry with
-    'tag' or 'commit'. Always stores the base commit for History/Trace tools.
+    If pattern search fails, returns a message (not an error) listing
+    version-relevant tags so you can retry with 'tag' or 'commit'.
     """
     input_schema = FindBaseCommitToolInput
 
@@ -404,6 +407,11 @@ class FindBaseCommitTool(Tool[FindBaseCommitToolInput, ToolRunOptions, StringToo
                 self.options["base_tag_commit"] = tool_input.commit
                 return StringToolOutput(result=f"Checked out commit {tool_input.commit} as base")
 
+            pkg_name = None
+            dir_name = tool_input.repo_path.name
+            if dir_name.endswith("-upstream"):
+                pkg_name = dir_name.removesuffix("-upstream")
+
             if tool_input.tag:
                 cmd = ["git", "rev-parse", "--verify", f"refs/tags/{tool_input.tag}"]
                 exit_code, _, stderr = await run_subprocess(cmd, cwd=tool_input.repo_path)
@@ -411,16 +419,35 @@ class FindBaseCommitTool(Tool[FindBaseCommitToolInput, ToolRunOptions, StringToo
                     raise ToolError(f"Tag '{tool_input.tag}' not found in repository: {stderr}")
                 found_tag = tool_input.tag
             else:
-                # Common tag patterns to try
+                ver = tool_input.version
+                ver_under = ver.replace(".", "_")
+                # Split digit-letter boundaries then uppercase (e.g. 9.9p1 -> 9_9_P1)
+                ver_upper = re.sub(r"(\d)([a-zA-Z])", r"\1_\2", ver_under).upper()
+
                 tag_patterns = [
-                    f"v{tool_input.version}",
-                    f"{tool_input.version}",
-                    f"release-{tool_input.version}",
-                    f"{tool_input.version}-release",
-                    f"rel-{tool_input.version}",
-                    f"{tool_input.version}.0",
-                    f"v{tool_input.version}.0",
+                    f"v{ver}",
+                    f"{ver}",
+                    f"release-{ver}",
+                    f"{ver}-release",
+                    f"rel-{ver}",
+                    f"{ver}.0",
+                    f"v{ver}.0",
+                    f"v{ver_under}",
+                    f"V_{ver_upper}",
+                    f"REL_{ver_under}",
+                    f"REL{ver_under}",
                 ]
+
+                if pkg_name:
+                    tag_patterns.extend(
+                        [
+                            f"{pkg_name}-{ver_under}",
+                            f"{pkg_name}-{ver}",
+                            f"{pkg_name}_{ver_under}",
+                            f"{pkg_name.upper()}-{ver_under}",
+                            f"{pkg_name.upper()}_{ver_upper}",
+                        ]
+                    )
 
                 found_tag = None
                 for tag in tag_patterns:
@@ -436,21 +463,32 @@ class FindBaseCommitTool(Tool[FindBaseCommitToolInput, ToolRunOptions, StringToo
                         cmd,
                         cwd=tool_input.repo_path,
                     )
-                    available_tags = stdout.strip().split("\n") if stdout.strip() else []
-                    tag_info = (
-                        f"Available tags: {', '.join(available_tags[:10])}"
-                        if available_tags
-                        else "No tags found in repository"
-                    )
-                    if len(available_tags) > 10:
-                        tag_info += f" (and {len(available_tags) - 10} more)"
+                    all_tags = stdout.strip().split("\n") if stdout.strip() else []
 
-                    raise ToolError(
-                        f"Could not find tag matching version {tool_input.version}. "
-                        f"Tried patterns: {', '.join(tag_patterns)}. "
-                        f"{tag_info}. "
-                        "Retry with 'tag' set to the exact tag name, "
-                        "or 'commit' set to the release commit hash."
+                    relevant = [t for t in all_tags if ver_under in t or ver in t]
+                    other = [t for t in all_tags if t not in set(relevant)]
+
+                    if relevant:
+                        tag_info = f"Tags matching version components: {', '.join(relevant[:15])}"
+                        if other:
+                            tag_info += f". Other tags (sample): {', '.join(other[:5])}"
+                            if len(other) > 5:
+                                tag_info += f" (and {len(other) - 5} more)"
+                    elif all_tags:
+                        tag_info = f"Available tags: {', '.join(all_tags[:15])}"
+                        if len(all_tags) > 15:
+                            tag_info += f" (and {len(all_tags) - 15} more)"
+                    else:
+                        tag_info = "No tags found in repository"
+
+                    return StringToolOutput(
+                        result=(
+                            f"Could not find tag matching version {ver}. "
+                            f"Tried patterns: {', '.join(tag_patterns)}. "
+                            f"{tag_info}. "
+                            "Retry with 'tag' set to the exact tag name, "
+                            "or 'commit' set to the release commit hash."
+                        )
                     )
 
             # Checkout the found tag


### PR DESCRIPTION

`find_base_commit` tried 7 tag patterns (`vX.Y.Z`, `X.Y.Z`, `release-X.Y.Z`, etc.) which missed many upstream conventions. From Jul 02-12 run data, 39 issues (110 error occurrences) hit tag-not-found — the single largest category of backport failure across curl, OpenSSH, PostgreSQL, gnutls, nginx, c-ares, pip, and others.
- Expand tag patterns from 7 to 21: infer package name from repo path, add underscore/uppercase variants (`curl-7_76_1`, `V_9_9_P1`, `REL_16_11`, `gnutls_3_6_2`), and strip trailing digits from RHEL versioned packages (`nodejs22` → `nodejs`)
- Soften tag-miss from `ToolError` to informational `StringToolOutput` — same retry guidance for the LLM, no error trace pollution
- Filter available tags by version components so the LLM sees relevant tags first
