### PR TITLE
Switch database backend to postgresql

### DIFF
--- a/Containerfile.phoenix
+++ b/Containerfile.phoenix
@@ -2,7 +2,7 @@
 FROM fedora:44
 RUN dnf install -y python3-pip python3-numpy python3-scipy \
     && dnf clean all \
-    && pip3 install --no-cache-dir 'arize-phoenix<16' 'pydantic-ai-slim<2' \
+    && pip3 install --no-cache-dir 'arize-phoenix[pg]<16' 'pydantic-ai-slim<2' \
     && useradd -u 1001 -g 0 -m -s /sbin/nologin phoenix
 USER 1001
 EXPOSE 6006 4317

--- a/README-agents.md
+++ b/README-agents.md
@@ -166,7 +166,7 @@ Issues can be re-triggered through the workflow in two ways:
 
 ### Phoenix: Alembic migration failure after version rollback
 
-When Phoenix is rolled back to an older version (e.g. v16 → v15), the SQLite database
+When Phoenix is rolled back to an older version (e.g. v16 → v15), the database
 contains an Alembic revision from the newer version that the older code doesn't
 recognize. Phoenix crashes on startup with:
 
@@ -190,32 +190,17 @@ expects. For the v16 → v15 rollback, the known revisions are:
    podman-compose stop phoenix
    ```
 
-2. Find the volume mount path:
+2. Stamp the database via `psql` on the phoenix-db container:
 
    ```bash
