### PR TITLE
Allow egress to cgit.git.savannah.gnu.org

### DIFF
--- a/openshift/tenant-egress.yml
+++ b/openshift/tenant-egress.yml
@@ -96,12 +96,16 @@ spec:
     - type: Allow
       to:
         dnsName: googleapis.com
-    # GNU project hosting (gnu.org, ftp.gnu.org, savannah.gnu.org, savannah.nongnu.org,
-    # git.savannah.nongnu.org). All resolve to 209.51.188.0/24; dnsName selector picks
-    # AAAA records which don't match this cluster's IPv4-only egress, so use CIDR instead.
+    # GNU project hosting. Most hosts (gnu.org, ftp.gnu.org, savannah.gnu.org,
+    # git.savannah.nongnu.org) resolve to 209.51.188.0/24; dnsName selector picks
+    # AAAA records which don't match this cluster's IPv4-only egress, so use CIDR.
+    # cgit.git.savannah.gnu.org is CDN-backed and resolves outside that CIDR.
     - type: Allow
       to:
         cidrSelector: 209.51.188.0/24
+    - type: Allow
+      to:
+        dnsName: cgit.git.savannah.gnu.org
     # sourceware.org — upstream git for glibc, binutils, elfutils, newlib, etc.
     # Resolves to 38.145.34.32 (Cogent); not covered by existing CIDRs.
     - type: Allow


### PR DESCRIPTION
cgit.git.savannah.gnu.org is served by a CDN whose IPs (185.112.147.x, 176.100.37.x, 15.204.88.x, 51.255.194.x) fall outside the existing 209.51.188.0/24 CIDR allowed for GNU hosts. The triage agent emits cgit HTTPS URLs as patch_urls, but the backport agent's get_patch_from_url fails terminally because the egress firewall blocks the connection.

Affected packages: gzip, tar, xz, gawk (week 31 terminal failures).

Use dnsName selector since the CDN IPs are not stable.

Assisted-by: Claude Opus 4.6
