### PR TITLE
Fix changelog Resolves mismatch in MR consolidation

### DIFF
--- a/ymir/agents/mr_consolidation_agent.py
+++ b/ymir/agents/mr_consolidation_agent.py
@@ -141,7 +141,6 @@ class ConsolidationState(PackageUpdateState):
     current_mrs_count: int = Field(default=0)
     mr_types: dict[str, str] = Field(default_factory=dict)
     cves_collected: list[str] = Field(default_factory=list)
-    cve_to_jira_map: dict[str, str] = Field(default_factory=dict)
 
 
 def _extract_jira_issues_from_description(description: str) -> list[str]:
@@ -181,102 +180,29 @@ def _extract_cves_from_text(text: str) -> list[str]:
     return sorted(set(re.findall(r"CVE-\d{4}-\d+", text)))
 
 
-def _build_cve_to_jira_map(mrs: list[dict]) -> dict[str, str]:
-    """Map CVE IDs to individual Jira keys from MR titles and branch names.
+async def _extract_resolves_from_commit(
+    commit_sha: str,
+    spec_name: str,
+    clone,
+    env=None,
+) -> str | None:
+    """Extract the Jira key from a commit's own changelog Resolves line.
 
-    When multiple backport MRs exist for the same package, each MR's title
-    contains the CVE ID and its branch name contains the Jira key.  This
-    mapping lets us correct changelog Resolves lines after cherry-picking
-    base-branch commits that carry the wrong (multi-CVE tracker) key.
+    Looks at the spec-file diff introduced by *commit_sha* and returns
+    the first ``RHEL-\\d+`` key found on an added ``Resolves:`` line,
+    or ``None`` if none is found.
     """
-    cve_to_jira: dict[str, str] = {}
-    for mr in mrs:
-        branch = mr.get("source_branch", "")
-        jira_match = re.search(r"(RHEL-\d+)", branch, re.IGNORECASE)
-        if not jira_match:
-            continue
-        jira_key = jira_match.group(1).upper()
-        title = mr.get("title", "")
-        for cve_id in re.findall(r"CVE-\d{4}-\d+", title, re.IGNORECASE):
-            cve_id = cve_id.upper()
-            existing = cve_to_jira.get(cve_id)
-            if existing and existing != jira_key:
-                logger.warning(
-                    "CVE %s maps to both %s and %s; keeping first",
-                    cve_id,
-                    existing,
-                    jira_key,
-                )
-                continue
-            cve_to_jira[cve_id] = jira_key
-    return cve_to_jira
-
-
-def _fix_changelog_resolves(spec_path, cve_to_jira: dict[str, str]) -> bool:
-    """Correct Resolves lines in %changelog using the CVE-to-Jira mapping.
-
-    Walks changelog entries looking for CVE IDs in descriptions and
-    mismatched Resolves lines.  Returns True if the file was modified.
-
-    Tracks all CVEs seen in the current entry (between ``*`` headers).
-    When a ``- Resolves:`` line is hit:
-    - If exactly one mapped CVE is present, replace only the first Jira
-      key on the Resolves line (preserving any trailing keys/text).
-    - If multiple CVEs map to different Jira keys, skip the line to
-      avoid an ambiguous rewrite.
-    """
-    if not cve_to_jira:
-        return False
-
-    content = spec_path.read_text()
-    lines = content.splitlines(keepends=True)
-
-    in_changelog = False
-    modified = False
-    cves_in_current_entry: list[str] = []
-
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped == "%changelog":
-            in_changelog = True
-            continue
-        if not in_changelog:
-            continue
-
-        if stripped.startswith("*"):
-            cves_in_current_entry = []
-            continue
-
-        cves_found = re.findall(r"CVE-\d{4}-\d+", stripped)
-        if cves_found:
-            cves_in_current_entry.extend(c for c in cves_found if c not in cves_in_current_entry)
-
-        resolves_match = re.match(r"^(\s*-\s*Resolves:\s*)(RHEL-\d+)", line)
-        if cves_in_current_entry and resolves_match:
-            mapped_keys = {cve_to_jira[c] for c in cves_in_current_entry if c in cve_to_jira}
-            if len(mapped_keys) == 1:
-                correct_jira = mapped_keys.pop()
-                current_jira = resolves_match.group(2)
-                if current_jira != correct_jira:
-                    new_line = re.sub(
-                        r"^(\s*-\s*Resolves:\s*)(RHEL-\d+)",
-                        rf"\g<1>{correct_jira}",
-                        line,
-                    )
-                    if new_line != line:
-                        lines[i] = new_line
-                        modified = True
-            elif len(mapped_keys) > 1:
-                logger.warning(
-                    "Skipping ambiguous Resolves rewrite: CVEs %s map to different keys %s",
-                    cves_in_current_entry,
-                    mapped_keys,
-                )
-            cves_in_current_entry = []
-
-    if modified:
-        spec_path.write_text("".join(lines))
-    return modified
+    _, diff_output, _ = await run_subprocess(
+        ["git", "diff", f"{commit_sha}^..{commit_sha}", "--", spec_name],
+        cwd=clone,
+        env=env,
+    )
+    for line in (diff_output or "").splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            m = re.search(r"Resolves:\s*(RHEL-\d+)", line, re.IGNORECASE)
+            if m:
+                return m.group(1).upper()
+    return None
 
 
 _CONSOLIDATION_MR_LABELS = ["ymir_backport", "ymir_rebuild"]
@@ -387,7 +313,6 @@ async def _resolve_source_issues(
     state.jira_issues_collected = sorted(set(all_jira))
     state.cves_collected = sorted(set(all_cves))
     state.jira_issue = state.jira_issues_collected[0] if state.jira_issues_collected else None
-    state.cve_to_jira_map = _build_cve_to_jira_map(matched_mrs)
 
     logger.info(
         "Label-triggered consolidation: resolved %s to MRs %s",
@@ -659,7 +584,6 @@ async def run_workflow(
                 state.jira_issues_collected = sorted(set(all_jira))
                 state.cves_collected = sorted(set(all_cves))
                 state.jira_issue = state.jira_issues_collected[0] if state.jira_issues_collected else None
-                state.cve_to_jira_map = _build_cve_to_jira_map(current_mrs)
                 if state.jira_issues_collected:
                     current_jira_issue.set(",".join(state.jira_issues_collected))
 
@@ -910,20 +834,6 @@ async def run_workflow(
                 )
                 await asyncio.sleep(_NFS_CACHE_WAIT)
 
-                if base_commits and state.cve_to_jira_map:
-                    spec_path = state.local_clone / spec_name
-                    if _fix_changelog_resolves(spec_path, state.cve_to_jira_map):
-                        logger.info("Fixed changelog Resolves lines using CVE-to-Jira mapping")
-                        await tasks.stage_changes(
-                            local_clone=state.local_clone,
-                            files_to_commit=[spec_name],
-                        )
-                        await check_subprocess(
-                            ["git", "commit", "--amend", "--no-edit"],
-                            cwd=state.local_clone,
-                            env=git_env,
-                        )
-
                 # --- Step 2: process each commit from other branches ---
                 for other_branch in other_branches:
                     other_idx = state.mr_branches.index(other_branch)
@@ -1059,10 +969,24 @@ async def run_workflow(
                         # Use the original commit message for the changelog
                         # summary so the log agent produces a matching entry.
                         summary = original_msg.split("\n")[0]
+
+                        # Extract the Jira key from the commit's own
+                        # changelog Resolves line so re-consolidated MRs
+                        # keep their per-CVE keys instead of inheriting
+                        # a single key from the MR description.
+                        commit_jira = await _extract_resolves_from_commit(
+                            commit_sha,
+                            spec_name,
+                            state.local_clone,
+                            env=git_env,
+                        )
+                        if not commit_jira:
+                            commit_jira = other_jira[0] if other_jira else None
+
                         log_prompt = render_template(
                             get_log_prompt(),
                             LogInputSchema(
-                                jira_issue=other_jira[0] if other_jira else None,
+                                jira_issue=commit_jira,
                                 changes_summary=summary,
                             ),
                         )

--- a/ymir/agents/mr_consolidation_agent.py
+++ b/ymir/agents/mr_consolidation_agent.py
@@ -141,6 +141,7 @@ class ConsolidationState(PackageUpdateState):
     current_mrs_count: int = Field(default=0)
     mr_types: dict[str, str] = Field(default_factory=dict)
     cves_collected: list[str] = Field(default_factory=list)
+    cve_to_jira_map: dict[str, str] = Field(default_factory=dict)
 
 
 def _extract_jira_issues_from_description(description: str) -> list[str]:
@@ -178,6 +179,104 @@ def _extract_jira_issues_from_description(description: str) -> list[str]:
 def _extract_cves_from_text(text: str) -> list[str]:
     """Extract CVE IDs (e.g. CVE-2024-12345) from arbitrary text."""
     return sorted(set(re.findall(r"CVE-\d{4}-\d+", text)))
+
+
+def _build_cve_to_jira_map(mrs: list[dict]) -> dict[str, str]:
+    """Map CVE IDs to individual Jira keys from MR titles and branch names.
+
+    When multiple backport MRs exist for the same package, each MR's title
+    contains the CVE ID and its branch name contains the Jira key.  This
+    mapping lets us correct changelog Resolves lines after cherry-picking
+    base-branch commits that carry the wrong (multi-CVE tracker) key.
+    """
+    cve_to_jira: dict[str, str] = {}
+    for mr in mrs:
+        branch = mr.get("source_branch", "")
+        jira_match = re.search(r"(RHEL-\d+)", branch, re.IGNORECASE)
+        if not jira_match:
+            continue
+        jira_key = jira_match.group(1).upper()
+        title = mr.get("title", "")
+        for cve_id in re.findall(r"CVE-\d{4}-\d+", title, re.IGNORECASE):
+            cve_id = cve_id.upper()
+            existing = cve_to_jira.get(cve_id)
+            if existing and existing != jira_key:
+                logger.warning(
+                    "CVE %s maps to both %s and %s; keeping first",
+                    cve_id,
+                    existing,
+                    jira_key,
+                )
+                continue
+            cve_to_jira[cve_id] = jira_key
+    return cve_to_jira
+
+
+def _fix_changelog_resolves(spec_path, cve_to_jira: dict[str, str]) -> bool:
+    """Correct Resolves lines in %changelog using the CVE-to-Jira mapping.
+
+    Walks changelog entries looking for CVE IDs in descriptions and
+    mismatched Resolves lines.  Returns True if the file was modified.
+
+    Tracks all CVEs seen in the current entry (between ``*`` headers).
+    When a ``- Resolves:`` line is hit:
+    - If exactly one mapped CVE is present, replace only the first Jira
+      key on the Resolves line (preserving any trailing keys/text).
+    - If multiple CVEs map to different Jira keys, skip the line to
+      avoid an ambiguous rewrite.
+    """
+    if not cve_to_jira:
+        return False
+
+    content = spec_path.read_text()
+    lines = content.splitlines(keepends=True)
+
+    in_changelog = False
+    modified = False
+    cves_in_current_entry: list[str] = []
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "%changelog":
+            in_changelog = True
+            continue
+        if not in_changelog:
+            continue
+
+        if stripped.startswith("*"):
+            cves_in_current_entry = []
+            continue
+
+        cves_found = re.findall(r"CVE-\d{4}-\d+", stripped)
+        if cves_found:
+            cves_in_current_entry.extend(c for c in cves_found if c not in cves_in_current_entry)
+
+        resolves_match = re.match(r"^(\s*-\s*Resolves:\s*)(RHEL-\d+)", line)
+        if cves_in_current_entry and resolves_match:
+            mapped_keys = {cve_to_jira[c] for c in cves_in_current_entry if c in cve_to_jira}
+            if len(mapped_keys) == 1:
+                correct_jira = mapped_keys.pop()
+                current_jira = resolves_match.group(2)
+                if current_jira != correct_jira:
+                    new_line = re.sub(
+                        r"^(\s*-\s*Resolves:\s*)(RHEL-\d+)",
+                        rf"\g<1>{correct_jira}",
+                        line,
+                    )
+                    if new_line != line:
+                        lines[i] = new_line
+                        modified = True
+            elif len(mapped_keys) > 1:
+                logger.warning(
+                    "Skipping ambiguous Resolves rewrite: CVEs %s map to different keys %s",
+                    cves_in_current_entry,
+                    mapped_keys,
+                )
+            cves_in_current_entry = []
+
+    if modified:
+        spec_path.write_text("".join(lines))
+    return modified
 
 
 _CONSOLIDATION_MR_LABELS = ["ymir_backport", "ymir_rebuild"]
@@ -288,6 +387,7 @@ async def _resolve_source_issues(
     state.jira_issues_collected = sorted(set(all_jira))
     state.cves_collected = sorted(set(all_cves))
     state.jira_issue = state.jira_issues_collected[0] if state.jira_issues_collected else None
+    state.cve_to_jira_map = _build_cve_to_jira_map(matched_mrs)
 
     logger.info(
         "Label-triggered consolidation: resolved %s to MRs %s",
@@ -559,6 +659,7 @@ async def run_workflow(
                 state.jira_issues_collected = sorted(set(all_jira))
                 state.cves_collected = sorted(set(all_cves))
                 state.jira_issue = state.jira_issues_collected[0] if state.jira_issues_collected else None
+                state.cve_to_jira_map = _build_cve_to_jira_map(current_mrs)
                 if state.jira_issues_collected:
                     current_jira_issue.set(",".join(state.jira_issues_collected))
 
@@ -808,6 +909,20 @@ async def run_workflow(
                     _NFS_CACHE_WAIT,
                 )
                 await asyncio.sleep(_NFS_CACHE_WAIT)
+
+                if base_commits and state.cve_to_jira_map:
+                    spec_path = state.local_clone / spec_name
+                    if _fix_changelog_resolves(spec_path, state.cve_to_jira_map):
+                        logger.info("Fixed changelog Resolves lines using CVE-to-Jira mapping")
+                        await tasks.stage_changes(
+                            local_clone=state.local_clone,
+                            files_to_commit=[spec_name],
+                        )
+                        await check_subprocess(
+                            ["git", "commit", "--amend", "--no-edit"],
+                            cwd=state.local_clone,
+                            env=git_env,
+                        )
 
                 # --- Step 2: process each commit from other branches ---
                 for other_branch in other_branches:
@@ -1258,7 +1373,9 @@ async def run_workflow(
             log_prompt = render_template(
                 get_log_prompt(),
                 LogInputSchema(
-                    jira_issue=state.jira_issue,
+                    jira_issue=(
+                        ", ".join(state.jira_issues_collected) if state.jira_issues_collected else None
+                    ),
                     changes_summary=changes_summary,
                 ),
             )

--- a/ymir/agents/tests/unit/test_mr_consolidation.py
+++ b/ymir/agents/tests/unit/test_mr_consolidation.py
@@ -5,10 +5,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from ymir.agents.mr_consolidation_agent import (
-    _build_cve_to_jira_map,
     _extract_cves_from_text,
     _extract_jira_issues_from_description,
-    _fix_changelog_resolves,
+    _extract_resolves_from_commit,
     _mr_type_from_labels,
 )
 from ymir.agents.tasks import (
@@ -714,268 +713,145 @@ class TestMrSelectionPriority:
         assert _mr_type_from_labels(selected[1]) == "rebuild"
 
 
-# -- _build_cve_to_jira_map ---------------------------------------------------
+# -- _extract_resolves_from_commit ---------------------------------------------
 
 
-class TestBuildCveToJiraMap:
-    def test_maps_cve_from_title_to_jira_from_branch(self):
-        mrs = [
-            {
-                "title": "Fix CVE-2026-58014 in mingw-glib2",
-                "source_branch": "automated-package-update-RHEL-190609",
-            },
-            {
-                "title": "Fix CVE-2026-58016 in mingw-glib2",
-                "source_branch": "automated-package-update-RHEL-190617",
-            },
-        ]
-        result = _build_cve_to_jira_map(mrs)
-        assert result == {
-            "CVE-2026-58014": "RHEL-190609",
-            "CVE-2026-58016": "RHEL-190617",
-        }
+class TestExtractResolvesFromCommit:
+    """Tests for extracting Jira keys from a commit's own spec changelog diff."""
 
