### PR TITLE
Replace Resolves: with Jira browse links in MR descriptions

### DIFF
--- a/agents_as_skills/backport/SKILL.md
+++ b/agents_as_skills/backport/SKILL.md
@@ -262,7 +262,7 @@ Then go back to **Step 6** to re-stage changes (the changelog was just modified)
        </details>
      >
 
-     Resolves: {{jira_issue}}
+     Jira: [{{jira_issue}}](https://redhat.atlassian.net/browse/{{jira_issue}})
 
      <details>
      <summary>Backporting steps</summary>

--- a/agents_as_skills/rebase/SKILL.md
+++ b/agents_as_skills/rebase/SKILL.md
@@ -202,7 +202,7 @@ Then go back to **Step 6** to re-stage changes (the changelog was just modified)
        - "Reasoning:" section with triage_summary (if set)
        - "Justification:" section with justification (if set)>
 
-     Resolves: {{jira_issue}}
+     Jira: [{{jira_issue}}](https://redhat.atlassian.net/browse/{{jira_issue}})
 
      <rebase_status from Step 3, wrapped in a collapsible <details> block titled "Rebase status">
 

--- a/agents_as_skills/rebuild/SKILL.md
+++ b/agents_as_skills/rebuild/SKILL.md
@@ -136,7 +136,8 @@ If this fails, set `rebuild_success=false` with the error and skip to **Step 6: 
    <description>
 
    [Dependency: <dependency_components>]  ← only if all_dependency_components is non-empty
-   Resolves: <all_jira_issues_str>
+   Jira: [<issue>](https://redhat.atlassian.net/browse/<issue>)  ← single issue
+   ### Resolved Jira Issues               ← multiple issues (bullet browse links)
    [
    Sibling consolidation analysis:
    <consolidation_summary>
@@ -147,6 +148,7 @@ If this fails, set `rebuild_success=false` with the error and skip to **Step 6: 
 
    > **Warning: AI-Generated MR**: Created by Ymir AI assistant. AI may make mistakes...
    ```
+   Do NOT put `Resolves:` in the MR description (use browse links instead) — `Resolves:` belongs in the commit message only.
 
 8. Open a merge request using `open_merge_request` with:
    - `fork_url`: from Step 1

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -24,7 +24,12 @@ from specfile import Specfile
 import ymir.agents.tasks as tasks
 from ymir.agents.build_agent import create_build_agent
 from ymir.agents.build_agent import get_prompt as get_build_prompt
-from ymir.agents.constants import I_AM_YMIR, ZSTREAM_TARGET_LABEL, mr_description_footer
+from ymir.agents.constants import (
+    I_AM_YMIR,
+    ZSTREAM_TARGET_LABEL,
+    format_jira_links_for_mr,
+    mr_description_footer,
+)
 from ymir.agents.log_agent import create_log_agent
 from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
@@ -701,7 +706,7 @@ async def run_workflow(
                         f"{state.log_result.description}\n\n"
                         f"Upstream patches:\n{formatted_patches}\n\n"
                         f"{triage_details_text}"
-                        f"Resolves: {state.jira_issue}\n\n"
+                        f"{format_jira_links_for_mr(state.jira_issue)}\n"
                         f"{wrap_details('Backporting steps', state.backport_log[-1])}"
                         f"\n\n{mr_description_footer(state.package)}"
                     ),

--- a/ymir/agents/constants.py
+++ b/ymir/agents/constants.py
@@ -1,7 +1,10 @@
+import re
 from string import Template
 
 BRANCH_PREFIX = "automated-package-update"
 ZSTREAM_TARGET_LABEL = "target::zstream"
+
+JIRA_BROWSE_URL = "https://redhat.atlassian.net/browse/{issue}"
 
 AGENT_WARNING = (
     "Warning: This is an AI-Generated contribution and may contain mistakes. "
@@ -18,6 +21,50 @@ JIRA_COMMENT_TEMPLATE = Template(
 )
 
 I_AM_YMIR = "by Ymir, a Red Hat Enterprise Linux software maintenance AI agent."
+
+
+def format_jira_links_for_mr(issues: str | list[str] | None) -> str:
+    """Format Jira issue key(s) as browse links for an MR description.
+
+    Prefer this over ``Resolves:`` in MR bodies so ``check_tickets`` is not
+    tripped. Commit messages should still use ``Resolves:``.
+    """
+    if not issues:
+        return ""
+    keys = [issues] if isinstance(issues, str) else [k for k in issues if k]
+    if not keys:
+        return ""
+    if len(keys) == 1:
+        url = JIRA_BROWSE_URL.format(issue=keys[0])
+        return f"Jira: [{keys[0]}]({url})\n"
+    lines = ["### Resolved Jira Issues", ""]
+    lines.extend(f"- [{k}]({JIRA_BROWSE_URL.format(issue=k)})" for k in keys)
+    return "\n".join(lines) + "\n"
+
+
+def strip_resolves_from_mr_text(text: str) -> str:
+    """Remove ticket footer lines so they cannot leak into an MR body.
+
+    Strips ``Resolves:``, ``Related:``, and ``Jira:`` lines (including the
+    browse-link form and optional markdown list markers such as ``- Resolves:``).
+    """
+    if not text:
+        return text
+    filtered = [
+        line
+        for line in text.splitlines()
+        if not re.match(r"^\s*([-*+]\s*)?(Resolves|Related|Jira)\s*:", line, re.IGNORECASE)
+    ]
+    # Collapse runs of blank lines left by removals
+    result: list[str] = []
+    prev_blank = False
+    for line in filtered:
+        blank = not line.strip()
+        if blank and prev_blank:
+            continue
+        result.append(line)
+        prev_blank = blank
+    return "\n".join(result).strip("\n")
 
 
 def mr_description_footer(package: str) -> str:

--- a/ymir/agents/merge_request_agent.py
+++ b/ymir/agents/merge_request_agent.py
@@ -103,9 +103,36 @@ def create_merge_request_agent(mcp_tools: list[Tool], local_tool_options: dict[s
 
 
 def extract_jira_issue(mr_description: str) -> str:
-    if not (m := re.search(r"Resolves:\s+(RHEL-\d+)", mr_description)):
-        raise RuntimeError("Failed to extract Jira issue from MR description")
-    return m.group(1)
+    """Extract the primary Jira issue key from an MR description.
+
+    Prefers the first key under ``### Resolved Jira Issues`` (consolidated /
+    multi-issue MRs). Otherwise searches legacy ``Resolves:`` / ``Related:``
+    and ``Jira: [RHEL-…](…)`` lines. Content inside ``<details>`` blocks is
+    ignored so embedded source descriptions cannot shadow the top-level issue.
+    """
+    # Strip embeds first so nested "Resolved Jira Issues" sections cannot win
+    text = re.sub(
+        r"<details\b[^>]*>.*?</details>",
+        "",
+        mr_description,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    if m := re.search(
+        r"^#{1,4}\s+Resolved Jira Issues\s*\n+(?:-\s*\[?(RHEL-\d+)\]?)",
+        text,
+        re.MULTILINE,
+    ):
+        return m.group(1)
+
+    for pattern in (
+        r"Resolves:\s+(RHEL-\d+)",
+        r"Related:\s+(RHEL-\d+)",
+        r"Jira:\s+\[(RHEL-\d+)\]",
+        r"\[(RHEL-\d+)\]\(https://(?:issues\.redhat\.com|redhat\.atlassian\.net)/browse/RHEL-\d+\)",
+    ):
+        if m := re.search(pattern, text):
+            return m.group(1)
+    raise RuntimeError("Failed to extract Jira issue from MR description")
 
 
 async def main() -> None:

--- a/ymir/agents/mr_consolidation_agent.py
+++ b/ymir/agents/mr_consolidation_agent.py
@@ -21,7 +21,13 @@ from specfile import Specfile
 import ymir.agents.tasks as tasks
 from ymir.agents.build_agent import create_build_agent
 from ymir.agents.build_agent import get_prompt as get_build_prompt
-from ymir.agents.constants import I_AM_YMIR, ZSTREAM_TARGET_LABEL, mr_description_footer
+from ymir.agents.constants import (
+    I_AM_YMIR,
+    ZSTREAM_TARGET_LABEL,
+    format_jira_links_for_mr,
+    mr_description_footer,
+    strip_resolves_from_mr_text,
+)
 from ymir.agents.log_agent import create_log_agent
 from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
@@ -1750,8 +1756,7 @@ def _build_consolidated_description(
         parts.append("")
 
     if jira_issues:
-        parts.append("### Resolved Jira Issues\n")
-        parts.extend(f"- [{issue}](https://issues.redhat.com/browse/{issue})" for issue in jira_issues)
+        parts.append(format_jira_links_for_mr(jira_issues).rstrip("\n"))
         parts.append("")
 
     parts.append("### Source Merge Requests\n")
@@ -1761,9 +1766,9 @@ def _build_consolidated_description(
         else:
             parts.append(f"#### MR {i}: {sub['title']}\n")
         if sub["description"]:
-            parts.append(
-                f"<details><summary>Original description</summary>\n\n{sub['description']}\n</details>\n"
-            )
+            sanitized = strip_resolves_from_mr_text(sub["description"])
+            if sanitized:
+                parts.append(f"<details><summary>Original description</summary>\n\n{sanitized}\n</details>\n")
 
     parts.append(mr_description_footer(package))
     return "\n".join(parts)

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -21,7 +21,12 @@ from pydantic import Field
 import ymir.agents.tasks as tasks
 from ymir.agents.build_agent import create_build_agent
 from ymir.agents.build_agent import get_prompt as get_build_prompt
-from ymir.agents.constants import I_AM_YMIR, ZSTREAM_TARGET_LABEL, mr_description_footer
+from ymir.agents.constants import (
+    I_AM_YMIR,
+    ZSTREAM_TARGET_LABEL,
+    format_jira_links_for_mr,
+    mr_description_footer,
+)
 from ymir.agents.log_agent import create_log_agent
 from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
@@ -349,7 +354,7 @@ async def main() -> None:
                         mr_description=(
                             f"{state.log_result.description}\n\n"
                             f"{triage_details_text}"
-                            f"Resolves: {state.jira_issue}\n\n"
+                            f"{format_jira_links_for_mr(state.jira_issue)}\n"
                             f"{wrap_details('Rebase status', state.rebase_log[-1])}"
                             f"\n\n{mr_description_footer(state.package)}"
                         ),

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -10,7 +10,12 @@ from beeai_framework.workflows import Workflow
 from pydantic import Field
 
 import ymir.agents.tasks as tasks
-from ymir.agents.constants import I_AM_YMIR, ZSTREAM_TARGET_LABEL, mr_description_footer
+from ymir.agents.constants import (
+    I_AM_YMIR,
+    ZSTREAM_TARGET_LABEL,
+    format_jira_links_for_mr,
+    mr_description_footer,
+)
 from ymir.agents.log_agent import create_log_agent
 from ymir.agents.log_agent import get_prompt as get_log_prompt
 from ymir.agents.observability import setup_observability
@@ -213,6 +218,7 @@ async def main() -> None:
 
                     all_issues = [state.jira_issue] + [ci.issue_key for ci in state.consolidated_issues]
                     resolves_text = "Resolves: " + ", ".join(all_issues)
+                    jira_links_text = format_jira_links_for_mr(all_issues)
 
                     side_tag_text = f"\nside-tag: {state.side_tag}\n" if state.side_tag else ""
 
@@ -245,7 +251,7 @@ async def main() -> None:
                             f"{state.log_result.description}\n\n"
                             f"{dep_text}"
                             f"{dep_issues_text}"
-                            f"{resolves_text}\n"
+                            f"{jira_links_text}"
                             f"{side_tag_text}\n"
                             f"{triage_details_text}"
                             f"{consolidation_text}"

--- a/ymir/agents/tests/unit/test_mr_jira_links.py
+++ b/ymir/agents/tests/unit/test_mr_jira_links.py
@@ -1,0 +1,127 @@
+"""Unit tests for MR Jira link helpers and issue extraction."""
+
+import pytest
+
+from ymir.agents.constants import format_jira_links_for_mr, strip_resolves_from_mr_text
+from ymir.agents.merge_request_agent import extract_jira_issue
+from ymir.agents.mr_consolidation_agent import _build_consolidated_description
+
+
+def test_format_jira_links_single():
+    assert format_jira_links_for_mr("RHEL-12345") == (
+        "Jira: [RHEL-12345](https://redhat.atlassian.net/browse/RHEL-12345)\n"
+    )
+
+
+def test_format_jira_links_multiple():
+    result = format_jira_links_for_mr(["RHEL-1", "RHEL-2"])
+    assert result.startswith("### Resolved Jira Issues\n")
+    assert "- [RHEL-1](https://redhat.atlassian.net/browse/RHEL-1)" in result
+    assert "- [RHEL-2](https://redhat.atlassian.net/browse/RHEL-2)" in result
+    assert "Resolves:" not in result
+
+
+def test_format_jira_links_empty():
+    assert format_jira_links_for_mr([]) == ""
+    assert format_jira_links_for_mr(None) == ""
+    assert format_jira_links_for_mr([None, "", "RHEL-1"]) == (  # type: ignore[list-item]
+        "Jira: [RHEL-1](https://redhat.atlassian.net/browse/RHEL-1)\n"
+    )
+
+
+def test_strip_resolves_from_mr_text():
+    text = (
+        "Backport fix.\n\n"
+        "Resolves: RHEL-12345\n\n"
+        "More text.\n"
+        "Related: RHEL-999\n"
+        "Jira: [RHEL-111](https://redhat.atlassian.net/browse/RHEL-111)\n"
+    )
+    assert strip_resolves_from_mr_text(text) == "Backport fix.\n\nMore text."
+
+
+def test_strip_resolves_with_list_markers():
+    text = (
+        "Changelog-style lines.\n"
+        "- Resolves: RHEL-123\n"
+        "* Related: RHEL-1\n"
+        "  - Jira: [RHEL-2](https://redhat.atlassian.net/browse/RHEL-2)\n"
+        "Keep this.\n"
+    )
+    assert strip_resolves_from_mr_text(text) == "Changelog-style lines.\nKeep this."
+
+
+def test_strip_resolves_preserves_other_content():
+    text = "Description only.\nNo footer."
+    assert strip_resolves_from_mr_text(text) == text
+
+
+def test_extract_jira_issue_from_jira_line():
+    desc = "Fix something.\n\nJira: [RHEL-154342](https://redhat.atlassian.net/browse/RHEL-154342)\n"
+    assert extract_jira_issue(desc) == "RHEL-154342"
+
+
+def test_extract_jira_issue_from_resolves_legacy():
+    assert extract_jira_issue("Resolves: RHEL-100\n") == "RHEL-100"
+
+
+def test_extract_jira_issue_prefers_resolved_section_over_embedded_jira():
+    desc = (
+        "### Resolved Jira Issues\n\n"
+        "- [RHEL-159051](https://redhat.atlassian.net/browse/RHEL-159051)\n"
+        "- [RHEL-159075](https://redhat.atlassian.net/browse/RHEL-159075)\n\n"
+        "### Source Merge Requests\n\n"
+        "<details><summary>Original description</summary>\n\n"
+        "Jira: [RHEL-11111](https://redhat.atlassian.net/browse/RHEL-11111)\n"
+        "</details>\n"
+    )
+    assert extract_jira_issue(desc) == "RHEL-159051"
+
+
+def test_extract_jira_issue_ignores_resolved_section_inside_details():
+    desc = (
+        "Jira: [RHEL-22222](https://redhat.atlassian.net/browse/RHEL-22222)\n\n"
+        "<details><summary>Original description</summary>\n\n"
+        "### Resolved Jira Issues\n\n"
+        "- [RHEL-11111](https://redhat.atlassian.net/browse/RHEL-11111)\n"
+        "</details>\n"
+    )
+    assert extract_jira_issue(desc) == "RHEL-22222"
+
+
+def test_extract_jira_issue_ignores_details_without_section():
+    desc = (
+        "Top-level fix.\n\n"
+        "<details><summary>Original description</summary>\n\n"
+        "Jira: [RHEL-11111](https://redhat.atlassian.net/browse/RHEL-11111)\n"
+        "</details>\n\n"
+        "Jira: [RHEL-22222](https://redhat.atlassian.net/browse/RHEL-22222)\n"
+    )
+    assert extract_jira_issue(desc) == "RHEL-22222"
+
+
+def test_extract_jira_issue_missing():
+    with pytest.raises(RuntimeError, match="Failed to extract Jira issue"):
+        extract_jira_issue("No jira here")
+
+
+def test_consolidated_description_strips_resolves_from_embedded_sources():
+    desc = _build_consolidated_description(
+        mr_titles=["Fix CVE"],
+        mr_descriptions=[
+            "Backport fix.\n\n"
+            "Resolves: RHEL-159051\n"
+            "- Resolves: RHEL-159051\n"
+            "Jira: [RHEL-159051](https://redhat.atlassian.net/browse/RHEL-159051)\n"
+        ],
+        mr_urls=["https://gitlab.example/mr/1"],
+        jira_issues=["RHEL-159051", "RHEL-159075"],
+        package="gnutls",
+    )
+    assert "Resolves:" not in desc
+    assert "Related:" not in desc
+    # Top-level section keeps browse links; embedded Jira: footers are stripped
+    assert desc.count("Jira:") == 0
+    assert "[RHEL-159051](https://redhat.atlassian.net/browse/RHEL-159051)" in desc
+    assert "[RHEL-159075](https://redhat.atlassian.net/browse/RHEL-159075)" in desc
+    assert "Backport fix." in desc


### PR DESCRIPTION
check_tickets often fails when MR bodies contain Resolves: RHEL-xxxx. Keep Resolves: in commit messages for packaging conventions, but use browse links in MR descriptions for backport, rebase, rebuild, and consolidation (including stripping Resolves from embedded source descriptions).
