### PR TITLE
Fix show-queue targets to display all queued issues

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -12,16 +12,16 @@ TAC := $(shell command -v tac 2>/dev/null || echo "tail -r")
 # agents' BRPOP), oldest-first to match pop order.
 define show_queue
 @echo "=== $(1)_todo (ymir_todo, priority — popped first) ==="
-@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1)_todo 0 -1 | jq -r '.metadata.issue // empty' | $(TAC)
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1)_todo 0 -1 | jq -r '.metadata.jira_issue // .metadata.issue // empty' | $(TAC)
 @echo
 @echo "=== $(1) (normal) ==="
-@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '.metadata.issue // empty' | $(TAC)
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '.metadata.jira_issue // .metadata.issue // empty' | $(TAC)
 endef
 
 # Dump a single input queue (one with no priority twin), oldest-first.
 define show_single_queue
 @echo "=== $(1) ==="
-@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '.metadata.issue // empty' | $(TAC)
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '.metadata.jira_issue // .metadata.issue // empty' | $(TAC)
 endef
 
 deploy:

--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -12,16 +12,16 @@ TAC := $(shell command -v tac 2>/dev/null || echo "tail -r")
 # agents' BRPOP), oldest-first to match pop order.
 define show_queue
 @echo "=== $(1)_todo (ymir_todo, priority — popped first) ==="
-@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1)_todo 0 -1 | jq -r '.metadata.jira_issue // .metadata.issue // empty' | $(TAC)
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1)_todo 0 -1 | jq -r '(.metadata.jira_issue // .metadata.issue // empty) | if type=="object" then (.key // empty) else . end' | $(TAC)
 @echo
 @echo "=== $(1) (normal) ==="
-@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '.metadata.jira_issue // .metadata.issue // empty' | $(TAC)
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '(.metadata.jira_issue // .metadata.issue // empty) | if type=="object" then (.key // empty) else . end' | $(TAC)
 endef
 
 # Dump a single input queue (one with no priority twin), oldest-first.
 define show_single_queue
 @echo "=== $(1) ==="
-@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '.metadata.jira_issue // .metadata.issue // empty' | $(TAC)
+@oc exec deployment/valkey -- valkey-cli --raw LRANGE $(1) 0 -1 | jq -r '(.metadata.jira_issue // .metadata.issue // empty) | if type=="object" then (.key // empty) else . end' | $(TAC)
 endef
 
 deploy:


### PR DESCRIPTION
The jq filter used `.metadata.issue` but downstream agents (rebase, backport, rebuild) populate `.metadata.jira_issue` instead. Tasks from triage used `.issue`, making the filter silently drop every post-triage queue entry.

Check both fields so all items are visible regardless of which agent enqueued them.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>