### PR TITLE
Fixes for consolidation

### DIFF
--- a/ymir/agents/mr_consolidation_agent.py
+++ b/ymir/agents/mr_consolidation_agent.py
@@ -6,6 +6,7 @@ import re
 import time
 import traceback
 from datetime import timedelta
+from pathlib import Path
 from typing import Any
 
 from beeai_framework.errors import FrameworkError
@@ -143,36 +144,28 @@ class ConsolidationState(PackageUpdateState):
     cves_collected: list[str] = Field(default_factory=list)
 
 
-def _extract_jira_issues_from_description(description: str) -> list[str]:
-    """Extract RHEL-NNNNN Jira issue keys from structured lines in MR descriptions.
+def _files_to_stage_for_patches(
+    local_clone: Path,
+    package: str,
+    original_patches: list[str] | None = None,
+) -> list[str]:
+    """Return paths to stage after patch adaptation.
 
-    Only extracts from:
-    - ``Resolves: RHEL-NNNNN, ...`` lines (backport agent format)
-    - Bullet items under ``### Resolved Jira Issues`` (consolidated MR format)
-
-    Ignores RHEL-NNNNN references in triage detail prose, ``<details>``
-    blocks, and other free-text context to prevent spurious issue collection.
+    Uses the current spec's Patch tags (post-LLM renames) and also includes
+    ``original_patches`` so renames/deletes of pre-adaptation filenames are
+    staged. Raises if the spec references a patch file that is missing on disk.
     """
-    issues: list[str] = []
-
-    for line in description.splitlines():
-        stripped = line.strip()
-        if stripped.startswith(("Resolves:", "Related:")):
-            issues.extend(re.findall(r"RHEL-\d+", stripped))
-
-    in_resolved_section = False
-    for line in description.splitlines():
-        stripped = line.strip()
-        if re.match(r"^#{1,4}\s+Resolved Jira Issues", stripped):
-            in_resolved_section = True
-            continue
-        if in_resolved_section:
-            if stripped.startswith("#") or (stripped and not stripped.startswith("-")):
-                in_resolved_section = False
-                continue
-            issues.extend(re.findall(r"RHEL-\d+", stripped))
-
-    return list(set(issues))
+    spec_name = f"{package}.spec"
+    with Specfile(local_clone / spec_name) as spec:
+        patch_files = [p.expanded_location for p in get_all_patches(spec) if p.expanded_location]
+    missing = [p for p in patch_files if not (local_clone / p).is_file()]
+    if missing:
+        raise RuntimeError(f"Spec references patch file(s) that do not exist: {missing}")
+    files = [spec_name, *patch_files]
+    for old in original_patches or []:
+        if old not in files:
+            files.append(old)
+    return files
 
 
 def _extract_cves_from_cve_footer_lines(text: str) -> list[str]:
@@ -212,23 +205,50 @@ async def _collect_footers_from_branches(
     """Collect CVE and Jira footers from all commits on the given branches.
 
     Returns ``(cves, jira_issues)`` sorted and deduplicated.
