### PR TITLE
Clean up all stale top-level git-repos directories

### DIFF
--- a/ymir/tools/privileged/tests/unit/test_utils.py
+++ b/ymir/tools/privileged/tests/unit/test_utils.py
@@ -17,15 +17,16 @@ def test_directories(mock_git_repo_basepath):
     # Create test directories
     old_dir = temp_dir / "rhel-old-package"
     new_dir = temp_dir / "rhel-new-package"
-    other_dir = temp_dir / "other-package"
+    other_old_dir = temp_dir / "curl-c9s"
 
     old_dir.mkdir()
     new_dir.mkdir()
-    other_dir.mkdir()
+    other_old_dir.mkdir()
 
     # Set different timestamps
     old_time = datetime.now() - timedelta(days=15)
     os.utime(old_dir, (old_time.timestamp(), old_time.timestamp()))
+    os.utime(other_old_dir, (old_time.timestamp(), old_time.timestamp()))
 
     new_time = datetime.now() - timedelta(days=5)
     os.utime(new_dir, (new_time.timestamp(), new_time.timestamp()))
@@ -34,7 +35,7 @@ def test_directories(mock_git_repo_basepath):
         "temp_dir": temp_dir,
         "old_dir": old_dir,
         "new_dir": new_dir,
-        "other_dir": other_dir,
+        "other_old_dir": other_old_dir,
     }
 
 
@@ -43,15 +44,15 @@ async def test_clean_stale_repositories(test_directories):
     """Test the clean_stale_repositories function."""
     old_dir = test_directories["old_dir"]
     new_dir = test_directories["new_dir"]
-    other_dir = test_directories["other_dir"]
+    other_old_dir = test_directories["other_old_dir"]
 
     result = await clean_stale_repositories()
 
-    assert result == 1
+    assert result == 2
 
     assert not old_dir.is_dir()
+    assert not other_old_dir.is_dir()
     assert new_dir.is_dir()
-    assert other_dir.is_dir()
 
 
 @pytest.mark.asyncio
@@ -61,20 +62,27 @@ async def test_clean_stale_repositories_no_stale_directories(mock_git_repo_basep
 
     recent_dir = temp_dir / "rhel-recent-package"
     recent_dir.mkdir()
+    recent_arbitrary = temp_dir / "openssh-upstream"
+    recent_arbitrary.mkdir()
 
     result = await clean_stale_repositories()
 
     assert result == 0
 
     assert recent_dir.is_dir()
+    assert recent_arbitrary.is_dir()
 
 
 @pytest.mark.asyncio
 async def test_clean_stale_repositories_error_handling(test_directories):
     """Test clean_stale_repositories error handling."""
     old_dir = test_directories["old_dir"]
+    other_old_dir = test_directories["other_old_dir"]
 
     flexmock(shutil).should_receive("rmtree").with_args(Path(old_dir)).and_raise(OSError("Permission denied"))
+    flexmock(shutil).should_receive("rmtree").with_args(Path(other_old_dir)).and_raise(
+        OSError("Permission denied")
+    )
 
     result = await clean_stale_repositories()
 

--- a/ymir/tools/privileged/utils.py
+++ b/ymir/tools/privileged/utils.py
@@ -17,20 +17,28 @@ def cleanup_stale_directories(git_repos_path: Path, cutoff_time: datetime) -> in
     Ignores all exceptions that could occur during cleanup.
     Return the number of deleted directories.
     """
-    deleted_count = 0
-    for item_path in git_repos_path.iterdir():
-        try:
-            if not item_path.is_dir() or not item_path.name.lower().startswith("rhel-"):
-                continue
+    stale_dirs: list[Path] = []
+    try:
+        for item_path in git_repos_path.iterdir():
+            try:
+                if not item_path.is_dir():
+                    continue
+                mod_time = datetime.fromtimestamp(item_path.stat().st_mtime)
+                if mod_time < cutoff_time:
+                    stale_dirs.append(item_path)
+            except Exception as ex:
+                logger.warning(f"Failed to inspect directory {item_path}: {ex}")
+    except Exception as ex:
+        logger.warning(f"Failed to list directory {git_repos_path}: {ex}")
 
-            mod_time = datetime.fromtimestamp(item_path.stat().st_mtime)
-            if mod_time < cutoff_time:
-                logger.info(f"Deleting old directory: {item_path}")
-                shutil.rmtree(item_path, ignore_errors=False)
-                deleted_count += 1
+    deleted_count = 0
+    for item_path in stale_dirs:
+        try:
+            logger.info(f"Deleting old directory: {item_path}")
+            shutil.rmtree(item_path, ignore_errors=False)
+            deleted_count += 1
         except Exception as ex:
             logger.warning(f"Failed to delete directory {item_path}: {ex}")
-            continue
 
     return deleted_count
 


### PR DESCRIPTION
The RHEL-* name filter left arbitrarily named LLM clones (curl-c9s, openssh-upstream, etc.) accumulating on the shared PV. Delete any top-level directory older than the retention window.

Assisted-by: Cursor Grok 4.5