### PR TITLE
Add prefix to paths and remove explicit file list

### DIFF
--- a/ymir/common/pyproject.toml
+++ b/ymir/common/pyproject.toml
@@ -23,16 +23,8 @@ test = [
 dev-mode-dirs = ["../.."]
 
 [tool.hatch.build.targets.wheel]
-packages = []
+include = ["**/*.py"]
+exclude = ["tests/**"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"__init__.py" = "ymir/common/__init__.py"
-"config.py" = "ymir/common/config.py"
-"constants.py" = "ymir/common/constants.py"
-"models.py" = "ymir/common/models.py"
-"utils.py" = "ymir/common/utils.py"
-"validators.py" = "ymir/common/validators.py"
-"version_utils.py" = "ymir/common/version_utils.py"
-"base_utils.py" = "ymir/common/base_utils.py"
-"mock_repos.py" = "ymir/common/mock_repos.py"
-"logging_setup.py" = "ymir/common/logging_setup.py"
+[tool.hatch.build.targets.wheel.sources]
+"" = "ymir/common"

--- a/ymir/tools/pyproject.toml
+++ b/ymir/tools/pyproject.toml
@@ -27,40 +27,8 @@ test = [
 [tool.hatch.build]
 dev-mode-dirs = ["../.."]
 [tool.hatch.build.targets.wheel]
-packages = []
+include = ["**/*.py"]
+exclude = ["**/tests/**"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"__init__.py" = "ymir/tools/__init__.py"
-"gateway_utils.py" = "ymir/tools/gateway_utils.py"
-"constants.py" = "ymir/tools/constants.py"
-"http.py" = "ymir/tools/http.py"
-"base.py" = "ymir/tools/base.py"
-"privileged/__init__.py" = "ymir/tools/privileged/__init__.py"
-"privileged/aiohttp_client_session_mock.py" = "ymir/tools/privileged/aiohttp_client_session_mock.py"
-"privileged/copr.py" = "ymir/tools/privileged/copr.py"
-"privileged/distgit.py" = "ymir/tools/privileged/distgit.py"
-"privileged/errata.py" = "ymir/tools/privileged/errata.py"
-"privileged/gateway.py" = "ymir/tools/privileged/gateway.py"
-"privileged/gitlab.py" = "ymir/tools/privileged/gitlab.py"
-"privileged/jira.py" = "ymir/tools/privileged/jira.py"
-"privileged/lookaside.py" = "ymir/tools/privileged/lookaside.py"
-"privileged/maintainer_rules.py" = "ymir/tools/privileged/maintainer_rules.py"
-"privileged/testing_farm.py" = "ymir/tools/privileged/testing_farm.py"
-"privileged/utils.py" = "ymir/tools/privileged/utils.py"
-"privileged/zstream_search.py" = "ymir/tools/privileged/zstream_search.py"
-"unprivileged/__init__.py" = "ymir/tools/unprivileged/__init__.py"
-"unprivileged/analyze_ewa_testrun.py" = "ymir/tools/unprivileged/analyze_ewa_testrun.py"
-"unprivileged/commands.py" = "ymir/tools/unprivileged/commands.py"
-"unprivileged/distgit_detector.py" = "ymir/tools/unprivileged/distgit_detector.py"
-"unprivileged/filesystem.py" = "ymir/tools/unprivileged/filesystem.py"
-"unprivileged/gateway.py" = "ymir/tools/unprivileged/gateway.py"
-"unprivileged/greenwave.py" = "ymir/tools/unprivileged/greenwave.py"
-"unprivileged/read_logfile.py" = "ymir/tools/unprivileged/read_logfile.py"
-"unprivileged/read_readme.py" = "ymir/tools/unprivileged/read_readme.py"
-"unprivileged/search_resultsdb.py" = "ymir/tools/unprivileged/search_resultsdb.py"
-"unprivileged/specfile.py" = "ymir/tools/unprivileged/specfile.py"
-"unprivileged/text.py" = "ymir/tools/unprivileged/text.py"
-"unprivileged/upstream_search.py" = "ymir/tools/unprivileged/upstream_search.py"
-"unprivileged/upstream_tools.py" = "ymir/tools/unprivileged/upstream_tools.py"
-"unprivileged/version_mapper.py" = "ymir/tools/unprivileged/version_mapper.py"
-"unprivileged/wicked_git.py" = "ymir/tools/unprivileged/wicked_git.py"
+[tool.hatch.build.targets.wheel.sources]
+"" = "ymir/tools"


### PR DESCRIPTION
The list of files in `ymir-common` was out of date again. I don't think that full restructuring of the layout is warranted at this point, but we can at least make situation slightly less brittle.


Hatch allows for rewriting of paths. This way we can pretend that our `pyproject.toml` files are actually two levels higher than they are. With this prefix in place, we can safely select files by a glob and do away with the list.

https://hatch.pypa.io/latest/config/build/#rewriting-paths