### PR TITLE
Fix zombie subprocess accumulation, oversized clones, and missing timeouts

### DIFF
--- a/ymir/common/base_utils.py
+++ b/ymir/common/base_utils.py
@@ -448,7 +448,12 @@ async def run_subprocess(
         if isinstance(cmd, str):
             cmd = shlex.split(cmd)
         proc = await asyncio.create_subprocess_exec(cmd[0], *cmd[1:], **kwargs)
-    stdout, stderr = await proc.communicate()
+    try:
+        stdout, stderr = await proc.communicate()
+    except BaseException:
+        proc.kill()
+        await proc.wait()
+        raise
     return (
         proc.returncode,
         stdout.decode() if stdout else None,

--- a/ymir/common/tests/unit/test_base_utils.py
+++ b/ymir/common/tests/unit/test_base_utils.py
@@ -355,3 +355,15 @@ class TestInstallShutdownHandler:
 
         assert {sig for sig, _ in registered} == {signal.SIGTERM, signal.SIGINT}
         assert all(callback == shutdown_event.set for _, callback in registered)
+
+
+class TestRunSubprocessKillOnCancel:
+    @pytest.mark.asyncio
+    async def test_kills_process_on_cancellation(self):
+        from ymir.common.base_utils import run_subprocess
+
+        task = asyncio.create_task(run_subprocess(["sleep", "60"]))
+        await asyncio.sleep(0.1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -25,6 +25,7 @@ from ogr.services.gitlab.project import GitlabProject
 from ogr.services.gitlab.pull_request import GitlabPullRequest
 from pydantic import BaseModel, Field
 
+from ymir.common.base_utils import run_subprocess
 from ymir.common.models import (
     CommentReply,
     FailedPipelineJob,
@@ -502,24 +503,22 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
         clone_path.mkdir(parents=True, exist_ok=True)
 
         if branch:
-            proc = await asyncio.create_subprocess_exec("git", "init", cwd=clone_path, env=git_env)
-            if await proc.wait():
+            returncode, _, _ = await run_subprocess(["git", "init"], cwd=clone_path, env=git_env)
+            if returncode:
                 raise ToolError(f"Failed to initialize git repo at {clone_path}")
 
             command = ["git", *auth_args, "fetch", repository, f"{branch}:refs/heads/{branch}"]
-            proc = await asyncio.create_subprocess_exec(command[0], *command[1:], cwd=clone_path, env=git_env)
-            if await proc.wait():
+            returncode, _, _ = await run_subprocess(command, cwd=clone_path, env=git_env)
+            if returncode:
                 raise ToolError(f"Failed to fetch {branch} from {repository}")
 
-            proc = await asyncio.create_subprocess_exec(
-                "git", "checkout", branch, cwd=clone_path, env=git_env
-            )
-            if await proc.wait():
+            returncode, _, _ = await run_subprocess(["git", "checkout", branch], cwd=clone_path, env=git_env)
+            if returncode:
                 raise ToolError(f"Failed to checkout branch {branch}")
         else:
             command = ["git", *auth_args, "clone", repository, str(clone_path)]
-            proc = await asyncio.create_subprocess_exec(command[0], *command[1:], env=git_env)
-            if await proc.wait():
+            returncode, _, _ = await run_subprocess(command, env=git_env)
+            if returncode:
                 raise ToolError(f"Failed to clone {repository}")
 
         return StringToolOutput(result=f"Successfully cloned the specified repository to {clone_path}")
@@ -559,8 +558,8 @@ class PushToRemoteRepositoryTool(Tool[PushToRemoteRepositoryToolInput, ToolRunOp
         command = ["git", *auth_args, "push", repository, branch]
         if force:
             command.append("--force")
-        proc = await asyncio.create_subprocess_exec(command[0], *command[1:], cwd=clone_path)
-        if await proc.wait():
+        returncode, _, _ = await run_subprocess(command, cwd=clone_path)
+        if returncode:
             raise ToolError("Failed to push to the specified repository")
         return StringToolOutput(result=f"Successfully pushed the specified branch to {repository}")
 
@@ -603,13 +602,8 @@ class FetchBranchTool(Tool[FetchBranchToolInput, ToolRunOptions, StringToolOutpu
             repository,
             f"{branch}:refs/heads/{branch}",
         ]
-        proc = await asyncio.create_subprocess_exec(
-            command[0],
-            *command[1:],
-            cwd=clone_path,
-            env=git_env,
-        )
-        if await proc.wait():
+        returncode, _, _ = await run_subprocess(command, cwd=clone_path, env=git_env)
+        if returncode:
             raise ToolError(f"Failed to fetch branch {branch} from {repository}")
         return StringToolOutput(result=f"Successfully fetched branch {branch} from {repository}")
 

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -508,7 +508,12 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
                 raise ToolError(f"Failed to initialize git repo at {clone_path}")
 
             command = ["git", *auth_args, "fetch", repository, f"{branch}:refs/heads/{branch}"]
-            returncode, _, _ = await run_subprocess(command, cwd=clone_path, env=git_env)
+            try:
+                returncode, _, _ = await asyncio.wait_for(
+                    run_subprocess(command, cwd=clone_path, env=git_env), timeout=3600
+                )
+            except TimeoutError:
+                raise ToolError(f"Fetch of {branch} timed out after 60 minutes") from None
             if returncode:
                 raise ToolError(f"Failed to fetch {branch} from {repository}")
 
@@ -517,7 +522,10 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
                 raise ToolError(f"Failed to checkout branch {branch}")
         else:
             command = ["git", *auth_args, "clone", repository, str(clone_path)]
-            returncode, _, _ = await run_subprocess(command, env=git_env)
+            try:
+                returncode, _, _ = await asyncio.wait_for(run_subprocess(command, env=git_env), timeout=3600)
+            except TimeoutError:
+                raise ToolError(f"Clone of {repository} timed out after 60 minutes") from None
             if returncode:
                 raise ToolError(f"Failed to clone {repository}")
 

--- a/ymir/tools/unprivileged/tests/unit/test_upstream_tools.py
+++ b/ymir/tools/unprivileged/tests/unit/test_upstream_tools.py
@@ -424,6 +424,53 @@ class TestCloneUpstreamRepositoryTool:
                 )
             ).middleware(GlobalTrajectoryMiddleware(pretty=True))
 
+        assert not (tmp_path / "mypackage-upstream").exists()
+
+    @pytest.mark.asyncio
+    async def test_clone_passes_blobless_filter(self, tool, tmp_path):
+        clone_dir = tmp_path / "mypackage"
+        expected_path = tmp_path / "mypackage-upstream"
+        captured_cmd = []
+
+        async def mock_run_subprocess(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            expected_path.mkdir(parents=True, exist_ok=True)
+            (expected_path / ".git").mkdir(exist_ok=True)
+            return (0, "", "")
+
+        flexmock(upstream_tools_mod).should_receive("run_subprocess").replace_with(mock_run_subprocess).once()
+
+        await tool.run(
+            input=CloneUpstreamRepositoryToolInput(
+                repo_url="https://github.com/owner/repo.git",
+                clone_directory=str(clone_dir),
+            )
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "--filter=blob:none" in captured_cmd
+
+    @pytest.mark.asyncio
+    async def test_clone_timeout_removes_partial_directory(self, tool, tmp_path, monkeypatch):
+        clone_dir = tmp_path / "mypackage"
+        expected_path = tmp_path / "mypackage-upstream"
+
+        async def mock_wait_for(coro, timeout):
+            expected_path.mkdir(parents=True, exist_ok=True)
+            coro.close()
+            raise TimeoutError
+
+        monkeypatch.setattr(upstream_tools_mod.asyncio, "wait_for", mock_wait_for)
+
+        with pytest.raises(ToolError, match="Clone timed out"):
+            await tool.run(
+                input=CloneUpstreamRepositoryToolInput(
+                    repo_url="https://github.com/owner/repo.git",
+                    clone_directory=str(clone_dir),
+                )
+            ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert not expected_path.exists()
+
 
 # ---------------------------------------------------------------------------
 # FindBaseCommitTool

--- a/ymir/tools/unprivileged/upstream_tools.py
+++ b/ymir/tools/unprivileged/upstream_tools.py
@@ -1,6 +1,8 @@
 """Tools for working with upstream repositories and fix URLs."""
 
+import asyncio
 import re
+import shutil
 from urllib.parse import quote, urlparse
 
 import aiohttp
@@ -287,6 +289,10 @@ class CloneUpstreamRepositoryTool(Tool[CloneUpstreamRepositoryToolInput, ToolRun
     description = """
     Clone an upstream git repository to a specified directory.
 
+    Uses a blobless partial clone (--filter=blob:none): the full commit graph,
+    tags, and trees are fetched, but file contents are downloaded on demand.
+    All git operations (log, diff, cherry-pick, checkout) work normally.
+
     This is used to get a local copy of the upstream repository so we can:
     - Checkout a specific version/tag
     - Apply existing patches
@@ -319,11 +325,19 @@ class CloneUpstreamRepositoryTool(Tool[CloneUpstreamRepositoryToolInput, ToolRun
             # Create parent directory if needed
             clone_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Clone the repository
-            cmd = ["git", "clone", tool_input.repo_url, str(clone_path)]
-            exit_code, _, stderr = await run_subprocess(cmd)
+            # Clone the repository (blobless: full commit graph but deferred blobs)
+            cmd = ["git", "clone", "--filter=blob:none", tool_input.repo_url, str(clone_path)]
+            try:
+                exit_code, _, stderr = await asyncio.wait_for(run_subprocess(cmd), timeout=3600)
+            except TimeoutError:
+                shutil.rmtree(clone_path, ignore_errors=True)
+                raise ToolError("Clone timed out after 60 minutes") from None
+            except BaseException:
+                shutil.rmtree(clone_path, ignore_errors=True)
+                raise
 
             if exit_code != 0:
+                shutil.rmtree(clone_path, ignore_errors=True)
                 raise ToolError(f"Git clone failed: {stderr}")
 
             # Verify the clone was successful


### PR DESCRIPTION
Agent pods accumulate zombie processes and memory over time, leading to OOMKills after ~18 hours. Three root causes addressed:
- **Zombie processes**: Subprocesses not killed on timeout/cancellation — 27 zombies observed on one pod. Now all `proc.communicate()` and `proc.wait()` calls have try/finally cleanup that kills and reaps the child on interruption.
- **Oversized upstream clones**: `clone_upstream_repository` did full `git clone` of massive repos (vim ~2 GB, grafana, openjdk). Switched to `--filter=blob:none` (blobless partial clone) which preserves full commit history/tags but defers blob downloads to on-demand. Also adds 60-min timeout and removes partial directories on failure so retries aren't blocked.
- **No timeout on dist-git clone/fetch**: A hung `git clone` or `git fetch` in `CloneRepositoryTool` blocked the agent slot indefinitely. Added 60-minute `asyncio.wait_for` timeout with proper kill/reap on expiry.

e2e backport tests found no regression