### PR TITLE
Clean up all stale working directories, not just RHEL-*

### DIFF
--- a/data_retention_policy.md
+++ b/data_retention_policy.md
@@ -8,7 +8,7 @@
 
 | Data Type | Retention | Status | Storage |
 |-----------|-----------|--------|---------|
-| **Git repository clones** | 14 days | ✅ Configured | `git-repos` volume |
+| **Git repository clones** | 7 days | ✅ Configured | `git-repos` volume |
 | **Phoenix observability traces** | Infinite (default) | ⚠️ Not configured | `phoenix-data` (10Gi) |
 | **Redis task queues** (Jira interaction history) | Indefinite | ⚠️ Not configured | `valkey-data` (2Gi) |
 | **Temporary build artifacts** | Agent execution only | ✅ Automatic | Within git clones |
@@ -18,15 +18,16 @@
 
 ## Implementation Details
 
-### Git Repository Clones (14 Days) ✅
+### Git Repository Clones (7 Days) ✅
 
 **Configured in:** `ymir/tools/privileged/utils.py`
 ```python
-REPO_CLEANUP_DAYS = 14
+REPO_CLEANUP_DAYS = 7
 ```
 
 - Automatic cleanup on every `clone_repository` call
-- Deletes `RHEL-*` directories older than 14 days based on modification time
+- Deletes all stale working directories older than 7 days based on modification time
+- Steps into container directories (`applicability/`, `merge_requests/`) and cleans their children individually
 - Implemented in `clean_stale_repositories()` function
 
 ---
@@ -35,7 +36,7 @@ REPO_CLEANUP_DAYS = 14
 
 **Current:** No retention policy configured (infinite retention)
 
-**Recommendation:** Add 14-day retention to align with git cleanup policy
+**Recommendation:** Add 7-day retention to align with git cleanup policy
 
 ```yaml
 # openshift/deployment-phoenix.yml
@@ -70,7 +71,7 @@ env:
 ## Summary
 
 **Configured Retention:**
-- ✅ Git clones: 14 days automatic cleanup
+- ✅ Git clones: 7 days automatic cleanup
 
 **Missing Retention:**
 - ⚠️ Phoenix traces: No policy (defaults to infinite, limited by 10Gi volume)

--- a/skills_installation.md
+++ b/skills_installation.md
@@ -120,7 +120,7 @@ directory that contains this file.
 | `JIRA_URL` | **Yes** | Base URL of the Jira instance (e.g. `https://issues.redhat.com/`). |
 | `JIRA_EMAIL` | **Yes** | Email address for Jira Basic Auth. |
 | `JIRA_TOKEN` | **Yes** | Jira API token for Basic Auth. |
-| `GIT_REPO_BASEPATH` | No | Absolute path to a directory for git repository housekeeping. Only required if you use `CloneRepositoryTool` (it cleans up stale clones older than 14 days from this directory on every clone). |
+| `GIT_REPO_BASEPATH` | No | Absolute path to a directory for git repository housekeeping. Only required if you use `CloneRepositoryTool` (it cleans up stale clones older than 7 days from this directory on every clone). |
 | `KRB5CCNAME` | **Yes** | Kerberos credential cache location (e.g. `FILE:/tmp/krb5cc_1000`). |
 | `KEYTAB_FILE` | No | Path to a Kerberos keytab for automated `kinit`. When unset, an existing ticket must be present. |
 | `DRY_RUN` | No | Set to `true` to skip mutating Jira and lookaside operations. |

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -37,6 +37,7 @@ from ymir.common.version_utils import (
     parse_rhel_version,
     parse_zstream_branch_name,
 )
+from ymir.tools.privileged.utils import APPLICABILITY_DIR, MERGE_REQUESTS_DIR
 from ymir.tools.unprivileged.specfile import UpdateReleaseTool
 from ymir.tools.unprivileged.wicked_git import RunPackagePrepTool
 
@@ -182,7 +183,7 @@ async def prepare_dist_git_from_merge_request(
     available_tools: list[Tool],
     with_fedora: bool = False,
 ) -> tuple[Path, MergeRequestDetails, Path | None]:
-    working_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / "merge_requests"
+    working_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / MERGE_REQUESTS_DIR
     working_dir.mkdir(parents=True, exist_ok=True)
     local_clone = working_dir / urlparse(merge_request_url).path.replace("/", "_")
     shutil.rmtree(local_clone, ignore_errors=True)
