### PR TITLE
Release pins on phoenix and pydantic-ai-slim

### DIFF
--- a/Containerfile.phoenix
+++ b/Containerfile.phoenix
@@ -2,7 +2,7 @@
 FROM fedora:44
 RUN dnf install -y python3-pip python3-numpy python3-scipy \
     && dnf clean all \
-    && pip3 install --no-cache-dir 'arize-phoenix[pg]<16' 'pydantic-ai-slim<2' \
+    && pip3 install --no-cache-dir 'arize-phoenix[pg]' \
     && useradd -u 1001 -g 0 -m -s /sbin/nologin phoenix
 USER 1001
 EXPOSE 6006 4317


### PR DESCRIPTION
I've encountered https://github.com/Arize-ai/phoenix/issues/10306 while working trough traces. This is considerable problem, as it blocks all but the most trivial of queries. Release https://github.com/Arize-ai/phoenix/releases/tag/arize-phoenix-v19.11.1 carries the fix. The cap of pydantic-ai-slim version has been implemented in the Phoenix itself, so we shouldn't need it. https://github.com/Arize-ai/phoenix/pull/13881 