-   podman volume inspect ai-workflows_phoenix-data --format '{{.Mountpoint}}'
+   podman-compose exec phoenix-db psql -U phoenix -d phoenix -c \
+     "SELECT version_num FROM alembic_version;"
+
+   podman-compose exec phoenix-db psql -U phoenix -d phoenix -c \
+     "UPDATE alembic_version SET version_num = '575aa27302ee' WHERE version_num = '0ff41b5b118f';"
    ```
 
-3. Stamp the database:
-
-   ```bash
-   python3 -c "
-   import sqlite3, sys
-   db = '$(podman volume inspect ai-workflows_phoenix-data --format '{{.Mountpoint}}')/phoenix.db'
-   conn = sqlite3.connect(db)
-   cur = conn.cursor()
-   cur.execute('SELECT version_num FROM alembic_version')
-   print('Current:', cur.fetchall())
-   cur.execute(\"UPDATE alembic_version SET version_num = '575aa27302ee' WHERE version_num = '0ff41b5b118f'\")
-   print('Rows updated:', cur.rowcount)
-   conn.commit()
-   cur.execute('SELECT version_num FROM alembic_version')
-   print('Updated:', cur.fetchall())
-   conn.close()
-   "
-   ```
-
-4. Start Phoenix again:
+3. Start Phoenix again:
 
    ```bash
    podman-compose start phoenix
@@ -223,7 +208,7 @@ expects. For the v16 → v15 rollback, the known revisions are:
 
 #### Fix in OpenShift
 
-1. Scale down Phoenix to release the PVC:
+1. Scale down Phoenix:
 
    ```bash
    oc scale deployment phoenix --replicas=0
@@ -242,24 +227,16 @@ expects. For the v16 → v15 rollback, the known revisions are:
    "
    ```
 
-3. Update the `alembic_version` in the SQLite database (replace `OLD_REV` and
+3. Update the `alembic_version` in PostgreSQL (replace `OLD_REV` and
    `NEW_REV` with the values from the table above, or use step 2 output for a
    different version pair):
 
    ```bash
-   oc debug deployment/phoenix --container=phoenix -- python3 -c "
-   import sqlite3
-   conn = sqlite3.connect('/mnt/data/phoenix.db')
-   cur = conn.cursor()
-   cur.execute('SELECT version_num FROM alembic_version')
-   print('Current:', cur.fetchall())
-   cur.execute(\"UPDATE alembic_version SET version_num = 'NEW_REV' WHERE version_num = 'OLD_REV'\")
-   print('Rows updated:', cur.rowcount)
-   conn.commit()
-   cur.execute('SELECT version_num FROM alembic_version')
-   print('Updated:', cur.fetchall())
-   conn.close()
-   "
+   oc exec deployment/phoenix-db -- psql -U phoenix -d phoenix -c \
+     "SELECT version_num FROM alembic_version;"
+
+   oc exec deployment/phoenix-db -- psql -U phoenix -d phoenix -c \
+     "UPDATE alembic_version SET version_num = 'NEW_REV' WHERE version_num = 'OLD_REV';"
    ```
 
 4. Scale Phoenix back up:
@@ -269,7 +246,7 @@ expects. For the v16 → v15 rollback, the known revisions are:
    ```
 
 The stamp only updates Alembic's tracking metadata — any extra columns or indexes
-added by the newer version's migrations remain in the database. SQLite tolerates
+added by the newer version's migrations remain in the database. PostgreSQL tolerates
 unused columns, so this is generally safe.
 
 ## Advanced Usage

--- a/compose.yaml
+++ b/compose.yaml
@@ -132,15 +132,35 @@ services:
     restart: unless-stopped
     profiles: ["agents", "supervisor", "e2e-test"]
 
+  phoenix-db:
+    image: quay.io/sclorg/postgresql-16-c9s
+    environment:
+      - POSTGRESQL_USER=phoenix
+      - POSTGRESQL_PASSWORD=phoenix
+      - POSTGRESQL_DATABASE=phoenix
+    volumes:
+      - phoenix-db-data:/var/lib/pgsql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U phoenix -d phoenix"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    profiles: ["agents", "supervisor", "e2e-test"]
+
   phoenix:
     image: quay.io/jotnar/phoenix:latest
     build:
       context: .
       dockerfile: Containerfile.phoenix
+    depends_on:
+      phoenix-db:
+        condition: service_healthy
     ports:
       - "0.0.0.0:6006:6006"
     environment:
       - PHOENIX_WORKING_DIR=/mnt/data
+      - PHOENIX_SQL_DATABASE_URL=postgresql://phoenix:phoenix@phoenix-db/phoenix
     volumes:
       - phoenix-data:/mnt/data
     restart: unless-stopped
@@ -372,5 +392,6 @@ services:
 volumes:
   valkey-data:
   phoenix-data:
+  phoenix-db-data:
   trace-server-data:
   git-repos:

--- a/data_retention_policy.md
+++ b/data_retention_policy.md
@@ -9,7 +9,7 @@
 | Data Type | Retention | Status | Storage |
 |-----------|-----------|--------|---------|
 | **Git repository clones** | 7 days | ✅ Configured | `git-repos` volume |
-| **Phoenix observability traces** | Infinite (default) | ⚠️ Not configured | `phoenix-data` (10Gi) |
+| **Phoenix observability traces** | Infinite (default) | ⚠️ Not configured | PostgreSQL (`phoenix-db-data`, 20Gi) |
 | **Redis task queues** (Jira interaction history) | Indefinite | ⚠️ Not configured | `valkey-data` (2Gi) |
 | **Temporary build artifacts** | Agent execution only | ✅ Automatic | Within git clones |
 | **MR comments/history** | N/A | Stored in GitLab.com | External |
@@ -34,7 +34,9 @@ REPO_CLEANUP_DAYS = 7
 
 ### Phoenix Observability Traces ⚠️
 
-**Current:** No retention policy configured (infinite retention)
+**Current:** No retention policy configured (infinite retention). Phoenix uses PostgreSQL
+as its database backend (migrated from SQLite). Data is stored in the `phoenix-db-data`
+PVC (20Gi).
 
 **Recommendation:** Add 7-day retention to align with git cleanup policy
 
@@ -74,7 +76,7 @@ env:
 - ✅ Git clones: 7 days automatic cleanup
 
 **Missing Retention:**
-- ⚠️ Phoenix traces: No policy (defaults to infinite, limited by 10Gi volume)
+- ⚠️ Phoenix traces: No policy (defaults to infinite, stored in PostgreSQL on 20Gi volume)
 - ⚠️ Redis queues (Jira interaction history): No policy (defaults to indefinite, limited by 2Gi volume)
 
 **Next Review:** 2027-03-04

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -35,6 +35,14 @@ Agents are deployed in the `jotnar-ymir--jotnar-ymir` project.
   SENTRY_DSN
   ```
 
+  `phoenix-db-env` (PostgreSQL credentials for Phoenix observability):
+  ```bash
+  oc create secret generic phoenix-db-env \
+    --from-literal=POSTGRESQL_USER=phoenix \
+    --from-literal=POSTGRESQL_PASSWORD=<generate-strong-password> \
+    --from-literal=POSTGRESQL_DATABASE=phoenix
+  ```
+
   Values of these secrets are documented in [README](https://github.com/packit/jotnar?tab=readme-ov-file#service-accounts--authentication).
 
 - Create RHEL configuration ConfigMap manually:

--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -44,7 +44,14 @@ apply configmap-endpoints-env.yml
 apply configmap-jira-env.yml
 apply configmap-kerberos-env.yml
 
-# # Phoenix (observability)
+# Phoenix PostgreSQL database
+apply imagestream-phoenix-db.yml
+import_image phoenix-db
+apply pvc-phoenix-db-data.yml
+apply service-phoenix-db.yml
+apply deployment-phoenix-db.yml
+
+# Phoenix (observability)
 apply imagestream-phoenix.yml
 import_image phoenix
 apply pvc-phoenix-data.yml

--- a/openshift/deployment-phoenix-db.yml
+++ b/openshift/deployment-phoenix-db.yml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: phoenix-db
+  annotations:
+    image.openshift.io/triggers: |
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "phoenix-db:prod"
+          },
+          "fieldPath": "spec.template.spec.containers[?(@.name==\"phoenix-db\")].image"
+        }
+      ]
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: phoenix-db
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: phoenix-db
+        deployment: phoenix-db
+    spec:
+      containers:
+      - envFrom:
+        - secretRef:
+            name: phoenix-db-env
+        image: phoenix-db:prod
+        imagePullPolicy: IfNotPresent
+        name: phoenix-db
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -U $POSTGRESQL_USER -d $POSTGRESQL_DATABASE
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -U $POSTGRESQL_USER -d $POSTGRESQL_DATABASE
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        resources:
+          limits:
+            cpu: "500m"
+            memory: 1Gi
+          requests:
+            cpu: "25m"
+            memory: 256Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/pgsql/data
+          name: phoenix-db-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: phoenix-db-data
+        persistentVolumeClaim:
+          claimName: phoenix-db-data