+
+    Raises:
+        RuntimeError: If ``git rev-list`` or ``git log`` fails for any branch.
     """
     all_cves: list[str] = []
     all_jira: list[str] = []
     for branch in branches:
-        _, commits_raw, _ = await run_subprocess(
+        exit_code, commits_raw, stderr = await run_subprocess(
             ["git", "rev-list", "--reverse", f"{target}..{branch}"],
             cwd=clone,
             env=env,
         )
+        if exit_code != 0:
+            err_msg = (stderr or "").strip()
+            logger.error(
+                "git rev-list failed for %s..%s (exit %d): %s",
+                target,
+                branch,
+                exit_code,
+                err_msg,
+            )
+            raise RuntimeError(
+                f"git rev-list {target}..{branch} failed (exit {exit_code}): {err_msg}",
+            )
         for sha in (commits_raw or "").strip().splitlines():
             if not sha:
                 continue
-            _, msg, _ = await run_subprocess(
+            exit_code, msg, stderr = await run_subprocess(
                 ["git", "log", "-1", "--format=%B", sha],
                 cwd=clone,
                 env=env,
             )
+            if exit_code != 0:
+                err_msg = (stderr or "").strip()
+                logger.error(
+                    "git log failed for %s on %s (exit %d): %s",
+                    sha[:12],
+                    branch,
+                    exit_code,
+                    err_msg,
+                )
+                raise RuntimeError(
+                    f"git log -1 {sha} failed for branch {branch} (exit {exit_code}): {err_msg}",
+                )
             all_cves.extend(_extract_cves_from_cve_footer_lines(msg or ""))
             all_jira.extend(_extract_jira_issues_from_resolves_footer_lines(msg or ""))
     return sorted(set(all_cves)), sorted(set(all_jira))
@@ -664,12 +684,21 @@ async def run_workflow(
 
             # Collect CVE / Jira from commit footers on all selected branches.
             # This overwrites any seed values and ignores MR descriptions.
-            state.cves_collected, state.jira_issues_collected = await _collect_footers_from_branches(
-                state.local_clone,
-                git_env,
-                dist_git_branch,
-                state.mr_branches,
-            )
+            try:
+                state.cves_collected, state.jira_issues_collected = await _collect_footers_from_branches(
+                    state.local_clone,
+                    git_env,
+                    dist_git_branch,
+                    state.mr_branches,
+                )
+            except RuntimeError as e:
+                logger.error("Failed to collect commit footers: %s", e)
+                state.consolidation_result = MRConsolidationOutputSchema(
+                    success=False,
+                    status="Failed to collect commit footers",
+                    error=str(e),
+                )
+                return "handle_failure"
             state.jira_issue = state.jira_issues_collected[0] if state.jira_issues_collected else None
             if state.jira_issues_collected:
                 current_jira_issue.set(",".join(state.jira_issues_collected))
@@ -1003,8 +1032,12 @@ async def run_workflow(
                             rebase=False,
                         )
 
-                        mr_patches = state.patches_per_mr.get(other_branch, [])
-                        files_to_stage = [spec_name, *mr_patches]
+                        files_to_stage = _files_to_stage_for_patches(
+                            state.local_clone,
+                            package,
+                            original_patches=state.patches_per_mr.get(other_branch, []),
+                        )
+                        logger.info("Staging files: %s", files_to_stage)
                         await tasks.stage_changes(
                             local_clone=state.local_clone,
                             files_to_commit=files_to_stage,
@@ -1300,11 +1333,7 @@ async def run_workflow(
 
         async def stage_changes(state):
             try:
-                spec_path = state.local_clone / f"{package}.spec"
-                with Specfile(spec_path) as spec:
-                    patch_files = [p.expanded_location for p in get_all_patches(spec) if p.expanded_location]
-
-                files_to_stage = [f"{package}.spec", *patch_files]
+                files_to_stage = _files_to_stage_for_patches(state.local_clone, package)
                 logger.info("Staging files: %s", files_to_stage)
                 await tasks.stage_changes(
                     local_clone=state.local_clone,
@@ -1369,7 +1398,8 @@ async def run_workflow(
                 commit_message += f"\n\nResolves: {resolves}"
 
             if state.cves_collected:
-                commit_message += f"\nCVE: {', '.join(state.cves_collected)}"
+                sep = "\n" if state.jira_issues_collected else "\n\n"
+                commit_message += f"{sep}CVE: {', '.join(state.cves_collected)}"
 
             try:
                 exit_code, _, _ = await run_subprocess(

--- a/ymir/agents/mr_consolidation_agent.py
+++ b/ymir/agents/mr_consolidation_agent.py
@@ -175,9 +175,63 @@ def _extract_jira_issues_from_description(description: str) -> list[str]:
     return list(set(issues))
 
 
-def _extract_cves_from_text(text: str) -> list[str]:
-    """Extract CVE IDs (e.g. CVE-2024-12345) from arbitrary text."""
-    return sorted(set(re.findall(r"CVE-\d{4}-\d+", text)))
+def _extract_cves_from_cve_footer_lines(text: str) -> list[str]:
+    """Extract CVE IDs only from lines that start with ``CVE:``.
+
+    Ignores CVE mentions in titles, triage prose, and patch filenames.
+    Supports multi-value footers such as ``CVE: CVE-A, CVE-B``.
+    """
+    cves: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("CVE:"):
+            cves.extend(re.findall(r"CVE-\d{4}-\d+", stripped))
+    return sorted(set(cves))
+
+
+def _extract_jira_issues_from_resolves_footer_lines(text: str) -> list[str]:
+    """Extract RHEL keys only from ``Resolves:`` / ``Related:`` lines.
+
+    Ignores RHEL-* mentions in titles, triage prose, and other free text.
+    Supports multi-value footers such as ``Resolves: RHEL-1, RHEL-2``.
+    """
+    issues: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("Resolves:", "Related:")):
+            issues.extend(re.findall(r"RHEL-\d+", stripped))
+    return sorted(set(issues))
+
+
+async def _collect_footers_from_branches(
+    clone,
+    env,
+    target: str,
+    branches: list[str],
+) -> tuple[list[str], list[str]]:
+    """Collect CVE and Jira footers from all commits on the given branches.
+
+    Returns ``(cves, jira_issues)`` sorted and deduplicated.
+    """
+    all_cves: list[str] = []
+    all_jira: list[str] = []
+    for branch in branches:
+        _, commits_raw, _ = await run_subprocess(
+            ["git", "rev-list", "--reverse", f"{target}..{branch}"],
+            cwd=clone,
+            env=env,
+        )
+        for sha in (commits_raw or "").strip().splitlines():
+            if not sha:
+                continue
+            _, msg, _ = await run_subprocess(
+                ["git", "log", "-1", "--format=%B", sha],
+                cwd=clone,
+                env=env,
+            )
+            all_cves.extend(_extract_cves_from_cve_footer_lines(msg or ""))
+            all_jira.extend(_extract_jira_issues_from_resolves_footer_lines(msg or ""))
+    return sorted(set(all_cves)), sorted(set(all_jira))
 
 
 async def _extract_resolves_from_commit(
@@ -305,15 +359,11 @@ async def _resolve_source_issues(
     state.mr_titles = [mr["title"] for mr in matched_mrs]
     state.mr_descriptions = [mr.get("description", "") for mr in matched_mrs]
     state.mr_types = {mr["source_branch"]: _mr_type_from_labels(mr) for mr in matched_mrs}
-
-    all_jira: list[str] = list(issue_keys)
-    all_cves: list[str] = []
-    for mr in matched_mrs:
-        all_jira.extend(_extract_jira_issues_from_description(mr.get("description", "")))
-        all_cves.extend(_extract_cves_from_text(mr.get("description", "")))
-    state.jira_issues_collected = sorted(set(all_jira))
-    state.cves_collected = sorted(set(all_cves))
-    state.jira_issue = state.jira_issues_collected[0] if state.jira_issues_collected else None
+    # CVE / Jira lists are collected from commit footers after branches are
+    # fetched in fork_and_prepare_dist_git — not from MR descriptions.
+    state.jira_issues_collected = []
+    state.cves_collected = []
+    state.jira_issue = None
 
     logger.info(
         "Label-triggered consolidation: resolved %s to MRs %s",
@@ -577,17 +627,6 @@ async def run_workflow(
                 state.mr_descriptions = [mr.get("description", "") for mr in selected]
                 state.mr_types = {mr["source_branch"]: _mr_type_from_labels(mr) for mr in selected}
 
-                all_jira: list[str] = []
-                all_cves: list[str] = []
-                for mr in selected:
-                    all_jira.extend(_extract_jira_issues_from_description(mr.get("description", "")))
-                    all_cves.extend(_extract_cves_from_text(mr.get("description", "")))
-                state.jira_issues_collected = sorted(set(all_jira))
-                state.cves_collected = sorted(set(all_cves))
-                state.jira_issue = state.jira_issues_collected[0] if state.jira_issues_collected else None
-                if state.jira_issues_collected:
-                    current_jira_issue.set(",".join(state.jira_issues_collected))
-
                 state.current_mrs_count = len(current_mrs)
 
                 logger.info(
@@ -622,6 +661,23 @@ async def run_workflow(
                 if new_patches:
                     state.patches_per_mr[branch_name] = new_patches
             logger.info("Per-MR patch mapping: %s", state.patches_per_mr)
+
+            # Collect CVE / Jira from commit footers on all selected branches.
+            # This overwrites any seed values and ignores MR descriptions.
+            state.cves_collected, state.jira_issues_collected = await _collect_footers_from_branches(
+                state.local_clone,
+                git_env,
+                dist_git_branch,
+                state.mr_branches,
+            )
+            state.jira_issue = state.jira_issues_collected[0] if state.jira_issues_collected else None
+            if state.jira_issues_collected:
+                current_jira_issue.set(",".join(state.jira_issues_collected))
+            logger.info(
+                "Collected from commit footers: CVEs=%s Jira=%s",
+                state.cves_collected,
+                state.jira_issues_collected,
+            )
 
             # If all non-base branches are rebuild MRs, use the simplified
             # append-only flow (no cherry-pick, no Release bump for rebuilds).
@@ -792,11 +848,6 @@ async def run_workflow(
                     env=git_env,
                 )
 
-                base_idx = state.mr_branches.index(base_branch)
-                base_jira_issues = _extract_jira_issues_from_description(
-                    state.mr_descriptions[base_idx] if base_idx < len(state.mr_descriptions) else "",
-                )
-
                 # --- Step 1: cherry-pick all commits from the base branch ---
                 _, base_commits_raw, _ = await run_subprocess(
                     ["git", "rev-list", "--reverse", f"{dist_git_branch}..{base_branch}"],
@@ -837,14 +888,6 @@ async def run_workflow(
 
                 # --- Step 2: process each commit from other branches ---
                 for other_branch in other_branches:
-                    other_idx = state.mr_branches.index(other_branch)
-                    other_jira = _extract_jira_issues_from_description(
-                        state.mr_descriptions[other_idx] if other_idx < len(state.mr_descriptions) else "",
-                    )
-                    if not other_jira and state.jira_issues_collected:
-                        remaining = [j for j in state.jira_issues_collected if j not in base_jira_issues]
-                        other_jira = remaining or [state.jira_issues_collected[-1]]
-
                     _, other_commits_raw, _ = await run_subprocess(
                         ["git", "rev-list", "--reverse", f"{dist_git_branch}..{other_branch}"],
                         cwd=state.local_clone,
@@ -971,18 +1014,17 @@ async def run_workflow(
                         # summary so the log agent produces a matching entry.
                         summary = original_msg.split("\n")[0]
 
-                        # Extract the Jira key from the commit's own
-                        # changelog Resolves line so re-consolidated MRs
-                        # keep their per-CVE keys instead of inheriting
-                        # a single key from the MR description.
-                        commit_jira = await _extract_resolves_from_commit(
-                            commit_sha,
-                            spec_name,
-                            state.local_clone,
-                            env=git_env,
-                        )
+                        # Prefer Resolves:/Related: from the commit message;
+                        # fall back to the spec changelog diff for older commits.
+                        msg_jira = _extract_jira_issues_from_resolves_footer_lines(original_msg)
+                        commit_jira = msg_jira[0] if msg_jira else None
                         if not commit_jira:
-                            commit_jira = other_jira[0] if other_jira else None
+                            commit_jira = await _extract_resolves_from_commit(
+                                commit_sha,
+                                spec_name,
+                                state.local_clone,
+                                env=git_env,
+                            )
 
                         log_prompt = render_template(
                             get_log_prompt(),
@@ -1114,30 +1156,28 @@ async def run_workflow(
                 )
                 await asyncio.sleep(_NFS_CACHE_WAIT)
 
-                # Collect Jira issues and CVEs from rebuild branches
+                # Collect Jira issues and CVEs from rebuild branch commit footers
                 rebuild_jira: list[str] = []
                 rebuild_cves: list[str] = []
                 for rb_branch in rebuild_branches:
-                    idx = state.mr_branches.index(rb_branch)
-                    desc = state.mr_descriptions[idx] if idx < len(state.mr_descriptions) else ""
-                    rebuild_jira.extend(_extract_jira_issues_from_description(desc))
-                    rebuild_cves.extend(_extract_cves_from_text(desc))
-
-                # Also extract CVEs from the base backport commit messages
-                for commit_sha in base_commits:
-                    _, msg, _ = await run_subprocess(
-                        ["git", "log", "-1", "--format=%B", commit_sha],
-                        cwd=state.local_clone,
-                        env=git_env,
+                    rb_cves, rb_jira = await _collect_footers_from_branches(
+                        state.local_clone,
+                        git_env,
+                        dist_git_branch,
+                        [rb_branch],
                     )
-                    state.cves_collected = sorted(
-                        set(state.cves_collected + _extract_cves_from_text(msg or ""))
-                    )
+                    rebuild_cves.extend(rb_cves)
+                    rebuild_jira.extend(rb_jira)
+                rebuild_jira = sorted(set(rebuild_jira))
+                rebuild_cves = sorted(set(rebuild_cves))
 
+                # Ensure state lists include rebuild footers (already collected
+                # in fork_and_prepare_dist_git, but rebuild-only amend needs them).
                 state.cves_collected = sorted(set(state.cves_collected + rebuild_cves))
+                state.jira_issues_collected = sorted(set(state.jira_issues_collected + rebuild_jira))
 
                 # Update changelog with the rebuild ticket reference
-                rebuild_issues_str = ", ".join(sorted(set(rebuild_jira))) or "rebuild"
+                rebuild_issues_str = ", ".join(rebuild_jira) or "rebuild"
                 log_prompt = render_template(
                     get_log_prompt(),
                     LogInputSchema(
@@ -1174,14 +1214,12 @@ async def run_workflow(
                 # Append rebuild Resolves: compare against what the commit
                 # message already contains, not state.jira_issues_collected
                 # (which includes rebuild tickets from discovery).
-                already_in_commit = set(re.findall(r"RHEL-\d+", last_msg))
+                already_in_commit = set(_extract_jira_issues_from_resolves_footer_lines(last_msg))
                 extra_resolves = sorted(set(rebuild_jira) - already_in_commit)
-                if extra_resolves:
-                    state.jira_issues_collected = sorted(set(state.jira_issues_collected + extra_resolves))
 
                 # Add rebuild CVEs to commit message only if original already had CVE line
                 if rebuild_cves and re.search(r"^CVE:", last_msg, re.MULTILINE):
-                    existing_cves = _extract_cves_from_text(last_msg)
+                    existing_cves = _extract_cves_from_cve_footer_lines(last_msg)
                     all_cves = sorted(set(existing_cves + rebuild_cves))
                     last_msg = re.sub(
                         r"^CVE:.*$",
@@ -1329,6 +1367,9 @@ async def run_workflow(
             if state.jira_issues_collected:
                 resolves = ", ".join(state.jira_issues_collected)
                 commit_message += f"\n\nResolves: {resolves}"
+
+            if state.cves_collected:
+                commit_message += f"\nCVE: {', '.join(state.cves_collected)}"
 
             try:
                 exit_code, _, _ = await run_subprocess(
@@ -1576,12 +1617,8 @@ async def run_workflow(
             initial_state.mr_branches = [b["branch"] for b in backport_branches]
             initial_state.mr_titles = [b.get("title", "") for b in backport_branches]
             initial_state.mr_descriptions = [b.get("description", "") for b in backport_branches]
-            all_jira = []
-            for b in backport_branches:
-                all_jira.extend(b.get("jira_issues", []))
-            initial_state.jira_issues_collected = sorted(set(all_jira))
-            if initial_state.jira_issues_collected:
-                initial_state.jira_issue = initial_state.jira_issues_collected[0]
+            # CVE / Jira lists are collected from commit footers after branches
+            # are fetched — do not seed from branch metadata.
 
         response = await workflow.run(initial_state)
         return response.state

--- a/ymir/agents/tests/unit/test_mr_consolidation.py
+++ b/ymir/agents/tests/unit/test_mr_consolidation.py
@@ -5,8 +5,9 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from ymir.agents.mr_consolidation_agent import (
-    _extract_cves_from_text,
+    _extract_cves_from_cve_footer_lines,
     _extract_jira_issues_from_description,
+    _extract_jira_issues_from_resolves_footer_lines,
     _extract_resolves_from_commit,
     _mr_type_from_labels,
 )
@@ -612,28 +613,83 @@ async def test_sweep_uses_activated_at_not_submitted_at(fake_redis):
     assert await fake_redis.hget(HASH_KEY, active_key) is not None
 
 
-# -- _extract_cves_from_text ---------------------------------------------------
+# -- _extract_cves_from_cve_footer_lines --------------------------------------
 
 
-class TestExtractCves:
-    def test_single_cve(self):
-        assert _extract_cves_from_text("Fixed CVE-2024-12345") == ["CVE-2024-12345"]
+class TestExtractCvesFromFooterLines:
+    def test_single_cve_footer(self):
+        assert _extract_cves_from_cve_footer_lines("CVE: CVE-2026-12617") == ["CVE-2026-12617"]
 
-    def test_multiple_cves(self):
-        text = "CVE: CVE-2024-1111, CVE-2024-2222\nAlso fixes CVE-2023-99999"
-        result = _extract_cves_from_text(text)
-        assert result == ["CVE-2023-99999", "CVE-2024-1111", "CVE-2024-2222"]
+    def test_multi_cve_footer(self):
+        text = "CVE: CVE-2026-11331, CVE-2026-13204"
+        assert _extract_cves_from_cve_footer_lines(text) == [
+            "CVE-2026-11331",
+            "CVE-2026-13204",
+        ]
 
-    def test_no_cves(self):
-        assert _extract_cves_from_text("No vulnerabilities here") == []
+    def test_ignores_cves_outside_footer(self):
+        text = (
+            "Fix named crash on CNAME/DNAME queries (CVE-2026-12617)\n\n"
+            "Backport CVE-2026-12617 fix from upstream.\n"
+            "pattern of backporting (e.g. bind-9.18-CVE-2024-4076.patch, "
+            "bind-9.18-CVE-2024-11187.patch).\n\n"
+            "CVE: CVE-2026-12617\n"
+            "Resolves: RHEL-213450\n"
+        )
+        assert _extract_cves_from_cve_footer_lines(text) == ["CVE-2026-12617"]
+
+    def test_no_footer_returns_empty(self):
+        assert _extract_cves_from_cve_footer_lines("No vulnerabilities here") == []
+        assert (
+            _extract_cves_from_cve_footer_lines(
+                "Added bind-9.18-CVE-2024-4076.patch",
+            )
+            == []
+        )
 
     def test_deduplication(self):
-        text = "CVE-2024-1111 and CVE-2024-1111 again"
-        assert _extract_cves_from_text(text) == ["CVE-2024-1111"]
+        text = "CVE: CVE-2024-1111\nCVE: CVE-2024-1111"
+        assert _extract_cves_from_cve_footer_lines(text) == ["CVE-2024-1111"]
 
     def test_cve_in_commit_message_format(self):
         text = "Rebuild gnutls\n\nCVE: CVE-2024-55555\nResolves: RHEL-12345"
-        assert _extract_cves_from_text(text) == ["CVE-2024-55555"]
+        assert _extract_cves_from_cve_footer_lines(text) == ["CVE-2024-55555"]
+
+
+# -- _extract_jira_issues_from_resolves_footer_lines ---------------------------
+
+
+class TestExtractJiraFromResolvesFooterLines:
+    def test_single_resolves(self):
+        assert _extract_jira_issues_from_resolves_footer_lines(
+            "Resolves: RHEL-213450",
+        ) == ["RHEL-213450"]
+
+    def test_multi_resolves(self):
+        assert _extract_jira_issues_from_resolves_footer_lines(
+            "Resolves: RHEL-1, RHEL-2",
+        ) == ["RHEL-1", "RHEL-2"]
+
+    def test_related_line(self):
+        assert _extract_jira_issues_from_resolves_footer_lines(
+            "Related: RHEL-99999",
+        ) == ["RHEL-99999"]
+
+    def test_ignores_prose_without_footer(self):
+        text = (
+            "Verified that RHEL-159046 was already closed.\n"
+            "The gnutls package (RHEL-154320) already shipped this.\n"
+        )
+        assert _extract_jira_issues_from_resolves_footer_lines(text) == []
+
+    def test_ignores_prose_keeps_footer(self):
+        text = (
+            "Fix CVE-2026-12617 for bind\n\n"
+            "Mentioning RHEL-99999 in triage only.\n\n"
+            "CVE: CVE-2026-12617\n"
+            "Resolves: RHEL-213450\n"
+        )
+        assert _extract_jira_issues_from_resolves_footer_lines(text) == ["RHEL-213450"]
 
 
 # -- _mr_type_from_labels ------------------------------------------------------

--- a/ymir/agents/tests/unit/test_mr_consolidation.py
+++ b/ymir/agents/tests/unit/test_mr_consolidation.py
@@ -5,10 +5,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from ymir.agents.mr_consolidation_agent import (
+    _collect_footers_from_branches,
     _extract_cves_from_cve_footer_lines,
-    _extract_jira_issues_from_description,
     _extract_jira_issues_from_resolves_footer_lines,
     _extract_resolves_from_commit,
+    _files_to_stage_for_patches,
     _mr_type_from_labels,
 )
 from ymir.agents.tasks import (
@@ -290,111 +291,6 @@ async def test_fetch_config_returns_default_when_no_consolidation_key():
 
     assert config.merge_mrs is True
     assert config.release_strategy.value == "per_commit"
-
-
-# -- _extract_jira_issues_from_description ------------------------------------
-
-
-def test_extract_from_resolves_line():
-    desc = "Some backport description.\n\nResolves: RHEL-154342\n"
-    assert _extract_jira_issues_from_description(desc) == ["RHEL-154342"]
-
-
-def test_extract_from_resolves_line_multiple():
-    desc = "Description.\n\nResolves: RHEL-100, RHEL-200, RHEL-300\n"
-    result = _extract_jira_issues_from_description(desc)
-    assert sorted(result) == ["RHEL-100", "RHEL-200", "RHEL-300"]
-
-
-def test_extract_from_resolved_jira_issues_section():
-    desc = (
-        "## Consolidated Backport MR\n\n"
-        "### Resolved Jira Issues\n\n"
-        "- [RHEL-159051](https://issues.redhat.com/browse/RHEL-159051)\n"
-        "- [RHEL-159070](https://issues.redhat.com/browse/RHEL-159070)\n\n"
-        "### Source Merge Requests\n\n"
-        "Some other text mentioning RHEL-999999\n"
-    )
-    result = _extract_jira_issues_from_description(desc)
-    assert sorted(result) == ["RHEL-159051", "RHEL-159070"]
-
-
-def test_ignores_issues_in_triage_details():
-    desc = (
-        "Backport fix for CVE-2026-3833.\n\n"
-        "<details>\n"
-        "<summary>Triage Details</summary>\n\n"
-        "The gnutls RHEL 8 package (RHEL-154320, version 3.6.16) "
-        "already shipped this fix.\n"
-        "Verified that RHEL-159046 was already closed.\n"
-        "</details>\n\n"
-        "Resolves: RHEL-154342\n"
-    )
-    result = _extract_jira_issues_from_description(desc)
-    assert result == ["RHEL-154342"]
-
-
-def test_ignores_issues_in_prose_text():
-    desc = (
-        "This is related to RHEL-99999 which was fixed upstream.\n"
-        "See also RHEL-88888 for context.\n\n"
-        "Resolves: RHEL-11111\n"
-    )
-    result = _extract_jira_issues_from_description(desc)
-    assert result == ["RHEL-11111"]
-
-
-def test_consolidated_mr_with_nested_triage_details():
-    """The exact scenario from the production bug: a consolidated MR whose
-    sub-MR descriptions contain triage details referencing other issues."""
-    desc = (
-        "## Consolidated Backport MR\n\n"
-        "### Resolved Jira Issues\n\n"
-        "- [RHEL-159051](https://issues.redhat.com/browse/RHEL-159051)\n"
-        "- [RHEL-159075](https://issues.redhat.com/browse/RHEL-159075)\n\n"
-        "### Source Merge Requests\n\n"
-        "#### MR 1: [Fix CVE-2026-33845](https://gitlab.com/example/-/merge_requests/1)\n\n"
-        "<details><summary>Original description</summary>\n\n"
-        "Backport fix for CVE-2026-33845.\n"
-        "Verified that the gnutls package (RHEL-159046) was already closed.\n\n"
-        "Resolves: RHEL-159051\n"
-        "</details>\n\n"
-        "#### MR 2: [Fix CVE-2026-3833](https://gitlab.com/example/-/merge_requests/2)\n\n"
-        "<details><summary>Original description</summary>\n\n"
-        "The gnutls RHEL 8 package (RHEL-154320) already shipped this.\n\n"
-        "Resolves: RHEL-159075\n"
-        "</details>\n"
-    )
-    result = _extract_jira_issues_from_description(desc)
-    assert sorted(result) == ["RHEL-159051", "RHEL-159075"]
-
-
-def test_extract_from_related_line():
-    desc = "Some description.\n\nRelated: RHEL-12345\n"
-    assert _extract_jira_issues_from_description(desc) == ["RHEL-12345"]
-
-
-def test_empty_description():
-    assert _extract_jira_issues_from_description("") == []
-
-
-def test_no_structured_issues():
-    desc = "Just a plain description with no Resolves line."
-    assert _extract_jira_issues_from_description(desc) == []
-
-
-def test_deduplicates_issues():
-    desc = (
-        "## Consolidated Backport MR\n\n"
-        "### Resolved Jira Issues\n\n"
-        "- [RHEL-100](https://issues.redhat.com/browse/RHEL-100)\n\n"
-        "### Source Merge Requests\n\n"
-        "<details><summary>Original description</summary>\n\n"
-        "Resolves: RHEL-100\n"
-        "</details>\n"
-    )
-    result = _extract_jira_issues_from_description(desc)
-    assert result == ["RHEL-100"]
 
 
 # -- process_task cancellation behavior ----------------------------------------
@@ -692,6 +588,77 @@ class TestExtractJiraFromResolvesFooterLines:
         assert _extract_jira_issues_from_resolves_footer_lines(text) == ["RHEL-213450"]
 
 
+# -- _collect_footers_from_branches --------------------------------------------
+
+
+class TestCollectFootersFromBranches:
+    """Failure handling when git commands fail during footer collection."""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_rev_list_fails(self, tmp_path):
+        async def fake_run(cmd, **kwargs):
+            return 128, None, "fatal: bad revision 'missing'"
+
+        with (
+            patch(
+                "ymir.agents.mr_consolidation_agent.run_subprocess",
+                new=AsyncMock(side_effect=fake_run),
+            ),
+            pytest.raises(RuntimeError, match=r"git rev-list.*failed"),
+        ):
+            await _collect_footers_from_branches(
+                tmp_path,
+                None,
+                "rhel-9.8.0",
+                ["mr-branch"],
+            )
+
+    @pytest.mark.asyncio
+    async def test_raises_when_git_log_fails(self, tmp_path):
+        async def fake_run(cmd, **kwargs):
+            if cmd[1] == "rev-list":
+                return 0, "abc123def456\n", None
+            return 128, None, "fatal: bad object abc123def456"
+
+        with (
+            patch(
+                "ymir.agents.mr_consolidation_agent.run_subprocess",
+                new=AsyncMock(side_effect=fake_run),
+            ),
+            pytest.raises(RuntimeError, match=r"git log -1.*failed"),
+        ):
+            await _collect_footers_from_branches(
+                tmp_path,
+                None,
+                "rhel-9.8.0",
+                ["mr-branch"],
+            )
+
+    @pytest.mark.asyncio
+    async def test_collects_footers_from_commit_messages(self, tmp_path):
+        async def fake_run(cmd, **kwargs):
+            if cmd[1] == "rev-list":
+                return 0, "abc123\n", None
+            return (
+                0,
+                "Fix something\n\nCVE: CVE-2026-11111\nResolves: RHEL-12345\n",
+                None,
+            )
+
+        with patch(
+            "ymir.agents.mr_consolidation_agent.run_subprocess",
+            new=AsyncMock(side_effect=fake_run),
+        ):
+            cves, jira = await _collect_footers_from_branches(
+                tmp_path,
+                None,
+                "rhel-9.8.0",
+                ["mr-branch"],
+            )
+        assert cves == ["CVE-2026-11111"]
+        assert jira == ["RHEL-12345"]
+
+
 # -- _mr_type_from_labels ------------------------------------------------------
 
 
@@ -911,3 +878,56 @@ class TestExtractResolvesFromCommit:
         )
         result = await _extract_resolves_from_commit(sha, "test.spec", git_repo)
         assert result == "RHEL-190609"
+
+
+# -- _files_to_stage_for_patches -----------------------------------------------
+
+
+class TestFilesToStageForPatches:
+    """Tests for staging patch files after LLM renumber/rename."""
+
+    def _write_spec_with_patches(self, repo, patch_filenames: list[str]):
+        patch_tags = "\n".join(
+            f"Patch{i}:          {name}" for i, name in enumerate(patch_filenames, start=1)
+        )
+        (repo / "test.spec").write_text(
+            "Name: test\nVersion: 1.0\nRelease: 1\n"
+            "Summary: Test package\nLicense: MIT\n"
+            f"{patch_tags}\n\n"
+            "%description\nTest package.\n\n"
+            "%changelog\n"
+            "* Thu Dec 23 2021 Dev <dev@redhat.com> - 1.0-1\n"
+            "- Initial build\n"
+        )
+
+    def test_includes_renamed_and_original_patch_names(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "0018-foo.patch").write_text("diff --git a/x b/x\n")
+        self._write_spec_with_patches(repo, ["0018-foo.patch"])
+
+        result = _files_to_stage_for_patches(
+            repo,
+            "test",
+            original_patches=["0017-foo.patch"],
+        )
+
+        assert result == ["test.spec", "0018-foo.patch", "0017-foo.patch"]
+
+    def test_raises_when_spec_patch_file_missing(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._write_spec_with_patches(repo, ["0018-foo.patch"])
+
+        with pytest.raises(RuntimeError, match="do not exist"):
+            _files_to_stage_for_patches(repo, "test")
+
+    def test_stages_spec_and_current_patches_without_originals(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "0017-bar.patch").write_text("diff --git a/x b/x\n")
+        self._write_spec_with_patches(repo, ["0017-bar.patch"])
+
+        result = _files_to_stage_for_patches(repo, "test")
+
+        assert result == ["test.spec", "0017-bar.patch"]


### PR DESCRIPTION
- Stage patches from the updated spec (and original names for renames) instead of pre-adaptation patches_per_mr paths, so LLM renumbering like Patch17→Patch18 still commits the patch file.
- Collect both only from CVE:/Resolves: commit footers so patch filenames and triage details no longer pollute consolidated MR metadata.
