### PR TITLE
Enforce use of up to date Log Detective MCP version

### DIFF
--- a/Containerfile.c9s-tests
+++ b/Containerfile.c9s-tests
@@ -41,7 +41,7 @@ RUN python3.11 -m venv --system-site-packages /opt/beeai-venv \
        GitPython \
        nitrate \
        tomli-w \
-       logdetective-mcp
+       "logdetective-mcp>=0.2.0"
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -43,7 +43,7 @@ RUN pip install --no-cache-dir \
       rpm \
       rpkg \
       specfile \
-      logdetective-mcp
+      "logdetective-mcp>=0.2.0"
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ beautifulsoup4>=4.13.4
 beeai-framework[duckduckgo]==0.1.80
 copr>=1.129
 fastmcp>=2.11.3
-logdetective-mcp>=0.1.0
+logdetective-mcp>=0.2.0
 ogr>=0.55.0
 openinference-instrumentation-beeai>=0.1.8
 redis>=6.4.0

--- a/ymir/tools/requirements.txt
+++ b/ymir/tools/requirements.txt
@@ -11,4 +11,4 @@ requests-gssapi>=1.3.0
 rpm>=0.4.0
 rpkg>=1.65
 specfile>=0.36.0
-logdetective-mcp>=0.1.0
+logdetective-mcp>=0.2.0


### PR DESCRIPTION
Log Detective MCP server version 0.2.0 has been released. Rather than letting the version float, we should enforce a reasonable lower bound.
https://pypi.org/project/logdetective-mcp/ 