--- a/openshift/deployment-phoenix.yml
+++ b/openshift/deployment-phoenix.yml
@@ -34,6 +34,25 @@ spec:
           value: /mnt/data
         - name: PHOENIX_PORT
           value: "6006"
+        - name: PHOENIX_POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: phoenix-db-env
+              key: POSTGRESQL_USER
+        - name: PHOENIX_POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: phoenix-db-env
+              key: POSTGRESQL_PASSWORD
+        - name: PHOENIX_POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: phoenix-db-env
+              key: POSTGRESQL_DATABASE
+        - name: PHOENIX_SQL_DATABASE_URL
+          value: postgresql://$(PHOENIX_POSTGRES_USER):$(PHOENIX_POSTGRES_PASSWORD)@phoenix-db/$(PHOENIX_POSTGRES_DB)
+        - name: PHOENIX_MIGRATE_INDEX_CONCURRENTLY
+          value: "true"
         image: phoenix:prod
         imagePullPolicy: IfNotPresent
         name: phoenix

--- a/openshift/imagestream-phoenix-db.yml
+++ b/openshift/imagestream-phoenix-db.yml
@@ -1,0 +1,14 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: phoenix-db
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+    - name: prod
+      from:
+        kind: DockerImage
+        name: quay.io/sclorg/postgresql-16-c9s
+      importPolicy:
+        scheduled: true

--- a/openshift/pvc-phoenix-db-data.yml
+++ b/openshift/pvc-phoenix-db-data.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: phoenix-data
+  name: phoenix-db-data
   annotations:
     trident.netapp.io/reclaimPolicy: Retain
     volume.beta.kubernetes.io/storage-provisioner: netapp.io/trident
@@ -12,6 +12,6 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
-  storageClassName: netapp-nfs
+      storage: 20Gi
+  storageClassName: rh-internal-iscsi
   volumeMode: Filesystem

--- a/openshift/service-phoenix-db.yml
+++ b/openshift/service-phoenix-db.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: phoenix-db
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: 5432-tcp
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app: phoenix-db
+    deployment: phoenix-db
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
This is obviously a substantial change. There is no easy way to migrate the trace data we have collected so far, but since we can't properly query it anyway, I don't see that as a much of an issue. That being said, we could export them, if we really want to.

- arize-phoenix is now installed with asyncpg
- Database credentials are set to defaults, it's going to run inside cluster with now outside facing API anyway
- New 150 GB volume for the database
- `phoenix-data` is now 2 GB, that should be enough for the runtime, maybe even an overkill 
- Shrinking volumes can be tricky, so we may have to delete the original and create a new one
- Uses quay.io/sclorg/postgresql-16-c9s container image

From local tests:
<img width="2365" height="469" alt="image" src="https://github.com/user-attachments/assets/17bc58cf-d060-46e8-997c-575a4a93d1aa" />

<!-- release notes footer -->

RELEASE NOTES BEGIN

Replace Phoenix SQLite backend with Postgresql.

RELEASE NOTES END
