### PR TITLE
Fix Z-stream fix approach logic bugs

### DIFF
--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -593,7 +593,7 @@ async def _check_zstream_fix_approach(
     output = await tool.run(
         input={
             "jql": jql,
-            "fields": ["fixVersions", FIXED_IN_BUILD_CUSTOM_FIELD],
+            "fields": ["fixVersions", FIXED_IN_BUILD_CUSTOM_FIELD, "status", "resolution"],
             "max_results": 50,
         }
     )
@@ -612,13 +612,46 @@ async def _check_zstream_fix_approach(
         for variant in get_fix_version_variants(v)
     }
 
+    def _build_rhel_first_result(clone_key: str, detail: str) -> tuple[FixApproach, list, str]:
+        """Helper to construct RHEL_FIRST result tuple consistently."""
+        return (FixApproach.RHEL_FIRST, [], f"{clone_key} {detail}")
+
     pending_keys = []
+    rhel_first_fallback = None  # Track RHEL_FIRST result if found, but keep checking for CS_FIRST
+
     for issue in issues:
         key = issue.get("key", "")
         fix_versions = issue.get("fields", {}).get("fixVersions", [])
         fv_names = [fv.get("name", "") for fv in fix_versions]
         if not any(fv.lower() in relevant_z_streams for fv in fv_names):
             continue
+
+        status_name = issue.get("fields", {}).get("status", {}).get("name", "")
+        resolution_raw = issue.get("fields", {}).get("resolution", {})
+        resolution_name = resolution_raw.get("name", "") if resolution_raw else ""
+
+        if status_name.upper() == "CLOSED":
+            if resolution_name.upper() in _REJECTED_RESOLUTIONS:
+                logger.info(f"  {key}: Closed/{resolution_name} — rejected, skipping")
+                continue
+            if resolution_name in ("Done-Errata", "Done"):
+                fixed_in_build = issue.get("fields", {}).get(FIXED_IN_BUILD_CUSTOM_FIELD)
+                if fixed_in_build:
+                    pass  # fall through to existing Koji check below
+                else:
+                    logger.info(
+                        f"  {key}: Closed/{resolution_name} but no Fixed in Build NVR, "
+                        "would assume RHEL first but checking remaining clones for CS builds"
+                    )
+                    if not rhel_first_fallback:
+                        rhel_first_fallback = _build_rhel_first_result(
+                            key, f"is Closed/{resolution_name} (no Fixed in Build NVR to check CS Koji)"
+                        )
+                    continue  # Keep checking other clones for CS_FIRST
+            else:
+                # Closed with a resolution that's not Done/Done-Errata/rejected - skip it
+                logger.info(f"  {key}: Closed/{resolution_name} (not a shipping resolution) — skipping")
+                continue
 
         fixed_in_build = issue.get("fields", {}).get(FIXED_IN_BUILD_CUSTOM_FIELD)
         if not fixed_in_build:
@@ -628,12 +661,15 @@ async def _check_zstream_fix_approach(
 
         cs_nvr = nvr_to_cs_nvr(fixed_in_build)
         if not cs_nvr:
-            logger.warning(f"  {key}: cannot derive CS NVR from {fixed_in_build}, assuming RHEL first")
-            return (
-                FixApproach.RHEL_FIRST,
-                [],
-                f"{key} has Fixed in Build {fixed_in_build} (could not derive CentOS Stream NVR)",
+            logger.warning(
+                f"  {key}: cannot derive CS NVR from {fixed_in_build}, "
+                "would assume RHEL first but checking remaining clones"
             )
+            if not rhel_first_fallback:
+                rhel_first_fallback = _build_rhel_first_result(
+                    key, f"has Fixed in Build {fixed_in_build} (could not derive CentOS Stream NVR)"
+                )
+            continue  # Keep checking for CS_FIRST
 
         logger.info(f"  {key}: Fixed in Build={fixed_in_build}, checking CS NVR={cs_nvr}")
         cs_build = await asyncio.to_thread(_get_koji_build, CENTOS_STREAM_KOJIHUB_URL, cs_nvr)
@@ -645,13 +681,20 @@ async def _check_zstream_fix_approach(
                 f"{key} has Fixed in Build {fixed_in_build}, "
                 f"matching CentOS Stream build {cs_nvr} found in CS Koji",
             )
-        logger.info(f"  {key}: CS build {cs_nvr} not found — RHEL first approach")
-        return (
-            FixApproach.RHEL_FIRST,
-            [],
-            f"{key} has Fixed in Build {fixed_in_build}, no matching CentOS Stream build {cs_nvr} in CS Koji",
-        )
+        logger.info(f"  {key}: CS build {cs_nvr} not found — RHEL first approach for this clone")
+        if not rhel_first_fallback:
+            rhel_first_fallback = _build_rhel_first_result(
+                key,
+                f"has Fixed in Build {fixed_in_build}, no matching CentOS Stream build {cs_nvr} in CS Koji",
+            )
+        # Continue checking remaining clones for CS_FIRST
 
+    # If we found any RHEL_FIRST evidence, return it (shipped clone wins over pending)
+    if rhel_first_fallback:
+        logger.info("No CS build found across all clones, using RHEL first approach")
+        return rhel_first_fallback
+
+    # If all we found were pending clones, wait for them
     if pending_keys:
         logger.info(f"No Z-stream clone has Fixed in Build yet for {cve_id}, waiting: {pending_keys}")
         return (FixApproach.PENDING, pending_keys, "")

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -626,9 +626,8 @@ async def _check_zstream_fix_approach(
         if not any(fv.lower() in relevant_z_streams for fv in fv_names):
             continue
 
-        status_name = issue.get("fields", {}).get("status", {}).get("name", "")
-        resolution_raw = issue.get("fields", {}).get("resolution", {})
-        resolution_name = resolution_raw.get("name", "") if resolution_raw else ""
+        status_name = (issue.get("fields", {}).get("status") or {}).get("name", "")
+        resolution_name = (issue.get("fields", {}).get("resolution") or {}).get("name", "")
 
         if status_name.upper() == "CLOSED":
             if resolution_name.upper() in _REJECTED_RESOLUTIONS:

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -633,7 +633,7 @@ async def _check_zstream_fix_approach(
             if resolution_name.upper() in _REJECTED_RESOLUTIONS:
                 logger.info(f"  {key}: Closed/{resolution_name} — rejected, skipping")
                 continue
-            if resolution_name in ("Done-Errata", "Done"):
+            if resolution_name.upper() in ("DONE-ERRATA", "DONE"):
                 fixed_in_build = issue.get("fields", {}).get(FIXED_IN_BUILD_CUSTOM_FIELD)
                 if fixed_in_build:
                     pass  # fall through to existing Koji check below

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -1007,6 +1007,32 @@ async def test_fix_approach_no_clones():
     assert pending == []
 
 
+@pytest.mark.asyncio
+async def test_fix_approach_none_status_field():
+    """Z-stream clone with status=None and resolution=None — should handle gracefully."""
+    search_result = [
+        {
+            "key": "RHEL-111",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.6.z"}],
+                "status": None,  # Field present but None
+                "resolution": None,
+                "customfield_10578": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+
+    approach, pending, _ = await _check_zstream_fix_approach("CVE-2025-12345", "curl", "RHEL-999", "9")
+    assert approach is FixApproach.PENDING
+    assert pending == ["RHEL-111"]
+
+
 # --- CVE triage eligibility tests ---
 
 

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -22,6 +22,7 @@ from ymir.tools.privileged.jira import (
     VerifyIssueAuthorTool,
     _check_duplicate_tracker,
     _check_zstream_clones_shipped,
+    _check_zstream_fix_approach,
     extract_cve_id,
 )
 
@@ -775,6 +776,235 @@ async def test_check_zstream_clones_stale_ystream_fixversion():
     any_shipped, pending = await _check_zstream_clones_shipped("CVE-2025-12345", "curl", "RHEL-999")
     assert any_shipped is False
     assert pending == ["RHEL-333"]
+
+
+# --- Z-stream fix approach tests (Low/Moderate Y-stream path) ---
+
+
+@pytest.mark.asyncio
+async def test_fix_approach_clone_shipped_no_nvr():
+    """Z-stream clone Closed/Done-Errata with no Fixed in Build — RHEL_FIRST (not PENDING)."""
+    search_result = [
+        {
+            "key": "RHEL-111",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.6.z"}],
+                "status": {"name": "Closed"},
+                "resolution": {"name": "Done-Errata"},
+                "customfield_10578": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+
+    approach, pending, _detail = await _check_zstream_fix_approach("CVE-2025-12345", "curl", "RHEL-999", "9")
+    assert approach is FixApproach.RHEL_FIRST
+    assert pending == []
+    assert "Closed/Done-Errata" in _detail
+
+
+@pytest.mark.asyncio
+async def test_fix_approach_clone_shipped_done_no_nvr():
+    """Z-stream clone Closed/Done with no Fixed in Build — RHEL_FIRST."""
+    search_result = [
+        {
+            "key": "RHEL-111",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.6.z"}],
+                "status": {"name": "Closed"},
+                "resolution": {"name": "Done"},
+                "customfield_10578": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+
+    approach, pending, _ = await _check_zstream_fix_approach("CVE-2025-12345", "curl", "RHEL-999", "9")
+    assert approach is FixApproach.RHEL_FIRST
+    assert pending == []
+
+
+@pytest.mark.asyncio
+async def test_fix_approach_clone_shipped_with_nvr_cs_build():
+    """Z-stream clone Closed/Done-Errata WITH Fixed in Build and CS Koji match — CS_FIRST."""
+    search_result = [
+        {
+            "key": "RHEL-111",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.6.z"}],
+                "status": {"name": "Closed"},
+                "resolution": {"name": "Done-Errata"},
+                "customfield_10578": "curl-8.0-2.el9_6",
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+    flexmock(jira_tools).should_receive("nvr_to_cs_nvr").with_args("curl-8.0-2.el9_6").and_return(
+        "curl-8.0-2.el9"
+    ).once()
+    flexmock(jira_tools).should_receive("_get_koji_build").and_return({"id": 123}).once()
+
+    approach, pending, _detail = await _check_zstream_fix_approach("CVE-2025-12345", "curl", "RHEL-999", "9")
+    assert approach is FixApproach.CS_FIRST
+    assert pending == []
+    assert "CentOS Stream build" in _detail
+
+
+@pytest.mark.asyncio
+async def test_fix_approach_clone_rejected():
+    """Z-stream clone Closed/WONTFIX — skipped, no other clones → NO_ZSTREAM_CLONES."""
+    search_result = [
+        {
+            "key": "RHEL-111",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.6.z"}],
+                "status": {"name": "Closed"},
+                "resolution": {"name": "WONTFIX"},
+                "customfield_10578": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+
+    approach, pending, _ = await _check_zstream_fix_approach("CVE-2025-12345", "curl", "RHEL-999", "9")
+    assert approach is FixApproach.NO_ZSTREAM_CLONES
+    assert pending == []
+
+
+@pytest.mark.asyncio
+async def test_fix_approach_clone_not_closed_no_nvr():
+    """Z-stream clone In Progress, no Fixed in Build — PENDING."""
+    search_result = [
+        {
+            "key": "RHEL-222",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.6.z"}],
+                "status": {"name": "In Progress"},
+                "resolution": None,
+                "customfield_10578": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+
+    approach, pending, _ = await _check_zstream_fix_approach("CVE-2025-12345", "curl", "RHEL-999", "9")
+    assert approach is FixApproach.PENDING
+    assert pending == ["RHEL-222"]
+
+
+@pytest.mark.asyncio
+async def test_fix_approach_shipped_clone_plus_pending_clone():
+    """One clone shipped (no NVR), another still pending — shipped one wins."""
+    search_result = [
+        {
+            "key": "RHEL-111",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.7.z"}],
+                "status": {"name": "Closed"},
+                "resolution": {"name": "Done-Errata"},
+                "customfield_10578": None,
+            },
+        },
+        {
+            "key": "RHEL-222",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.6.z"}],
+                "status": {"name": "In Progress"},
+                "resolution": None,
+                "customfield_10578": None,
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+
+    approach, pending, _ = await _check_zstream_fix_approach("CVE-2025-12345", "curl", "RHEL-999", "9")
+    assert approach is FixApproach.RHEL_FIRST
+    assert pending == []
+
+
+@pytest.mark.asyncio
+async def test_fix_approach_shipped_no_nvr_then_cs_first():
+    """First clone shipped without NVR, second has CS build — CS_FIRST wins (not early RHEL_FIRST)."""
+    search_result = [
+        {
+            "key": "RHEL-111",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.7.z"}],
+                "status": {"name": "Closed"},
+                "resolution": {"name": "Done-Errata"},
+                "customfield_10578": None,  # No NVR
+            },
+        },
+        {
+            "key": "RHEL-222",
+            "fields": {
+                "fixVersions": [{"name": "rhel-9.6.z"}],
+                "status": {"name": "Closed"},
+                "resolution": {"name": "Done-Errata"},
+                "customfield_10578": "curl-8.0-2.el9_6",  # Has NVR with CS build
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+    flexmock(jira_tools).should_receive("nvr_to_cs_nvr").with_args("curl-8.0-2.el9_6").and_return(
+        "curl-8.0-2.el9"
+    ).once()
+    flexmock(jira_tools).should_receive("_get_koji_build").and_return({"id": 456}).once()
+
+    approach, pending, _detail = await _check_zstream_fix_approach("CVE-2025-12345", "curl", "RHEL-999", "9")
+    assert approach is FixApproach.CS_FIRST  # Not RHEL_FIRST from first clone
+    assert pending == []
+    assert "CentOS Stream build" in _detail
+
+
+@pytest.mark.asyncio
+async def test_fix_approach_no_clones():
+    """No Z-stream clones at all — NO_ZSTREAM_CLONES."""
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=[]))
+    ).once()
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(RHEL_CONFIG)
+    ).once()
+
+    approach, pending, _ = await _check_zstream_fix_approach("CVE-2025-12345", "curl", "RHEL-999", "9")
+    assert approach is FixApproach.NO_ZSTREAM_CLONES
+    assert pending == []
 
 
 # --- CVE triage eligibility tests ---


### PR DESCRIPTION
## Summary

Fixes Low/Moderate Y-stream postponement that ignores shipped Z-stream clones.

## Problem

`_check_zstream_fix_approach()` only checked the "Fixed in Build" custom field to decide whether a Z-stream clone was ready. A clone that had already reached **Closed/Done-Errata** (shipped) but had an empty "Fixed in Build" field was incorrectly treated as still pending, causing the Y-stream issue to be postponed indefinitely.

## Solution

The function now requests **status** and **resolution** from Jira and checks them before falling back to the "Fixed in Build" field:

- **Closed + Done-Errata/Done with NVR** → existing Koji lookup (CS vs RHEL)
- **Closed + Done-Errata/Done without NVR** → RHEL_FIRST (proceed)
- **Closed + rejected resolution** (WONTFIX, etc.) → skip the clone

## Additional improvements (latest commit)

Also fixed 6 related bugs discovered during code review:
1. Case-sensitive resolution comparison (now uses `.upper()` consistently)
2. Closed issues with non-shipping resolutions (e.g., "Cannot Reproduce") are now skipped
3. Shipped clone wins over pending (RHEL_FIRST takes precedence)
4. Added guards to prevent overwriting the first RHEL_FIRST diagnostic context
5. Extracted `_build_rhel_first_result()` helper to eliminate code duplication
6. Simplified resolution extraction by removing intermediate variable

## Test plan
- [x] Added comprehensive unit tests covering all resolution scenarios
- [x] Existing unit tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)