### PR TITLE
Accept "Done" resolution as shipped in Z-stream clone check

### DIFF
--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -433,7 +433,7 @@ async def _check_zstream_clones_shipped(
             logger.info(f"  {key}: fixVersions={fv_names} — not a relevant Z-stream, skipping")
             continue
 
-        if status_name == "Closed" and resolution_name == "Done-Errata":
+        if status_name == "Closed" and resolution_name in ("Done-Errata", "Done"):
             logger.info(f"  {key}: fixVersions={fv_names}, resolution={resolution_name} — shipped")
             any_shipped = True
         elif status_name == "Closed":

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -554,6 +554,31 @@ async def test_check_zstream_clones_all_closed():
 
 
 @pytest.mark.asyncio
+async def test_check_zstream_clones_closed_done():
+    """Clone closed with resolution 'Done' (not 'Done-Errata') counts as shipped."""
+    search_result = [
+        {
+            "key": "RHEL-111",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.7.z"}],
+                "status": {"name": "Closed"},
+                "resolution": {"name": "Done"},
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+
+    any_shipped, pending = await _check_zstream_clones_shipped("CVE-2025-12345", "curl", "RHEL-999")
+    assert any_shipped is True
+    assert pending == []
+
+
+@pytest.mark.asyncio
 async def test_check_zstream_clones_one_shipped_one_open():
     """At least one Z-stream clone shipped — proceed even if others are still open."""
     search_result = [


### PR DESCRIPTION
The Y-stream CVE postponement gate only recognized "Done-Errata" as a shipped resolution, causing clones closed with resolution "Done" to be silently dropped — neither counted as shipped nor listed as pending. This left Y-stream issues permanently postponed even after their Z-stream clones had shipped.

Assisted-by: Claude Opus 4.6 (Cursor)