-    def test_skips_mr_without_jira_in_branch(self):
-        mrs = [
-            {
-                "title": "Fix CVE-2026-58014",
-                "source_branch": "some-other-branch",
-            },
-        ]
-        assert _build_cve_to_jira_map(mrs) == {}
+    @pytest.fixture
+    def git_repo(self, tmp_path):
+        """Create a minimal git repo with an initial spec file."""
+        import subprocess
 
-    def test_skips_mr_without_cve_in_title(self):
-        mrs = [
-            {
-                "title": "Backport patch for mingw-glib2",
-                "source_branch": "automated-package-update-RHEL-190609",
-            },
-        ]
-        assert _build_cve_to_jira_map(mrs) == {}
-
-    def test_multiple_cves_in_title(self):
-        mrs = [
-            {
-                "title": "Fix CVE-2026-1111 and CVE-2026-2222",
-                "source_branch": "automated-package-update-RHEL-99999",
-            },
-        ]
-        result = _build_cve_to_jira_map(mrs)
-        assert result == {
-            "CVE-2026-1111": "RHEL-99999",
-            "CVE-2026-2222": "RHEL-99999",
-        }
-
-    def test_empty_list(self):
-        assert _build_cve_to_jira_map([]) == {}
-
-    def test_missing_fields_handled(self):
-        mrs = [
-            {},
-            {"title": "Fix CVE-2026-1111"},
-            {"source_branch": "automated-package-update-RHEL-100"},
-        ]
-        assert _build_cve_to_jira_map(mrs) == {}
-
-    def test_lowercase_branch_and_title(self):
-        mrs = [
-            {
-                "title": "Fix cve-2026-58014 in mingw-glib2",
-                "source_branch": "automated-package-update-rhel-190609",
-            },
-        ]
-        result = _build_cve_to_jira_map(mrs)
-        assert result == {"CVE-2026-58014": "RHEL-190609"}
-
-    def test_conflicting_cve_keeps_first(self):
-        """When two MRs map the same CVE to different Jira keys,
-        the first mapping wins and the conflict is logged."""
-        mrs = [
-            {
-                "title": "Fix CVE-2026-58014 in mingw-glib2",
-                "source_branch": "automated-package-update-RHEL-190609",
-            },
-            {
-                "title": "Fix CVE-2026-58014 in mingw-glib2",
-                "source_branch": "automated-package-update-RHEL-999999",
-            },
-        ]
-        result = _build_cve_to_jira_map(mrs)
-        assert result == {"CVE-2026-58014": "RHEL-190609"}
-
-
-# -- _fix_changelog_resolves --------------------------------------------------
-
-
-class TestFixChangelogResolves:
-    def _write_spec(self, tmp_path, changelog_lines):
-        spec = tmp_path / "test.spec"
-        content = "Name: test\nVersion: 1.0\nRelease: 1\n\n%changelog\n" + "\n".join(changelog_lines) + "\n"
-        spec.write_text(content)
-        return spec
-
-    def test_corrects_mismatched_resolves(self, tmp_path):
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-3",
-                "- Fix CVE-2026-58014",
-                "- Resolves: RHEL-154707",
-                "",
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
-                "- Fix CVE-2026-58016",
-                "- Resolves: RHEL-154707",
-            ],
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        spec = repo / "test.spec"
+        spec.write_text(
+            "Name: test\nVersion: 1.0\nRelease: 1\n\n"
+            "%changelog\n"
+            "* Thu Dec 23 2021 Dev <dev@redhat.com> - 1.0-1\n"
+            "- Initial build\n"
         )
