### PR TITLE
Add diagnostic logging to clone/fetch/push git tools

### DIFF
--- a/ymir/tools/privileged/distgit.py
+++ b/ymir/tools/privileged/distgit.py
@@ -19,7 +19,7 @@ from ymir.common.base_utils import KerberosError, init_kerberos_ticket
 from ymir.common.utils import get_latest_candidate_build, get_latest_z_pending_build
 from ymir.common.version_utils import is_older_zstream, parse_zstream_branch_name
 from ymir.tools.base import CloneableTool as Tool
-from ymir.tools.privileged.utils import sanitize_url as _sanitize_url
+from ymir.tools.privileged.utils import sanitize_url
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ async def _retry_transient(
                 backoff = random.uniform(0, base_delay * 2**attempt)  # noqa: S311
                 logger.warning(
                     f"{label} failed (attempt {attempt + 1}/{max_retries}): "
-                    f"{_sanitize_url(str(e))}; retrying in {backoff:.1f}s"
+                    f"{sanitize_url(str(e))}; retrying in {backoff:.1f}s"
                 )
                 await asyncio.sleep(backoff)
             else:
@@ -197,7 +197,7 @@ class CreateZstreamBranchTool(Tool[CreateZstreamBranchToolInput, ToolRunOptions,
                     result=f"Z-Stream branch {branch} already exists, no need to create it"
                 )
         except Exception as e:
-            raise ToolError(f"Failed to check GitLab remote: {_sanitize_url(str(e))}") from e
+            raise ToolError(f"Failed to check GitLab remote: {sanitize_url(str(e))}") from e
         try:
             with tempfile.TemporaryDirectory() as path:
                 # Username is taken from the Kerberos principal and embedded in
@@ -249,7 +249,7 @@ class CreateZstreamBranchTool(Tool[CreateZstreamBranchToolInput, ToolRunOptions,
                     except git.exc.GitCommandError as e:
                         if not _is_transient_git_error(e):
                             raise
-                        logger.warning(f"Transient error polling GitLab mirror sync: {_sanitize_url(str(e))}")
+                        logger.warning(f"Transient error polling GitLab mirror sync: {sanitize_url(str(e))}")
                     elapsed = int(time.monotonic() - start_time)
                     logger.info(
                         f"Waiting for GitLab mirror sync of {package} branch {branch} ({elapsed}s elapsed)"
@@ -259,4 +259,4 @@ class CreateZstreamBranchTool(Tool[CreateZstreamBranchToolInput, ToolRunOptions,
                     f"The {branch} branch wasn't synced to GitLab after {SYNC_TIMEOUT} seconds"
                 )
         except Exception as e:
-            raise ToolError(f"Failed to create Z-Stream branch: {_sanitize_url(str(e))}") from e
+            raise ToolError(f"Failed to create Z-Stream branch: {sanitize_url(str(e))}") from e

--- a/ymir/tools/privileged/distgit.py
+++ b/ymir/tools/privileged/distgit.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import os
 import random
-import re
 import shutil
 import tempfile
 import time
@@ -20,6 +19,7 @@ from ymir.common.base_utils import KerberosError, init_kerberos_ticket
 from ymir.common.utils import get_latest_candidate_build, get_latest_z_pending_build
 from ymir.common.version_utils import is_older_zstream, parse_zstream_branch_name
 from ymir.tools.base import CloneableTool as Tool
+from ymir.tools.privileged.utils import sanitize_url as _sanitize_url
 
 logger = logging.getLogger(__name__)
 
@@ -40,11 +40,6 @@ _TRANSIENT_STDERR_PATTERNS = (
 )
 
 _T = TypeVar("_T")
-
-
-def _sanitize_url(text: str) -> str:
-    """Remove oauth2:{token}@ credentials from URLs in error messages."""
-    return re.sub(r"oauth2:[^@\s]+@", "oauth2:***@", text)
 
 
 def _is_transient_git_error(exc: Exception) -> bool:

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, urlparse
@@ -37,9 +38,20 @@ from ymir.common.validators import AbsolutePath
 from ymir.tools.base import CloneableTool as Tool
 from ymir.tools.constants import AIOHTTP_TIMEOUT, YMIR_USER_AGENT
 from ymir.tools.http import aiohttp_get_with_retries
-from ymir.tools.privileged.utils import clean_stale_repositories
+from ymir.tools.privileged.utils import clean_stale_repositories, sanitize_url
 
 logger = logging.getLogger(__name__)
+
+_STDERR_HINT_MAX = 500
+
+
+def _git_subprocess_error(stderr: str | None, message: str) -> ToolError:
+    """Log a git subprocess failure at ERROR level and return a ToolError with a stderr hint."""
+    safe_stderr = sanitize_url(stderr or "")
+    hint = safe_stderr.strip()[-_STDERR_HINT_MAX:]
+    logger.error("%s\nstderr (last %d chars): %s", message, len(hint), hint)
+    return ToolError(f"{message}: {hint}" if hint else message)
+
 
 # GitLab access levels: Guest (10), Reporter (20), Developer (30),
 # Maintainer (40), Owner (50)
@@ -502,32 +514,54 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
 
         clone_path.mkdir(parents=True, exist_ok=True)
 
+        safe_url = sanitize_url(repository)
+
         if branch:
-            returncode, _, _ = await run_subprocess(["git", "init"], cwd=clone_path, env=git_env)
+            returncode, _, stderr = await run_subprocess(["git", "init"], cwd=clone_path, env=git_env)
             if returncode:
-                raise ToolError(f"Failed to initialize git repo at {clone_path}")
+                raise _git_subprocess_error(stderr, f"git init failed at {clone_path}")
 
             command = ["git", *auth_args, "fetch", repository, f"{branch}:refs/heads/{branch}"]
+            logger.info("git fetch %s branch=%s path=%s", safe_url, branch, clone_path)
+            t0 = time.monotonic()
             try:
-                returncode, _, _ = await asyncio.wait_for(
+                returncode, _, stderr = await asyncio.wait_for(
                     run_subprocess(command, cwd=clone_path, env=git_env), timeout=3600
                 )
             except TimeoutError:
+                elapsed = time.monotonic() - t0
+                logger.error("git fetch timed out after %.1fs: %s branch=%s", elapsed, safe_url, branch)
                 raise ToolError(f"Fetch of {branch} timed out after 60 minutes") from None
+            elapsed = time.monotonic() - t0
             if returncode:
-                raise ToolError(f"Failed to fetch {branch} from {repository}")
+                msg = f"git fetch failed (exit_code={returncode}, elapsed={elapsed:.1f}s)"
+                raise _git_subprocess_error(stderr, f"{msg}: {safe_url} branch={branch}")
+            logger.info("git fetch completed in %.1fs: %s branch=%s", elapsed, safe_url, branch)
 
-            returncode, _, _ = await run_subprocess(["git", "checkout", branch], cwd=clone_path, env=git_env)
+            returncode, _, stderr = await run_subprocess(
+                ["git", "checkout", branch], cwd=clone_path, env=git_env
+            )
             if returncode:
-                raise ToolError(f"Failed to checkout branch {branch}")
+                raise _git_subprocess_error(stderr, f"git checkout failed for branch={branch}")
         else:
             command = ["git", *auth_args, "clone", repository, str(clone_path)]
+            logger.info("git clone %s path=%s", safe_url, clone_path)
+            t0 = time.monotonic()
             try:
-                returncode, _, _ = await asyncio.wait_for(run_subprocess(command, env=git_env), timeout=3600)
+                returncode, _, stderr = await asyncio.wait_for(
+                    run_subprocess(command, env=git_env), timeout=3600
+                )
             except TimeoutError:
-                raise ToolError(f"Clone of {repository} timed out after 60 minutes") from None
+                elapsed = time.monotonic() - t0
+                logger.error("git clone timed out after %.1fs: %s", elapsed, safe_url)
+                raise ToolError(f"Clone of {safe_url} timed out after 60 minutes") from None
+            elapsed = time.monotonic() - t0
             if returncode:
-                raise ToolError(f"Failed to clone {repository}")
+                raise _git_subprocess_error(
+                    stderr,
+                    f"git clone failed (exit_code={returncode}, elapsed={elapsed:.1f}s): {safe_url}",
+                )
+            logger.info("git clone completed in %.1fs: %s", elapsed, safe_url)
 
         return StringToolOutput(result=f"Successfully cloned the specified repository to {clone_path}")
 
@@ -562,14 +596,20 @@ class PushToRemoteRepositoryTool(Tool[PushToRemoteRepositoryToolInput, ToolRunOp
         clone_path = tool_input.clone_path
         branch = tool_input.branch
         force = tool_input.force
+        safe_url = sanitize_url(repository)
         auth_args = _get_git_auth_args(repository)
         command = ["git", *auth_args, "push", repository, branch]
         if force:
             command.append("--force")
-        returncode, _, _ = await run_subprocess(command, cwd=clone_path)
+        logger.info("git push %s branch=%s force=%s", safe_url, branch, force)
+        t0 = time.monotonic()
+        returncode, _, stderr = await run_subprocess(command, cwd=clone_path)
+        elapsed = time.monotonic() - t0
         if returncode:
-            raise ToolError("Failed to push to the specified repository")
-        return StringToolOutput(result=f"Successfully pushed the specified branch to {repository}")
+            msg = f"git push failed (exit_code={returncode}, elapsed={elapsed:.1f}s)"
+            raise _git_subprocess_error(stderr, f"{msg}: {safe_url} branch={branch}")
+        logger.info("git push completed in %.1fs: %s branch=%s", elapsed, safe_url, branch)
+        return StringToolOutput(result=f"Successfully pushed the specified branch to {safe_url}")
 
 
 class FetchBranchToolInput(BaseModel):
@@ -601,6 +641,7 @@ class FetchBranchTool(Tool[FetchBranchToolInput, ToolRunOptions, StringToolOutpu
         repository = tool_input.repository
         branch = tool_input.branch
         clone_path = tool_input.clone_path
+        safe_url = sanitize_url(repository)
         auth_args = _get_git_auth_args(repository)
         git_env = _get_mock_git_env()
         command = [
@@ -610,10 +651,15 @@ class FetchBranchTool(Tool[FetchBranchToolInput, ToolRunOptions, StringToolOutpu
             repository,
             f"{branch}:refs/heads/{branch}",
         ]
-        returncode, _, _ = await run_subprocess(command, cwd=clone_path, env=git_env)
+        logger.info("git fetch %s branch=%s path=%s", safe_url, branch, clone_path)
+        t0 = time.monotonic()
+        returncode, _, stderr = await run_subprocess(command, cwd=clone_path, env=git_env)
+        elapsed = time.monotonic() - t0
         if returncode:
-            raise ToolError(f"Failed to fetch branch {branch} from {repository}")
-        return StringToolOutput(result=f"Successfully fetched branch {branch} from {repository}")
+            msg = f"git fetch failed (exit_code={returncode}, elapsed={elapsed:.1f}s)"
+            raise _git_subprocess_error(stderr, f"{msg}: {safe_url} branch={branch}")
+        logger.info("git fetch completed in %.1fs: %s branch=%s", elapsed, safe_url, branch)
+        return StringToolOutput(result=f"Successfully fetched branch {branch} from {safe_url}")
 
 
 class AddMergeRequestLabelsToolInput(BaseModel):

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -53,6 +53,46 @@ def _git_subprocess_error(stderr: str | None, message: str) -> ToolError:
     return ToolError(f"{message}: {hint}" if hint else message)
 
 
+async def _run_git_cmd(
+    command: list[str],
+    *,
+    label: str,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = 3600,
+) -> None:
+    """Run a git subprocess with structured logging, timing, and error handling.
+
+    Args:
+        command: The git command to execute as a list of arguments.
+        label: Human-readable description for log messages (e.g. "git fetch <url> branch=main").
+        cwd: Working directory for the subprocess.
+        env: Environment variables to pass to the subprocess.
+        timeout: Timeout in seconds, or None for no timeout.
+
+    Raises:
+        ToolError: If the command fails or times out.
+    """
+    logger.info("%s", label)
+    t0 = time.monotonic()
+    try:
+        coro = run_subprocess(command, cwd=cwd, env=env)
+        if timeout is not None:
+            returncode, _, stderr = await asyncio.wait_for(coro, timeout=timeout)
+        else:
+            returncode, _, stderr = await coro
+    except TimeoutError:
+        elapsed = time.monotonic() - t0
+        logger.error("%s timed out after %.1fs", label, elapsed)
+        raise ToolError(f"{label} timed out after {int(timeout)}s") from None
+    elapsed = time.monotonic() - t0
+    if returncode:
+        raise _git_subprocess_error(
+            stderr, f"{label} failed (exit_code={returncode}, elapsed={elapsed:.1f}s)"
+        )
+    logger.info("%s completed in %.1fs", label, elapsed)
+
+
 # GitLab access levels: Guest (10), Reporter (20), Developer (30),
 # Maintainer (40), Owner (50)
 DEVELOPER_ACCESS_LEVEL = 30
@@ -517,51 +557,34 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
         safe_url = sanitize_url(repository)
 
         if branch:
-            returncode, _, stderr = await run_subprocess(["git", "init"], cwd=clone_path, env=git_env)
-            if returncode:
-                raise _git_subprocess_error(stderr, f"git init failed at {clone_path}")
-
-            command = ["git", *auth_args, "fetch", repository, f"{branch}:refs/heads/{branch}"]
-            logger.info("git fetch %s branch=%s path=%s", safe_url, branch, clone_path)
-            t0 = time.monotonic()
-            try:
-                returncode, _, stderr = await asyncio.wait_for(
-                    run_subprocess(command, cwd=clone_path, env=git_env), timeout=3600
-                )
-            except TimeoutError:
-                elapsed = time.monotonic() - t0
-                logger.error("git fetch timed out after %.1fs: %s branch=%s", elapsed, safe_url, branch)
-                raise ToolError(f"Fetch of {branch} timed out after 60 minutes") from None
-            elapsed = time.monotonic() - t0
-            if returncode:
-                msg = f"git fetch failed (exit_code={returncode}, elapsed={elapsed:.1f}s)"
-                raise _git_subprocess_error(stderr, f"{msg}: {safe_url} branch={branch}")
-            logger.info("git fetch completed in %.1fs: %s branch=%s", elapsed, safe_url, branch)
-
-            returncode, _, stderr = await run_subprocess(
-                ["git", "checkout", branch], cwd=clone_path, env=git_env
+            await _run_git_cmd(
+                ["git", "init"],
+                label=f"git init {clone_path}",
+                cwd=clone_path,
+                env=git_env,
+                timeout=None,
             )
-            if returncode:
-                raise _git_subprocess_error(stderr, f"git checkout failed for branch={branch}")
+
+            await _run_git_cmd(
+                ["git", *auth_args, "fetch", repository, f"{branch}:refs/heads/{branch}"],
+                label=f"git fetch {safe_url} branch={branch}",
+                cwd=clone_path,
+                env=git_env,
+            )
+
+            await _run_git_cmd(
+                ["git", "checkout", branch],
+                label=f"git checkout branch={branch}",
+                cwd=clone_path,
+                env=git_env,
+                timeout=None,
+            )
         else:
-            command = ["git", *auth_args, "clone", repository, str(clone_path)]
-            logger.info("git clone %s path=%s", safe_url, clone_path)
-            t0 = time.monotonic()
-            try:
-                returncode, _, stderr = await asyncio.wait_for(
-                    run_subprocess(command, env=git_env), timeout=3600
-                )
-            except TimeoutError:
-                elapsed = time.monotonic() - t0
-                logger.error("git clone timed out after %.1fs: %s", elapsed, safe_url)
-                raise ToolError(f"Clone of {safe_url} timed out after 60 minutes") from None
-            elapsed = time.monotonic() - t0
-            if returncode:
-                raise _git_subprocess_error(
-                    stderr,
-                    f"git clone failed (exit_code={returncode}, elapsed={elapsed:.1f}s): {safe_url}",
-                )
-            logger.info("git clone completed in %.1fs: %s", elapsed, safe_url)
+            await _run_git_cmd(
+                ["git", *auth_args, "clone", repository, str(clone_path)],
+                label=f"git clone {safe_url}",
+                env=git_env,
+            )
 
         return StringToolOutput(result=f"Successfully cloned the specified repository to {clone_path}")
 
@@ -601,14 +624,12 @@ class PushToRemoteRepositoryTool(Tool[PushToRemoteRepositoryToolInput, ToolRunOp
         command = ["git", *auth_args, "push", repository, branch]
         if force:
             command.append("--force")
-        logger.info("git push %s branch=%s force=%s", safe_url, branch, force)
-        t0 = time.monotonic()
-        returncode, _, stderr = await run_subprocess(command, cwd=clone_path)
-        elapsed = time.monotonic() - t0
-        if returncode:
-            msg = f"git push failed (exit_code={returncode}, elapsed={elapsed:.1f}s)"
-            raise _git_subprocess_error(stderr, f"{msg}: {safe_url} branch={branch}")
-        logger.info("git push completed in %.1fs: %s branch=%s", elapsed, safe_url, branch)
+        await _run_git_cmd(
+            command,
+            label=f"git push {safe_url} branch={branch} force={force}",
+            cwd=clone_path,
+            timeout=None,
+        )
         return StringToolOutput(result=f"Successfully pushed the specified branch to {safe_url}")
 
 
@@ -644,21 +665,13 @@ class FetchBranchTool(Tool[FetchBranchToolInput, ToolRunOptions, StringToolOutpu
         safe_url = sanitize_url(repository)
         auth_args = _get_git_auth_args(repository)
         git_env = _get_mock_git_env()
-        command = [
-            "git",
-            *auth_args,
-            "fetch",
-            repository,
-            f"{branch}:refs/heads/{branch}",
-        ]
-        logger.info("git fetch %s branch=%s path=%s", safe_url, branch, clone_path)
-        t0 = time.monotonic()
-        returncode, _, stderr = await run_subprocess(command, cwd=clone_path, env=git_env)
-        elapsed = time.monotonic() - t0
-        if returncode:
-            msg = f"git fetch failed (exit_code={returncode}, elapsed={elapsed:.1f}s)"
-            raise _git_subprocess_error(stderr, f"{msg}: {safe_url} branch={branch}")
-        logger.info("git fetch completed in %.1fs: %s branch=%s", elapsed, safe_url, branch)
+        await _run_git_cmd(
+            ["git", *auth_args, "fetch", repository, f"{branch}:refs/heads/{branch}"],
+            label=f"git fetch {safe_url} branch={branch}",
+            cwd=clone_path,
+            env=git_env,
+            timeout=None,
+        )
         return StringToolOutput(result=f"Successfully fetched branch {branch} from {safe_url}")
 
 

--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -16,6 +16,7 @@ from ymir.tools.privileged.gitlab import (
     AddMergeRequestCommentTool,
     AddMergeRequestLabelsTool,
     CloneRepositoryTool,
+    FetchBranchTool,
     ForkRepositoryTool,
     GetAuthorizedCommentsFromMergeRequestTool,
     GetFailedPipelineJobsFromMergeRequestTool,
@@ -24,6 +25,7 @@ from ymir.tools.privileged.gitlab import (
     RetryPipelineJobTool,
     _get_git_auth_args,
 )
+from ymir.tools.privileged.utils import sanitize_url
 
 
 @pytest.mark.parametrize(
@@ -897,3 +899,180 @@ async def test_get_authorized_comments_invalid_url():
             input={"merge_request_url": "https://github.com/user/repo/pull/123"}
         )
     assert "Could not parse merge request URL" in str(exc_info.value)
+
+
+# --- sanitize_url tests ---
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        (
+            "https://oauth2:glpat-abc123@gitlab.com/redhat/rpms/vim",  # pragma: allowlist secret
+            "https://oauth2:***@gitlab.com/redhat/rpms/vim",
+        ),
+        (
+            "clone failed: https://gitlab.com/redhat/rpms/vim",
+            "clone failed: https://gitlab.com/redhat/rpms/vim",
+        ),
+        ("no credentials here", "no credentials here"),
+        ("", ""),
+    ],
+)
+def test_sanitize_url(text, expected):
+    assert sanitize_url(text) == expected
+
+
+# --- clone / fetch / push failure logging tests ---
+
+
+def _make_failing_subprocess(stderr_text):
+    """Return an async mock that simulates a git command failure with stderr."""
+
+    async def create_subprocess_exec(cmd, *args, **kwargs):
+        async def communicate():
+            return (b"", stderr_text.encode())
+
+        return flexmock(communicate=communicate, returncode=128)
+
+    return create_subprocess_exec
+
+
+def _make_subprocess_sequence(results):
+    """Return an async mock that yields different results per call.
+
+    *results* is a list of (returncode, stderr) tuples, consumed in order.
+    """
+    call_iter = iter(results)
+
+    async def create_subprocess_exec(cmd, *args, **kwargs):
+        returncode, stderr_text = next(call_iter)
+
+        async def communicate():
+            return (b"", stderr_text.encode())
+
+        return flexmock(communicate=communicate, returncode=returncode)
+
+    return create_subprocess_exec
+
+
+@pytest.mark.asyncio
+async def test_clone_repository_logs_stderr_on_failure(mock_git_repo_basepath, caplog):
+    """Clone failure surfaces git stderr in logs and ToolError."""
+    clone_path = mock_git_repo_basepath / "vim"
+    stderr_msg = "fatal: repository 'https://github.com/vim/vim' not found"
+
+    flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(
+        _make_subprocess_sequence(
+            [
+                (0, ""),  # git init succeeds
+                (128, stderr_msg),  # git fetch fails
+            ]
+        )
+    )
+
+    with pytest.raises(ToolError, match="not found"):
+        await CloneRepositoryTool().run(
+            input={
+                "repository": "https://github.com/vim/vim",
+                "branch": "main",
+                "clone_path": clone_path,
+            }
+        )
+
+    assert "not found" in caplog.text
+    assert "git fetch failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_clone_repository_no_branch_logs_stderr_on_failure(mock_git_repo_basepath, caplog):
+    """Full clone (no branch) failure surfaces git stderr."""
+    clone_path = mock_git_repo_basepath / "vim"
+    stderr_msg = "fatal: unable to access: The requested URL returned error: 403"
+
+    flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(
+        _make_failing_subprocess(stderr_msg)
+    )
+
+    with pytest.raises(ToolError, match="403"):
+        await CloneRepositoryTool().run(
+            input={
+                "repository": "https://github.com/vim/vim",
+                "clone_path": clone_path,
+            }
+        )
+
+    assert "403" in caplog.text
+    assert "git clone failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_clone_repository_sanitizes_stderr(mock_git_repo_basepath, caplog):
+    """Credentials in git stderr are sanitized before logging."""
+    clone_path = mock_git_repo_basepath / "vim"
+    token = "glpat-secret"  # pragma: allowlist secret
+    repo = f"https://oauth2:{token}@gitlab.com/redhat/rpms/vim"
+    stderr_msg = f"fatal: unable to access '{repo}/': 403"
+
+    flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(
+        _make_failing_subprocess(stderr_msg)
+    )
+
+    with pytest.raises(ToolError) as exc_info:
+        await CloneRepositoryTool().run(
+            input={
+                "repository": repo,
+                "clone_path": clone_path,
+            }
+        )
+
+    assert token not in caplog.text
+    assert "oauth2:***@" in caplog.text
+    assert token not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_fetch_branch_logs_stderr_on_failure(mock_git_repo_basepath, caplog):
+    """FetchBranchTool failure surfaces git stderr."""
+    clone_path = mock_git_repo_basepath / "vim"
+    clone_path.mkdir()
+    stderr_msg = "fatal: couldn't find remote ref main"
+
+    flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(
+        _make_failing_subprocess(stderr_msg)
+    )
+
+    with pytest.raises(ToolError, match="remote ref"):
+        await FetchBranchTool().run(
+            input={
+                "repository": "https://github.com/vim/vim",
+                "branch": "main",
+                "clone_path": clone_path,
+            }
+        )
+
+    assert "remote ref" in caplog.text
+    assert "git fetch failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_push_logs_stderr_on_failure(caplog):
+    """PushToRemoteRepositoryTool failure surfaces git stderr."""
+    clone_path = Path("/git-repos/bash")
+    stderr_msg = "error: failed to push some refs to 'https://gitlab.com/ai-bot/bash.git'"
+
+    flexmock(asyncio).should_receive("create_subprocess_exec").replace_with(
+        _make_failing_subprocess(stderr_msg)
+    )
+
+    with pytest.raises(ToolError, match="failed to push"):
+        await PushToRemoteRepositoryTool().run(
+            input={
+                "repository": "https://gitlab.com/ai-bot/bash.git",
+                "clone_path": clone_path,
+                "branch": "my-branch",
+            }
+        )
+
+    assert "failed to push" in caplog.text
+    assert "git push failed" in caplog.text

--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -981,7 +981,8 @@ async def test_clone_repository_logs_stderr_on_failure(mock_git_repo_basepath, c
         )
 
     assert "not found" in caplog.text
-    assert "git fetch failed" in caplog.text
+    assert "git fetch" in caplog.text
+    assert "failed" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1003,7 +1004,8 @@ async def test_clone_repository_no_branch_logs_stderr_on_failure(mock_git_repo_b
         )
 
     assert "403" in caplog.text
-    assert "git clone failed" in caplog.text
+    assert "git clone" in caplog.text
+    assert "failed" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1052,7 +1054,8 @@ async def test_fetch_branch_logs_stderr_on_failure(mock_git_repo_basepath, caplo
         )
 
     assert "remote ref" in caplog.text
-    assert "git fetch failed" in caplog.text
+    assert "git fetch" in caplog.text
+    assert "failed" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1075,4 +1078,5 @@ async def test_push_logs_stderr_on_failure(caplog):
         )
 
     assert "failed to push" in caplog.text
-    assert "git push failed" in caplog.text
+    assert "git push" in caplog.text
+    assert "failed" in caplog.text

--- a/ymir/tools/privileged/utils.py
+++ b/ymir/tools/privileged/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import re
 import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -9,6 +10,12 @@ logger = logging.getLogger(__name__)
 
 
 REPO_CLEANUP_DAYS = 7
+
+
+def sanitize_url(text: str) -> str:
+    """Remove oauth2:{token}@ credentials from URLs in error messages."""
+    return re.sub(r"oauth2:[^@\s]+@", "oauth2:***@", text)
+
 
 APPLICABILITY_DIR = "applicability"
 MERGE_REQUESTS_DIR = "merge_requests"


### PR DESCRIPTION
`CloneRepositoryTool`, `FetchBranchTool`, and `PushToRemoteRepositoryTool` had zero logging — stderr was silently discarded and `ToolError` messages contained no git output, making it impossible to diagnose GitHub throttling or GitLab failures from traces.
### Changes
- **Capture stderr on all git subprocess calls** — `returncode, _, _` → `returncode, _, stderr` for init, fetch, checkout, clone, and push
- **Log timing and context** — each network operation logs the sanitized URL, branch, and elapsed time on both success and failure
- **Include stderr in `ToolError`** — failures now surface the last 500 chars of sanitized git stderr in the error message, so it appears in traces and Jira comments
- **`_git_subprocess_error` helper** — shared function that sanitizes credentials, logs at ERROR level, and builds the `ToolError` with a stderr hint
- **Move `sanitize_url` to `privileged/utils.py`** — extracted from `distgit.py` so both `distgit.py` and `gitlab.py` can use it