@@ -655,7 +656,7 @@ async def clone_and_prep_sources(
     """
     if not jira_issue or Path(jira_issue).is_absolute() or ".." in jira_issue:
         raise ValueError(f"Invalid jira_issue: {jira_issue}")
-    working_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / "applicability" / jira_issue
+    working_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / APPLICABILITY_DIR / jira_issue
     if working_dir.is_dir():
         _force_rmtree(working_dir)
     working_dir.mkdir(parents=True, exist_ok=True)

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -69,6 +69,7 @@ from ymir.common.version_utils import (
     normalize_fix_version,
     parse_rhel_version,
 )
+from ymir.tools.privileged.utils import APPLICABILITY_DIR
 from ymir.tools.unprivileged.commands import RunShellCommandTool
 
 ## UpstreamSearchTool is currently unmaintained and disabled.
@@ -807,7 +808,7 @@ async def run_workflow(
             return "comment_in_jira"
 
         async def comment_in_jira(state):
-            applicability_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / "applicability" / state.jira_issue
+            applicability_dir = Path(os.environ["GIT_REPO_BASEPATH"]) / APPLICABILITY_DIR / state.jira_issue
             if applicability_dir.exists():
                 shutil.rmtree(applicability_dir, ignore_errors=True)
                 state.applicability_local_clone = None

--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -277,10 +277,10 @@ async def test_clone_repository(mock_git_repo_basepath):
         else:
             pytest.fail(f"Unexpected git command: {args}")
 
-        async def wait():
-            return 0
+        async def communicate():
+            return (b"", b"")
 
-        return flexmock(wait=wait)
+        return flexmock(communicate=communicate, returncode=0)
 
     flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)
 
@@ -333,10 +333,10 @@ async def test_clone_repository_accepts_path_inside_basepath(mock_git_repo_basep
     valid_path = mock_git_repo_basepath / "RHEL-12345" / "bash"
 
     async def create_subprocess_exec(cmd, *args, **kwargs):
-        async def wait():
-            return 0
+        async def communicate():
+            return (b"", b"")
 
-        return flexmock(wait=wait)
+        return flexmock(communicate=communicate, returncode=0)
 
     flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)
 
@@ -361,10 +361,10 @@ async def test_push_to_remote_repository():
         assert args[2] == branch
         assert kwargs.get("cwd") == clone_path
 
-        async def wait():
-            return 0
+        async def communicate():
+            return (b"", b"")
 
-        return flexmock(wait=wait)
+        return flexmock(communicate=communicate, returncode=0)
 
     flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(create_subprocess_exec)
     result = (

--- a/ymir/tools/privileged/tests/unit/test_utils.py
+++ b/ymir/tools/privileged/tests/unit/test_utils.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 from datetime import datetime, timedelta
-from pathlib import Path
 
 import pytest
 from flexmock import flexmock
@@ -15,43 +14,44 @@ def test_directories(mock_git_repo_basepath):
     temp_dir = mock_git_repo_basepath
 
     # Create test directories
-    old_dir = temp_dir / "rhel-old-package"
+    old_rhel_dir = temp_dir / "rhel-old-package"
+    old_other_dir = temp_dir / "consolidation-pkg-c9s-123456"
     new_dir = temp_dir / "rhel-new-package"
-    other_dir = temp_dir / "other-package"
 
-    old_dir.mkdir()
+    old_rhel_dir.mkdir()
+    old_other_dir.mkdir()
     new_dir.mkdir()
-    other_dir.mkdir()
 
     # Set different timestamps
     old_time = datetime.now() - timedelta(days=15)
-    os.utime(old_dir, (old_time.timestamp(), old_time.timestamp()))
+    os.utime(old_rhel_dir, (old_time.timestamp(), old_time.timestamp()))
+    os.utime(old_other_dir, (old_time.timestamp(), old_time.timestamp()))
 
-    new_time = datetime.now() - timedelta(days=5)
+    new_time = datetime.now() - timedelta(days=1)
     os.utime(new_dir, (new_time.timestamp(), new_time.timestamp()))
 
     return {
         "temp_dir": temp_dir,
-        "old_dir": old_dir,
+        "old_rhel_dir": old_rhel_dir,
+        "old_other_dir": old_other_dir,
         "new_dir": new_dir,
-        "other_dir": other_dir,
     }
 
 
 @pytest.mark.asyncio
 async def test_clean_stale_repositories(test_directories):
     """Test the clean_stale_repositories function."""
-    old_dir = test_directories["old_dir"]
+    old_rhel_dir = test_directories["old_rhel_dir"]
+    old_other_dir = test_directories["old_other_dir"]
     new_dir = test_directories["new_dir"]
-    other_dir = test_directories["other_dir"]
 
     result = await clean_stale_repositories()
 
-    assert result == 1
+    assert result == 2
 
-    assert not old_dir.is_dir()
+    assert not old_rhel_dir.is_dir()
+    assert not old_other_dir.is_dir()
     assert new_dir.is_dir()
-    assert other_dir.is_dir()
 
 
 @pytest.mark.asyncio
@@ -70,11 +70,39 @@ async def test_clean_stale_repositories_no_stale_directories(mock_git_repo_basep
 
 
 @pytest.mark.asyncio
+async def test_clean_stale_repositories_cleans_container_children(mock_git_repo_basepath):
+    """Test that children inside applicability/ and merge_requests/ are cleaned."""
+    temp_dir = mock_git_repo_basepath
+    old_time = datetime.now() - timedelta(days=15)
+
+    applicability = temp_dir / "applicability"
+    applicability.mkdir()
+    old_child = applicability / "RHEL-12345"
+    old_child.mkdir()
+    os.utime(old_child, (old_time.timestamp(), old_time.timestamp()))
+    new_child = applicability / "RHEL-99999"
+    new_child.mkdir()
+
+    mr_dir = temp_dir / "merge_requests"
+    mr_dir.mkdir()
+    old_mr = mr_dir / "_redhat_rhel_rpms_bash_123"
+    old_mr.mkdir()
+    os.utime(old_mr, (old_time.timestamp(), old_time.timestamp()))
+
+    result = await clean_stale_repositories()
+
+    assert result == 2
+    assert not old_child.is_dir()
+    assert new_child.is_dir()
+    assert applicability.is_dir()
+    assert not old_mr.is_dir()
+    assert mr_dir.is_dir()
+
+
+@pytest.mark.asyncio
 async def test_clean_stale_repositories_error_handling(test_directories):
     """Test clean_stale_repositories error handling."""
-    old_dir = test_directories["old_dir"]
-
-    flexmock(shutil).should_receive("rmtree").with_args(Path(old_dir)).and_raise(OSError("Permission denied"))
+    flexmock(shutil).should_receive("rmtree").and_raise(OSError("Permission denied"))
 
     result = await clean_stale_repositories()
 

--- a/ymir/tools/privileged/utils.py
+++ b/ymir/tools/privileged/utils.py
@@ -10,16 +10,27 @@ logger = logging.getLogger(__name__)
 
 REPO_CLEANUP_DAYS = 7
 
+APPLICABILITY_DIR = "applicability"
+MERGE_REQUESTS_DIR = "merge_requests"
+NESTED_WORK_DIRS = {APPLICABILITY_DIR, MERGE_REQUESTS_DIR}
 
-_NESTED_WORK_DIRS = {"applicability", "merge_requests"}
+
+def _remove_if_stale(path: Path, cutoff_time: datetime) -> bool:
+    """Delete *path* if its mtime predates *cutoff_time*. Return True on deletion."""
+    mod_time = datetime.fromtimestamp(path.stat().st_mtime)
+    if mod_time < cutoff_time:
+        logger.info(f"Deleting old directory: {path}")
+        shutil.rmtree(path, ignore_errors=False)
+        return True
+    return False
 
 
 def cleanup_stale_directories(git_repos_path: Path, cutoff_time: datetime) -> int:
     """
     Finds and deletes stale directories in the specified path.
     Top-level directories are checked directly; known container directories
-    (applicability/, merge_requests/) are stepped into and their children
-    are checked individually.
+    (see NESTED_WORK_DIRS) are stepped into and their children are checked
+    individually.
     Ignores all exceptions that could occur during cleanup.
     Return the number of deleted directories.
     """
@@ -29,38 +40,22 @@ def cleanup_stale_directories(git_repos_path: Path, cutoff_time: datetime) -> in
             if not item_path.is_dir():
                 continue
 
-            if item_path.name in _NESTED_WORK_DIRS:
-                deleted_count += _cleanup_children(item_path, cutoff_time)
+            if item_path.name in NESTED_WORK_DIRS:
+                for child in item_path.iterdir():
+                    try:
+                        if child.is_dir() and _remove_if_stale(child, cutoff_time):
+                            deleted_count += 1
+                    except Exception as ex:
+                        logger.warning(f"Failed to delete directory {child}: {ex}")
                 continue
 
-            mod_time = datetime.fromtimestamp(item_path.stat().st_mtime)
-            if mod_time < cutoff_time:
-                logger.info(f"Deleting old directory: {item_path}")
-                shutil.rmtree(item_path, ignore_errors=False)
+            if _remove_if_stale(item_path, cutoff_time):
                 deleted_count += 1
         except Exception as ex:
-            logger.warning(f"Failed to delete directory {item_path}: {ex}")
+            logger.warning(f"Failed to process directory {item_path}: {ex}")
             continue
 
     return deleted_count
-
-
-def _cleanup_children(container: Path, cutoff_time: datetime) -> int:
-    """Remove stale subdirectories inside a container directory."""
-    deleted = 0
-    for child in container.iterdir():
-        try:
-            if not child.is_dir():
-                continue
-            mod_time = datetime.fromtimestamp(child.stat().st_mtime)
-            if mod_time < cutoff_time:
-                logger.info(f"Deleting old directory: {child}")
-                shutil.rmtree(child, ignore_errors=False)
-                deleted += 1
-        except Exception as ex:
-            logger.warning(f"Failed to delete directory {child}: {ex}")
-            continue
-    return deleted
 
 
 async def clean_stale_repositories() -> int:

--- a/ymir/tools/privileged/utils.py
+++ b/ymir/tools/privileged/utils.py
@@ -8,19 +8,29 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-REPO_CLEANUP_DAYS = 14
+REPO_CLEANUP_DAYS = 7
+
+
+_NESTED_WORK_DIRS = {"applicability", "merge_requests"}
 
 
 def cleanup_stale_directories(git_repos_path: Path, cutoff_time: datetime) -> int:
     """
     Finds and deletes stale directories in the specified path.
+    Top-level directories are checked directly; known container directories
+    (applicability/, merge_requests/) are stepped into and their children
+    are checked individually.
     Ignores all exceptions that could occur during cleanup.
     Return the number of deleted directories.
     """
     deleted_count = 0
     for item_path in git_repos_path.iterdir():
         try:
-            if not item_path.is_dir() or not item_path.name.lower().startswith("rhel-"):
+            if not item_path.is_dir():
+                continue
+
+            if item_path.name in _NESTED_WORK_DIRS:
+                deleted_count += _cleanup_children(item_path, cutoff_time)
                 continue
 
             mod_time = datetime.fromtimestamp(item_path.stat().st_mtime)
@@ -35,9 +45,27 @@ def cleanup_stale_directories(git_repos_path: Path, cutoff_time: datetime) -> in
     return deleted_count
 
 
+def _cleanup_children(container: Path, cutoff_time: datetime) -> int:
+    """Remove stale subdirectories inside a container directory."""
+    deleted = 0
+    for child in container.iterdir():
+        try:
+            if not child.is_dir():
+                continue
+            mod_time = datetime.fromtimestamp(child.stat().st_mtime)
+            if mod_time < cutoff_time:
+                logger.info(f"Deleting old directory: {child}")
+                shutil.rmtree(child, ignore_errors=False)
+                deleted += 1
+        except Exception as ex:
+            logger.warning(f"Failed to delete directory {child}: {ex}")
+            continue
+    return deleted
+
+
 async def clean_stale_repositories() -> int:
     """
-    Cleans up stale repositories (older than 14 days).
+    Cleans up stale repositories (older than REPO_CLEANUP_DAYS days).
 
     Don't raise an error if the cleanup fails.
     Return the number of deleted directories.


### PR DESCRIPTION
  The /git-repos shared NFS volume (150Gi, ReadWriteMany) hit 99% inode exhaustion, causing ENOSPC errors across rebase and backport agents. The root cause was twofold:

  1. The cleanup only targeted RHEL-* directories, leaving consolidation-* dirs (from the MR consolidation agent), stray <package>-upstream dirs (from LLM-directed upstream clones), and other agent-created
  working directories to accumulate indefinitely.
  2. applicability/ and merge_requests/ are long-lived parent directories whose mtime stays fresh whenever a child is added, so the top-level age check never reached them — their stale children accumulated
  forever.
  3. The 14-day cleanup threshold was too generous given the volume of concurrent workflows (up to 12 simultaneous tasks across 10 agent deployments).

Changes

  - Reduce REPO_CLEANUP_DAYS from 14 to 7 — still gives plenty of margin for debugging while preventing excessive accumulation.
  - Remove the rhel- prefix filter — all stale top-level directories under /git-repos are now cleaned, covering consolidation-*, <package>-upstream, and any other agent-created working directories.
  - Step into applicability/ and merge_requests/ — these nested working directories now have their stale children cleaned individually, since the parent directory's mtime is always fresh.
  - Update tests to reflect the new behavior, including a new test for container directory child cleanup.