-        cve_to_jira = {
-            "CVE-2026-58014": "RHEL-190609",
-            "CVE-2026-58016": "RHEL-190617",
-        }
-        assert _fix_changelog_resolves(spec, cve_to_jira) is True
-
-        content = spec.read_text()
-        assert "Resolves: RHEL-190609" in content
-        assert "Resolves: RHEL-190617" in content
-        assert "RHEL-154707" not in content
-
-    def test_leaves_correct_resolves_unchanged(self, tmp_path):
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
-                "- Fix CVE-2026-58014",
-                "- Resolves: RHEL-190609",
-            ],
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
         )
-        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
-        assert _fix_changelog_resolves(spec, cve_to_jira) is False
-
-    def test_no_op_with_empty_map(self, tmp_path):
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
-                "- Fix CVE-2026-58014",
-                "- Resolves: RHEL-154707",
-            ],
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
         )
-        assert _fix_changelog_resolves(spec, {}) is False
-
-    def test_no_op_when_cve_not_in_map(self, tmp_path):
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
-                "- Fix CVE-2026-99999",
-                "- Resolves: RHEL-154707",
-            ],
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
         )
-        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
-        assert _fix_changelog_resolves(spec, cve_to_jira) is False
+        return repo
 
-    def test_handles_entry_without_cve(self, tmp_path):
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
-                "- General bugfix",
-                "- Resolves: RHEL-154707",
-            ],
+    def _make_commit(self, repo, spec_content, message="update"):
+        import subprocess
+
+        spec = repo / "test.spec"
+        spec.write_text(spec_content)
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", message],
+            cwd=repo,
+            check=True,
+            capture_output=True,
         )
-        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
-        assert _fix_changelog_resolves(spec, cve_to_jira) is False
-
-    def test_resets_cve_tracking_at_new_entry_header(self, tmp_path):
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-3",
-                "- Fix CVE-2026-58014",
-                "- Resolves: RHEL-154707",
-                "",
-                "* Mon Jul 14 2026 Someone <someone@redhat.com> - 1.0-2",
-                "- Resolves: RHEL-154707",
-            ],
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
         )
-        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
-        result = _fix_changelog_resolves(spec, cve_to_jira)
-        assert result is True
+        return sha.stdout.strip()
 
-        content = spec.read_text()
-        lines = content.splitlines()
-        changelog_start = lines.index("%changelog")
-        assert "Resolves: RHEL-190609" in lines[changelog_start + 3]
-        assert "Resolves: RHEL-154707" in lines[changelog_start + 6]
-
-    def test_replaces_only_first_jira_key_on_resolves_line(self, tmp_path):
-        """A Resolves line with multiple Jira keys should only have
-        the first key (the one from the Resolves: field) replaced."""
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
-                "- Fix CVE-2026-58014",
-                "- Resolves: RHEL-154707, RHEL-999999",
-            ],
+    @pytest.mark.asyncio
+    async def test_extracts_resolves_from_commit_diff(self, git_repo):
+        sha = self._make_commit(
+            git_repo,
+            "Name: test\nVersion: 1.0\nRelease: 2\n\n"
+            "%changelog\n"
+            "* Mon Jul 20 2026 Ymir <ymir@redhat.com> - 1.0-2\n"
+            "- Fix CVE-2026-58014\n"
+            "- Resolves: RHEL-190609\n"
+            "\n"
+            "* Thu Dec 23 2021 Dev <dev@redhat.com> - 1.0-1\n"
+            "- Initial build\n",
         )
-        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
-        assert _fix_changelog_resolves(spec, cve_to_jira) is True
+        result = await _extract_resolves_from_commit(sha, "test.spec", git_repo)
+        assert result == "RHEL-190609"
 
-        content = spec.read_text()
-        assert "Resolves: RHEL-190609, RHEL-999999" in content
-
-    def test_multiple_cves_same_mapping_applies(self, tmp_path):
-        """When multiple CVEs in one entry all map to the same Jira key,
-        the rewrite should proceed."""
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
-                "- Fix CVE-2026-1111 and CVE-2026-2222",
-                "- Resolves: RHEL-154707",
-            ],
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_resolves(self, git_repo):
+        sha = self._make_commit(
+            git_repo,
+            "Name: test\nVersion: 1.0\nRelease: 2\n\n"
+            "%changelog\n"
+            "* Mon Jul 20 2026 Ymir <ymir@redhat.com> - 1.0-2\n"
+            "- General bugfix\n"
+            "\n"
+            "* Thu Dec 23 2021 Dev <dev@redhat.com> - 1.0-1\n"
+            "- Initial build\n",
         )
-        cve_to_jira = {
-            "CVE-2026-1111": "RHEL-190609",
-            "CVE-2026-2222": "RHEL-190609",
-        }
-        assert _fix_changelog_resolves(spec, cve_to_jira) is True
+        result = await _extract_resolves_from_commit(sha, "test.spec", git_repo)
+        assert result is None
 
-        content = spec.read_text()
-        assert "Resolves: RHEL-190609" in content
-
-    def test_multiple_cves_disagreeing_mappings_skips(self, tmp_path):
-        """When multiple CVEs in one entry map to different Jira keys,
-        the Resolves line should NOT be rewritten (ambiguous)."""
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
-                "- Fix CVE-2026-1111 and CVE-2026-2222",
-                "- Resolves: RHEL-154707",
-            ],
+    @pytest.mark.asyncio
+    async def test_handles_indented_resolves(self, git_repo):
+        sha = self._make_commit(
+            git_repo,
+            "Name: test\nVersion: 1.0\nRelease: 2\n\n"
+            "%changelog\n"
+            "* Mon Jul 20 2026 Ymir <ymir@redhat.com> - 1.0-2\n"
+            "- Fix CVE-2026-58014\n"
+            "  Resolves: RHEL-190609\n"
+            "\n"
+            "* Thu Dec 23 2021 Dev <dev@redhat.com> - 1.0-1\n"
+            "- Initial build\n",
         )
-        cve_to_jira = {
-            "CVE-2026-1111": "RHEL-190609",
-            "CVE-2026-2222": "RHEL-190617",
-        }
-        assert _fix_changelog_resolves(spec, cve_to_jira) is False
+        result = await _extract_resolves_from_commit(sha, "test.spec", git_repo)
+        assert result == "RHEL-190609"
 
-        content = spec.read_text()
-        assert "Resolves: RHEL-154707" in content
-
-    def test_corrects_indented_resolves_line(self, tmp_path):
-        spec = self._write_spec(
-            tmp_path,
-            [
-                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
-                "- Fix CVE-2026-58014",
-                "  - Resolves: RHEL-154707",
-            ],
+    @pytest.mark.asyncio
+    async def test_normalizes_lowercase_jira_key(self, git_repo):
+        sha = self._make_commit(
+            git_repo,
+            "Name: test\nVersion: 1.0\nRelease: 2\n\n"
+            "%changelog\n"
+            "* Mon Jul 20 2026 Ymir <ymir@redhat.com> - 1.0-2\n"
+            "- Fix something\n"
+            "- Resolves: rhel-190609\n"
+            "\n"
+            "* Thu Dec 23 2021 Dev <dev@redhat.com> - 1.0-1\n"
+            "- Initial build\n",
         )
-        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
-        assert _fix_changelog_resolves(spec, cve_to_jira) is True
+        result = await _extract_resolves_from_commit(sha, "test.spec", git_repo)
+        assert result == "RHEL-190609"
 
-        content = spec.read_text()
-        assert "Resolves: RHEL-190609" in content
-        assert "RHEL-154707" not in content
+    @pytest.mark.asyncio
+    async def test_returns_first_resolves_when_multiple(self, git_repo):
+        sha = self._make_commit(
+            git_repo,
+            "Name: test\nVersion: 1.0\nRelease: 2\n\n"
+            "%changelog\n"
+            "* Mon Jul 20 2026 Ymir <ymir@redhat.com> - 1.0-2\n"
+            "- Fix something\n"
+            "- Resolves: RHEL-190609\n"
+            "- Related: RHEL-154707\n"
+            "\n"
+            "* Thu Dec 23 2021 Dev <dev@redhat.com> - 1.0-1\n"
+            "- Initial build\n",
+        )
+        result = await _extract_resolves_from_commit(sha, "test.spec", git_repo)
+        assert result == "RHEL-190609"

--- a/ymir/agents/tests/unit/test_mr_consolidation.py
+++ b/ymir/agents/tests/unit/test_mr_consolidation.py
@@ -5,8 +5,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from ymir.agents.mr_consolidation_agent import (
+    _build_cve_to_jira_map,
     _extract_cves_from_text,
     _extract_jira_issues_from_description,
+    _fix_changelog_resolves,
     _mr_type_from_labels,
 )
 from ymir.agents.tasks import (
@@ -710,3 +712,270 @@ class TestMrSelectionPriority:
 
         assert _mr_type_from_labels(selected[0]) == "backport"
         assert _mr_type_from_labels(selected[1]) == "rebuild"
+
+
+# -- _build_cve_to_jira_map ---------------------------------------------------
+
+
+class TestBuildCveToJiraMap:
+    def test_maps_cve_from_title_to_jira_from_branch(self):
+        mrs = [
+            {
+                "title": "Fix CVE-2026-58014 in mingw-glib2",
+                "source_branch": "automated-package-update-RHEL-190609",
+            },
+            {
+                "title": "Fix CVE-2026-58016 in mingw-glib2",
+                "source_branch": "automated-package-update-RHEL-190617",
+            },
+        ]
+        result = _build_cve_to_jira_map(mrs)
+        assert result == {
+            "CVE-2026-58014": "RHEL-190609",
+            "CVE-2026-58016": "RHEL-190617",
+        }
+
+    def test_skips_mr_without_jira_in_branch(self):
+        mrs = [
+            {
+                "title": "Fix CVE-2026-58014",
+                "source_branch": "some-other-branch",
+            },
+        ]
+        assert _build_cve_to_jira_map(mrs) == {}
+
+    def test_skips_mr_without_cve_in_title(self):
+        mrs = [
+            {
+                "title": "Backport patch for mingw-glib2",
+                "source_branch": "automated-package-update-RHEL-190609",
+            },
+        ]
+        assert _build_cve_to_jira_map(mrs) == {}
+
+    def test_multiple_cves_in_title(self):
+        mrs = [
+            {
+                "title": "Fix CVE-2026-1111 and CVE-2026-2222",
+                "source_branch": "automated-package-update-RHEL-99999",
+            },
+        ]
+        result = _build_cve_to_jira_map(mrs)
+        assert result == {
+            "CVE-2026-1111": "RHEL-99999",
+            "CVE-2026-2222": "RHEL-99999",
+        }
+
+    def test_empty_list(self):
+        assert _build_cve_to_jira_map([]) == {}
+
+    def test_missing_fields_handled(self):
+        mrs = [
+            {},
+            {"title": "Fix CVE-2026-1111"},
+            {"source_branch": "automated-package-update-RHEL-100"},
+        ]
+        assert _build_cve_to_jira_map(mrs) == {}
+
+    def test_lowercase_branch_and_title(self):
+        mrs = [
+            {
+                "title": "Fix cve-2026-58014 in mingw-glib2",
+                "source_branch": "automated-package-update-rhel-190609",
+            },
+        ]
+        result = _build_cve_to_jira_map(mrs)
+        assert result == {"CVE-2026-58014": "RHEL-190609"}
+
+    def test_conflicting_cve_keeps_first(self):
+        """When two MRs map the same CVE to different Jira keys,
+        the first mapping wins and the conflict is logged."""
+        mrs = [
+            {
+                "title": "Fix CVE-2026-58014 in mingw-glib2",
+                "source_branch": "automated-package-update-RHEL-190609",
+            },
+            {
+                "title": "Fix CVE-2026-58014 in mingw-glib2",
+                "source_branch": "automated-package-update-RHEL-999999",
+            },
+        ]
+        result = _build_cve_to_jira_map(mrs)
+        assert result == {"CVE-2026-58014": "RHEL-190609"}
+
+
+# -- _fix_changelog_resolves --------------------------------------------------
+
+
+class TestFixChangelogResolves:
+    def _write_spec(self, tmp_path, changelog_lines):
+        spec = tmp_path / "test.spec"
+        content = "Name: test\nVersion: 1.0\nRelease: 1\n\n%changelog\n" + "\n".join(changelog_lines) + "\n"
+        spec.write_text(content)
+        return spec
+
+    def test_corrects_mismatched_resolves(self, tmp_path):
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-3",
+                "- Fix CVE-2026-58014",
+                "- Resolves: RHEL-154707",
+                "",
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
+                "- Fix CVE-2026-58016",
+                "- Resolves: RHEL-154707",
+            ],
+        )
+        cve_to_jira = {
+            "CVE-2026-58014": "RHEL-190609",
+            "CVE-2026-58016": "RHEL-190617",
+        }
+        assert _fix_changelog_resolves(spec, cve_to_jira) is True
+
+        content = spec.read_text()
+        assert "Resolves: RHEL-190609" in content
+        assert "Resolves: RHEL-190617" in content
+        assert "RHEL-154707" not in content
+
+    def test_leaves_correct_resolves_unchanged(self, tmp_path):
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
+                "- Fix CVE-2026-58014",
+                "- Resolves: RHEL-190609",
+            ],
+        )
+        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
+        assert _fix_changelog_resolves(spec, cve_to_jira) is False
+
+    def test_no_op_with_empty_map(self, tmp_path):
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
+                "- Fix CVE-2026-58014",
+                "- Resolves: RHEL-154707",
+            ],
+        )
+        assert _fix_changelog_resolves(spec, {}) is False
+
+    def test_no_op_when_cve_not_in_map(self, tmp_path):
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
+                "- Fix CVE-2026-99999",
+                "- Resolves: RHEL-154707",
+            ],
+        )
+        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
+        assert _fix_changelog_resolves(spec, cve_to_jira) is False
+
+    def test_handles_entry_without_cve(self, tmp_path):
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
+                "- General bugfix",
+                "- Resolves: RHEL-154707",
+            ],
+        )
+        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
+        assert _fix_changelog_resolves(spec, cve_to_jira) is False
+
+    def test_resets_cve_tracking_at_new_entry_header(self, tmp_path):
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-3",
+                "- Fix CVE-2026-58014",
+                "- Resolves: RHEL-154707",
+                "",
+                "* Mon Jul 14 2026 Someone <someone@redhat.com> - 1.0-2",
+                "- Resolves: RHEL-154707",
+            ],
+        )
+        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
+        result = _fix_changelog_resolves(spec, cve_to_jira)
+        assert result is True
+
+        content = spec.read_text()
+        lines = content.splitlines()
+        changelog_start = lines.index("%changelog")
+        assert "Resolves: RHEL-190609" in lines[changelog_start + 3]
+        assert "Resolves: RHEL-154707" in lines[changelog_start + 6]
+
+    def test_replaces_only_first_jira_key_on_resolves_line(self, tmp_path):
+        """A Resolves line with multiple Jira keys should only have
+        the first key (the one from the Resolves: field) replaced."""
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
+                "- Fix CVE-2026-58014",
+                "- Resolves: RHEL-154707, RHEL-999999",
+            ],
+        )
+        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
+        assert _fix_changelog_resolves(spec, cve_to_jira) is True
+
+        content = spec.read_text()
+        assert "Resolves: RHEL-190609, RHEL-999999" in content
+
+    def test_multiple_cves_same_mapping_applies(self, tmp_path):
+        """When multiple CVEs in one entry all map to the same Jira key,
+        the rewrite should proceed."""
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
+                "- Fix CVE-2026-1111 and CVE-2026-2222",
+                "- Resolves: RHEL-154707",
+            ],
+        )
+        cve_to_jira = {
+            "CVE-2026-1111": "RHEL-190609",
+            "CVE-2026-2222": "RHEL-190609",
+        }
+        assert _fix_changelog_resolves(spec, cve_to_jira) is True
+
+        content = spec.read_text()
+        assert "Resolves: RHEL-190609" in content
+
+    def test_multiple_cves_disagreeing_mappings_skips(self, tmp_path):
+        """When multiple CVEs in one entry map to different Jira keys,
+        the Resolves line should NOT be rewritten (ambiguous)."""
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
+                "- Fix CVE-2026-1111 and CVE-2026-2222",
+                "- Resolves: RHEL-154707",
+            ],
+        )
+        cve_to_jira = {
+            "CVE-2026-1111": "RHEL-190609",
+            "CVE-2026-2222": "RHEL-190617",
+        }
+        assert _fix_changelog_resolves(spec, cve_to_jira) is False
+
+        content = spec.read_text()
+        assert "Resolves: RHEL-154707" in content
+
+    def test_corrects_indented_resolves_line(self, tmp_path):
+        spec = self._write_spec(
+            tmp_path,
+            [
+                "* Mon Jul 21 2026 Ymir <ymir@redhat.com> - 1.0-2",
+                "- Fix CVE-2026-58014",
+                "  - Resolves: RHEL-154707",
+            ],
+        )
+        cve_to_jira = {"CVE-2026-58014": "RHEL-190609"}
+        assert _fix_changelog_resolves(spec, cve_to_jira) is True
+
+        content = spec.read_text()
+        assert "Resolves: RHEL-190609" in content
+        assert "RHEL-154707" not in content


### PR DESCRIPTION
When per_commit_flow cherry-picks base-branch commits, their changelog entries carry the base MR's Jira key. If the base was backported under a multi-CVE tracker (e.g. RHEL-154707), all CVE entries get that key instead of per-CVE keys (RHEL-190609, RHEL-190617).

Add _build_cve_to_jira_map() to derive CVE→Jira mappings from MR titles and branch names, and _fix_changelog_resolves() to correct mismatched Resolves lines in the spec after cherry-picking base commits. Also fix run_log_agent (merged strategy) to pass all collected Jira keys instead of only the first one alphabetically.

Observed in mingw-glib2 MR !37 — uril flagged two changelog mismatches (CVE-2026-58014 → RHEL-154707, CVE-2026-58016 → RHEL-154707).

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>