### PR TITLE
Add per-issue Redis locks for distributed agent dedup

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "openshift/deployment-triage-agent.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 79,
+        "line_number": 81,
         "is_secret": false
       }
     ],
@@ -308,5 +308,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-17T05:34:48Z"
+  "generated_at": "2026-08-03T18:41:12Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -143,7 +143,7 @@
         "filename": "openshift/deployment-backport-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 82,
         "is_secret": false
       }
     ],
@@ -153,7 +153,7 @@
         "filename": "openshift/deployment-backport-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 82,
         "is_secret": false
       }
     ],
@@ -163,7 +163,7 @@
         "filename": "openshift/deployment-rebase-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 82,
         "is_secret": false
       }
     ],
@@ -173,7 +173,7 @@
         "filename": "openshift/deployment-rebase-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 82,
         "is_secret": false
       }
     ],
@@ -183,7 +183,7 @@
         "filename": "openshift/deployment-rebuild-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 79,
+        "line_number": 82,
         "is_secret": false
       }
     ],
@@ -193,7 +193,7 @@
         "filename": "openshift/deployment-rebuild-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 79,
+        "line_number": 82,
         "is_secret": false
       }
     ],
@@ -308,5 +308,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-03T18:41:12Z"
+  "generated_at": "2026-08-03T18:41:55Z"
 }

--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -10,7 +10,10 @@ spec:
     matchLabels:
       app: backport-agent-c10s
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -66,8 +69,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 90
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-backport-agent-c9s.yml
+++ b/openshift/deployment-backport-agent-c9s.yml
@@ -10,7 +10,10 @@ spec:
     matchLabels:
       app: backport-agent-c9s
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -66,8 +69,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 90
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-rebase-agent-c10s.yml
+++ b/openshift/deployment-rebase-agent-c10s.yml
@@ -10,7 +10,10 @@ spec:
     matchLabels:
       app: rebase-agent-c10s
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -66,8 +69,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 90
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-rebase-agent-c9s.yml
+++ b/openshift/deployment-rebase-agent-c9s.yml
@@ -10,7 +10,10 @@ spec:
     matchLabels:
       app: rebase-agent-c9s
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -66,8 +69,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 90
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -10,7 +10,10 @@ spec:
     matchLabels:
       app: rebuild-agent-c10s
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -66,7 +69,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 90
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-rebuild-agent-c9s.yml
+++ b/openshift/deployment-rebuild-agent-c9s.yml
@@ -10,7 +10,10 @@ spec:
     matchLabels:
       app: rebuild-agent-c9s
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -66,7 +69,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 90
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/openshift/deployment-triage-agent.yml
+++ b/openshift/deployment-triage-agent.yml
@@ -10,7 +10,10 @@ spec:
     matchLabels:
       app: triage-agent
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -65,8 +68,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      # TODO: this should be reset when we have enough data.
-      terminationGracePeriodSeconds: 45
+      terminationGracePeriodSeconds: 90
       volumes:
       - name: mcp-server-git-repos
         persistentVolumeClaim:

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -52,6 +52,7 @@ from ymir.agents.utils import (
 )
 from ymir.common.base_utils import fix_await, install_shutdown_handler, redis_client, run_task_loop
 from ymir.common.constants import JiraLabels, RedisQueues
+from ymir.common.issue_lock import issue_lock
 from ymir.common.logging_setup import configure_logging, current_jira_issue, get_trajectory_writeable
 from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
@@ -874,6 +875,16 @@ async def main() -> None:
             triage_state = task.metadata
             backport_data = BackportData.model_validate(triage_state["triage_result"]["data"])
             current_jira_issue.set(backport_data.jira_issue)
+            async with issue_lock(redis, backport_data.jira_issue, prefix="lock:backport:") as lock_token:
+                if lock_token is None:
+                    logger.info(
+                        "Issue %s is already locked by another worker; dropping duplicate",
+                        backport_data.jira_issue,
+                    )
+                    return
+                await _process_backport_locked(task, triage_state, backport_data)
+
+        async def _process_backport_locked(task, triage_state, backport_data):
             dist_git_branch = triage_state["target_branch"]
             dist_git_namespace = triage_state.get("dist_git_namespace")
             user_triggered = task.user_triggered

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -46,6 +46,7 @@ from ymir.agents.utils import (
 )
 from ymir.common.base_utils import fix_await, install_shutdown_handler, redis_client, run_task_loop
 from ymir.common.constants import JiraLabels, RedisQueues
+from ymir.common.issue_lock import issue_lock
 from ymir.common.logging_setup import configure_logging, current_jira_issue, get_trajectory_writeable
 from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
@@ -466,6 +467,16 @@ async def main() -> None:
             triage_state = task.metadata
             rebase_data = RebaseData.model_validate(triage_state["triage_result"]["data"])
             current_jira_issue.set(rebase_data.jira_issue)
+            async with issue_lock(redis, rebase_data.jira_issue, prefix="lock:rebase:") as lock_token:
+                if lock_token is None:
+                    logger.info(
+                        "Issue %s is already locked by another worker; dropping duplicate",
+                        rebase_data.jira_issue,
+                    )
+                    return
+                await _process_rebase_locked(task, triage_state, rebase_data)
+
+        async def _process_rebase_locked(task, triage_state, rebase_data):
             dist_git_branch = triage_state["target_branch"]
             dist_git_namespace = triage_state.get("dist_git_namespace")
             user_triggered = task.user_triggered

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -32,6 +32,7 @@ from ymir.agents.utils import (
 )
 from ymir.common.base_utils import fix_await, install_shutdown_handler, redis_client, run_task_loop
 from ymir.common.constants import JiraLabels, RedisQueues
+from ymir.common.issue_lock import issue_lock
 from ymir.common.logging_setup import configure_logging, current_jira_issue
 from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
@@ -406,9 +407,6 @@ async def main() -> None:
                 triage_state = task.metadata
                 rebuild_data = RebuildData.model_validate(triage_state["triage_result"]["data"])
                 current_jira_issue.set(rebuild_data.jira_issue)
-                dist_git_branch = triage_state["target_branch"]
-                dist_git_namespace = triage_state.get("dist_git_namespace")
-                user_triggered = task.user_triggered
             except Exception as e:
                 logger.error(f"Failed to parse task payload, skipping: {e}")
                 await fix_await(
@@ -420,6 +418,20 @@ async def main() -> None:
                     )
                 )
                 return
+
+            async with issue_lock(redis, rebuild_data.jira_issue, prefix="lock:rebuild:") as lock_token:
+                if lock_token is None:
+                    logger.info(
+                        "Issue %s is already locked by another worker; dropping duplicate",
+                        rebuild_data.jira_issue,
+                    )
+                    return
+                await _process_rebuild_locked(task, triage_state, rebuild_data)
+
+        async def _process_rebuild_locked(task, triage_state, rebuild_data):
+            dist_git_branch = triage_state["target_branch"]
+            dist_git_namespace = triage_state.get("dist_git_namespace")
+            user_triggered = task.user_triggered
 
             logger.info(
                 f"Processing rebuild for package: {rebuild_data.package}, "

--- a/ymir/agents/tests/unit/test_triage_agent.py
+++ b/ymir/agents/tests/unit/test_triage_agent.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -69,6 +70,11 @@ def _make_payload(issue: str = "RHEL-99999", user_triggered: bool = False) -> by
     return task.model_dump_json().encode()
 
 
+@asynccontextmanager
+async def _always_acquired_lock(*_args, **_kwargs):
+    yield "test-lock-token"
+
+
 async def _capture_process_task(main_fn):
     """Run main() in queue mode, capture the process_task closure it registers."""
     captured = {}
@@ -110,6 +116,7 @@ async def test_process_task_skips_closed_issues(status):
     process_task = await _capture_process_task(main)
 
     with (
+        patch("ymir.agents.triage_agent.issue_lock", side_effect=_always_acquired_lock),
         patch(
             "ymir.agents.tasks.get_jira_issue_metadata",
             new_callable=AsyncMock,
@@ -130,6 +137,7 @@ async def test_process_task_skips_closed_user_triggered_with_cleanup():
     process_task = await _capture_process_task(main)
 
     with (
+        patch("ymir.agents.triage_agent.issue_lock", side_effect=_always_acquired_lock),
         patch(
             "ymir.agents.tasks.get_jira_issue_metadata",
             new_callable=AsyncMock,
@@ -157,6 +165,7 @@ async def test_process_task_proceeds_for_open_issues():
     process_task = await _capture_process_task(main)
 
     with (
+        patch("ymir.agents.triage_agent.issue_lock", side_effect=_always_acquired_lock),
         patch(
             "ymir.agents.tasks.get_jira_issue_metadata",
             new_callable=AsyncMock,
@@ -397,3 +406,55 @@ async def test_determine_target_branch_non_modular_has_no_explicit_namespace():
         )
     assert branch == "rhel-10.2"
     assert namespace is None
+
+
+# --- Per-issue lock tests ---
+
+
+@asynccontextmanager
+async def _lock_already_held(*_args, **_kwargs):
+    yield None
+
+
+@pytest.mark.asyncio
+async def test_process_task_drops_duplicate_when_locked():
+    """When the per-issue lock is already held, process_task silently drops the task."""
+    from ymir.agents.triage_agent import main
+
+    process_task = await _capture_process_task(main)
+
+    with (
+        patch("ymir.agents.triage_agent.issue_lock", side_effect=_lock_already_held),
+        patch(
+            "ymir.agents.tasks.get_jira_issue_metadata",
+            new_callable=AsyncMock,
+        ) as mock_metadata,
+        patch("ymir.agents.triage_agent.run_workflow", new_callable=AsyncMock) as mock_workflow,
+    ):
+        await process_task(_make_payload())
+
+    mock_metadata.assert_not_awaited()
+    mock_workflow.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_task_acquires_lock_and_proceeds():
+    """When the lock is available, process_task proceeds to call run_workflow."""
+    from ymir.agents.triage_agent import main
+
+    process_task = await _capture_process_task(main)
+
+    with (
+        patch("ymir.agents.triage_agent.issue_lock", side_effect=_always_acquired_lock),
+        patch(
+            "ymir.agents.tasks.get_jira_issue_metadata",
+            new_callable=AsyncMock,
+            return_value=([], "New"),
+        ),
+        patch("ymir.agents.tasks.set_jira_labels", new_callable=AsyncMock),
+        patch("ymir.agents.tasks.post_user_ack_once", new_callable=AsyncMock),
+        patch("ymir.agents.triage_agent.run_workflow", new_callable=AsyncMock) as mock_workflow,
+    ):
+        await process_task(_make_payload())
+
+    mock_workflow.assert_awaited_once()

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -39,6 +39,7 @@ from ymir.agents.utils import (
 from ymir.common.base_utils import fix_await, install_shutdown_handler, redis_client, run_task_loop
 from ymir.common.config import load_rhel_config
 from ymir.common.constants import JiraLabels, RedisQueues
+from ymir.common.issue_lock import issue_lock
 from ymir.common.logging_setup import configure_logging, current_jira_issue, get_trajectory_writeable
 from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
@@ -1102,6 +1103,16 @@ async def main() -> None:
             task = Task.model_validate_json(payload)
             input = InputSchema.model_validate(task.metadata)
             current_jira_issue.set(input.issue)
+            async with issue_lock(redis, input.issue) as lock_token:
+                if lock_token is None:
+                    logger.info(
+                        "Issue %s is already locked by another worker; dropping duplicate",
+                        input.issue,
+                    )
+                    return
+                await _process_triage_locked(task, input)
+
+        async def _process_triage_locked(task, input):
             user_triggered = task.user_triggered
             logger.info(
                 f"Processing triage for JIRA issue: {input.issue}, attempt: {task.attempts + 1}"
@@ -1313,7 +1324,6 @@ async def main() -> None:
                                     f"{consolidated.issue_key}: {e}"
                                 )
 
-                # Dispatch to downstream queues
                 if output.resolution == Resolution.ERROR:
                     await retry(task, output.data.model_dump_json())
                 elif output.resolution == Resolution.POSTPONED:
@@ -1341,7 +1351,6 @@ async def main() -> None:
                             queue = RedisQueues.CLARIFICATION_NEEDED_QUEUE.value
                             downstream_payload = task.model_dump_json()
                         elif not state.target_branch:
-                            # Unmapped tickets return None; skip branch-based queues.
                             logger.info(f"No target branch for {input.issue} — skipping downstream dispatch")
                             queue = None
                         else:

--- a/ymir/common/base_utils.py
+++ b/ymir/common/base_utils.py
@@ -136,7 +136,7 @@ async def run_task_loop(
     queues: list[str],
     process_fn: Callable[[bytes], Coroutine],
     max_concurrent: int = 1,
-    poll_timeout: int = 30,
+    poll_timeout: int = 5,
     poll_fn: Callable[[], Coroutine] | None = None,
     shutdown_event: asyncio.Event | None = None,
 ) -> None:

--- a/ymir/common/issue_lock.py
+++ b/ymir/common/issue_lock.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import uuid
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+import redis.asyncio as aioredis
+
+from ymir.common.base_utils import fix_await
+
+logger = logging.getLogger(__name__)
+
+LOCK_KEY_PREFIX = "lock:triage:"
+DEFAULT_LOCK_TTL_MS = 300_000  # 5 minutes
+
+
+# Compare-and-delete for string keys.  Analogous to _CONDITIONAL_HDEL_LUA in
+# merge_queue.py which does the same for hash fields.
+_CONDITIONAL_DEL_LUA = """
+local current = redis.call('GET', KEYS[1])
+if current == ARGV[1] then
+    redis.call('DEL', KEYS[1])
+    return 1
+end
+return 0
+"""
+
+# Compare-and-extend: only refresh TTL if we still own the lock.
+_CONDITIONAL_PEXPIRE_LUA = """
+local current = redis.call('GET', KEYS[1])
+if current == ARGV[1] then
+    redis.call('PEXPIRE', KEYS[1], ARGV[2])
+    return 1
+end
+return 0
+"""
+
+
+def _lock_key(issue_key: str, prefix: str = LOCK_KEY_PREFIX) -> str:
+    return f"{prefix}{issue_key.upper()}"
+
+
+async def acquire_issue_lock(
+    redis_conn: aioredis.Redis,
+    issue_key: str,
+    token: str,
+    ttl_ms: int = DEFAULT_LOCK_TTL_MS,
+    prefix: str = LOCK_KEY_PREFIX,
+) -> bool:
+    """Acquire a per-issue lock.
+
+    Uses SET NX PX for atomic acquire-with-expiry.
+
+    Returns True if acquired, False if already held by another holder.
+    """
+    result = await fix_await(redis_conn.set(_lock_key(issue_key, prefix), token, nx=True, px=ttl_ms))
+    return result is True or result == b"OK"
+
+
+async def release_issue_lock(
+    redis_conn: aioredis.Redis,
+    issue_key: str,
+    token: str,
+    prefix: str = LOCK_KEY_PREFIX,
+) -> bool:
+    """Release a per-issue lock, but only if still owned by this token.
+
+    Uses a compare-and-delete Lua script for atomicity.
+
+    Returns True if released, False if already expired or owned by another.
+    """
+    result = await fix_await(redis_conn.eval(_CONDITIONAL_DEL_LUA, 1, _lock_key(issue_key, prefix), token))
+    return result == 1
+
+
+async def extend_issue_lock(
+    redis_conn: aioredis.Redis,
+    issue_key: str,
+    token: str,
+    ttl_ms: int = DEFAULT_LOCK_TTL_MS,
+    prefix: str = LOCK_KEY_PREFIX,
+) -> bool:
+    """Extend the TTL of a lock, but only if still owned by this token.
+
+    Uses a compare-and-PEXPIRE Lua script for atomicity.
+
+    Returns True if extended, False if already expired or owned by another.
+    """
+    result = await fix_await(
+        redis_conn.eval(_CONDITIONAL_PEXPIRE_LUA, 1, _lock_key(issue_key, prefix), token, ttl_ms)
+    )
+    return result == 1
+
+
+async def _heartbeat_loop(
+    redis_conn: aioredis.Redis,
+    issue_key: str,
+    token: str,
+    ttl_ms: int,
+    prefix: str = LOCK_KEY_PREFIX,
+) -> None:
+    interval = ttl_ms / 3000.0
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            extended = await extend_issue_lock(redis_conn, issue_key, token, ttl_ms, prefix)
+            if not extended:
+                # Lock expired (Redis outage > TTL) and was re-acquired
+                # by another worker.  We stop heartbeating but do NOT
+                # cancel the task — see issue_lock() docstring.
+                logger.error(
+                    "Heartbeat failed: lock for %s no longer owned by us (token=%s)",
+                    issue_key,
+                    token[:8],
+                )
+                return
+        except Exception:
+            logger.warning(
+                "Redis error during heartbeat for %s; will retry in %.1fs",
+                issue_key,
+                interval,
+                exc_info=True,
+            )
+
+
+@asynccontextmanager
+async def issue_lock(
+    redis_conn: aioredis.Redis,
+    issue_key: str,
+    ttl_ms: int = DEFAULT_LOCK_TTL_MS,
+    prefix: str = LOCK_KEY_PREFIX,
+) -> AsyncGenerator[str | None, None]:
+    """Acquire a per-issue lock, maintain it via heartbeat, release on exit.
+
+    Yields the lock token if acquired, None if already held by another
+    worker.  On exit (including CancelledError), cancels the heartbeat
+    and releases the lock.
+
+    If Redis becomes unreachable for longer than ``ttl_ms`` the lock
+    auto-expires and another worker can acquire it.  The heartbeat
+    detects this and logs an error but does NOT cancel the running task
+    — the Jira in-progress label acts as a fallback dedup anchor.  This
+    trades a small risk of duplicate work for avoiding the abort of a
+    long-running task due to a transient Redis outage.
+    """
+    token = str(uuid.uuid4())
+    acquired = await acquire_issue_lock(redis_conn, issue_key, token, ttl_ms, prefix)
+    if not acquired:
+        yield None
+        return
+
+    heartbeat_task = asyncio.create_task(_heartbeat_loop(redis_conn, issue_key, token, ttl_ms, prefix))
+    try:
+        yield token
+    finally:
+        heartbeat_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await heartbeat_task
+        try:
+            await release_issue_lock(redis_conn, issue_key, token, prefix)
+        except Exception:
+            logger.warning(
+                "Failed to release lock for %s during cleanup; lock will auto-expire in <=%.0fs",
+                issue_key,
+                ttl_ms / 1000,
+                exc_info=True,
+            )

--- a/ymir/common/tests/unit/test_issue_lock.py
+++ b/ymir/common/tests/unit/test_issue_lock.py
@@ -1,0 +1,310 @@
+import asyncio
+import contextlib
+
+import pytest
+
+from ymir.common.issue_lock import (
+    _CONDITIONAL_DEL_LUA,
+    _CONDITIONAL_PEXPIRE_LUA,
+    _heartbeat_loop,
+    acquire_issue_lock,
+    extend_issue_lock,
+    issue_lock,
+    release_issue_lock,
+)
+
+
+class FakeRedis:
+    """Minimal stand-in for redis.asyncio.Redis covering the lock primitives.
+
+    Simulates SET NX PX, GET, DEL, PEXPIRE, and EVAL for the two Lua scripts
+    used by issue_lock.py.
+    """
+
+    def __init__(self):
+        self._store: dict[str, str] = {}
+        self.eval_calls: list[tuple[str, int, tuple]] = []
+
+    async def set(self, name, value, *, nx=False, px=None):
+        if nx and name in self._store:
+            return None
+        self._store[name] = value
+        return True
+
+    async def get(self, name):
+        return self._store.get(name)
+
+    async def eval(self, script, numkeys, *args):
+        self.eval_calls.append((script, numkeys, args))
+        if script == _CONDITIONAL_DEL_LUA:
+            key = args[0]
+            token = args[1]
+            current = self._store.get(key)
+            if current == token:
+                del self._store[key]
+                return 1
+            return 0
+        if script == _CONDITIONAL_PEXPIRE_LUA:
+            key = args[0]
+            token = args[1]
+            current = self._store.get(key)
+            if current == token:
+                return 1
+            return 0
+        return None
+
+    def inject(self, key: str, value: str) -> None:
+        """Directly set a key for test setup."""
+        self._store[key] = value
+
+
+async def _wait_until(predicate, timeout=2.0, interval=0.005):
+    async def _poll():
+        while not predicate():
+            await asyncio.sleep(interval)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+class TestAcquireIssueLock:
+    @pytest.mark.asyncio
+    async def test_acquire_succeeds_on_empty_key(self):
+        fake = FakeRedis()
+        assert await acquire_issue_lock(fake, "RHEL-123", "tok-1") is True
+        assert fake._store["lock:triage:RHEL-123"] == "tok-1"
+
+    @pytest.mark.asyncio
+    async def test_acquire_fails_when_already_held(self):
+        fake = FakeRedis()
+        assert await acquire_issue_lock(fake, "RHEL-123", "tok-1") is True
+        assert await acquire_issue_lock(fake, "RHEL-123", "tok-2") is False
+        assert fake._store["lock:triage:RHEL-123"] == "tok-1"
+
+    @pytest.mark.asyncio
+    async def test_acquire_succeeds_after_expiry(self):
+        fake = FakeRedis()
+        assert await acquire_issue_lock(fake, "RHEL-123", "tok-1") is True
+        # Simulate expiry by removing the key
+        del fake._store["lock:triage:RHEL-123"]
+        assert await acquire_issue_lock(fake, "RHEL-123", "tok-2") is True
+        assert fake._store["lock:triage:RHEL-123"] == "tok-2"
+
+
+class TestReleaseIssueLock:
+    @pytest.mark.asyncio
+    async def test_release_succeeds_with_matching_token(self):
+        fake = FakeRedis()
+        fake.inject("lock:triage:RHEL-123", "tok-1")
+        assert await release_issue_lock(fake, "RHEL-123", "tok-1") is True
+        assert "lock:triage:RHEL-123" not in fake._store
+
+    @pytest.mark.asyncio
+    async def test_release_fails_with_wrong_token(self):
+        fake = FakeRedis()
+        fake.inject("lock:triage:RHEL-123", "tok-1")
+        assert await release_issue_lock(fake, "RHEL-123", "tok-WRONG") is False
+        assert fake._store["lock:triage:RHEL-123"] == "tok-1"
+
+    @pytest.mark.asyncio
+    async def test_release_fails_on_expired_key(self):
+        fake = FakeRedis()
+        assert await release_issue_lock(fake, "RHEL-123", "tok-1") is False
+
+
+class TestExtendIssueLock:
+    @pytest.mark.asyncio
+    async def test_extend_succeeds_with_matching_token(self):
+        fake = FakeRedis()
+        fake.inject("lock:triage:RHEL-123", "tok-1")
+        assert await extend_issue_lock(fake, "RHEL-123", "tok-1") is True
+
+    @pytest.mark.asyncio
+    async def test_extend_fails_with_wrong_token(self):
+        fake = FakeRedis()
+        fake.inject("lock:triage:RHEL-123", "tok-1")
+        assert await extend_issue_lock(fake, "RHEL-123", "tok-WRONG") is False
+
+    @pytest.mark.asyncio
+    async def test_extend_fails_on_expired_key(self):
+        fake = FakeRedis()
+        assert await extend_issue_lock(fake, "RHEL-123", "tok-1") is False
+
+
+class TestHeartbeatLoop:
+    @pytest.mark.asyncio
+    async def test_heartbeat_calls_extend_periodically(self):
+        fake = FakeRedis()
+        fake.inject("lock:triage:RHEL-123", "tok-1")
+        ttl_ms = 150  # short TTL so heartbeat fires quickly (~50ms interval)
+
+        task = asyncio.create_task(_heartbeat_loop(fake, "RHEL-123", "tok-1", ttl_ms))
+        try:
+            await _wait_until(lambda: len(fake.eval_calls) >= 2)
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        assert len(fake.eval_calls) >= 2
+        for _, _, args in fake.eval_calls:
+            assert args[0] == "lock:triage:RHEL-123"
+            assert args[1] == "tok-1"
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_stops_when_lock_lost(self):
+        fake = FakeRedis()
+        # Lock is NOT in the store, so extend will return False immediately
+        ttl_ms = 150
+
+        task = asyncio.create_task(_heartbeat_loop(fake, "RHEL-123", "tok-1", ttl_ms))
+        # Heartbeat should return on its own (not hang forever)
+        await asyncio.wait_for(task, timeout=2.0)
+
+        assert len(fake.eval_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_survives_redis_error(self):
+        call_count = 0
+        original_eval = FakeRedis.eval
+
+        async def flaky_eval(self, script, numkeys, *args):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("simulated redis error")
+            return await original_eval(self, script, numkeys, *args)
+
+        fake = FakeRedis()
+        fake.inject("lock:triage:RHEL-123", "tok-1")
+        fake.eval = flaky_eval.__get__(fake)
+        ttl_ms = 150
+
+        task = asyncio.create_task(_heartbeat_loop(fake, "RHEL-123", "tok-1", ttl_ms))
+        try:
+            # Should survive the first error and succeed on the second call
+            await _wait_until(lambda: len(fake.eval_calls) >= 1)
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_is_cleanly_cancellable(self):
+        fake = FakeRedis()
+        fake.inject("lock:triage:RHEL-123", "tok-1")
+
+        task = asyncio.create_task(_heartbeat_loop(fake, "RHEL-123", "tok-1", 60_000))
+        await asyncio.sleep(0.01)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+class TestIssueLockContextManager:
+    @pytest.mark.asyncio
+    async def test_acquire_and_release_on_normal_exit(self):
+        fake = FakeRedis()
+
+        async with issue_lock(fake, "RHEL-123", ttl_ms=300) as token:
+            assert fake._store["lock:triage:RHEL-123"] == token
+
+        assert "lock:triage:RHEL-123" not in fake._store
+
+    @pytest.mark.asyncio
+    async def test_release_on_exception(self):
+        fake = FakeRedis()
+
+        with pytest.raises(ValueError):
+            async with issue_lock(fake, "RHEL-123", ttl_ms=300):
+                raise ValueError("boom")
+
+        assert "lock:triage:RHEL-123" not in fake._store
+
+    @pytest.mark.asyncio
+    async def test_release_on_cancellation(self):
+        fake = FakeRedis()
+        entered = asyncio.Event()
+
+        async def hold_lock():
+            async with issue_lock(fake, "RHEL-123", ttl_ms=300):
+                entered.set()
+                await asyncio.Event().wait()  # hang until cancelled
+
+        task = asyncio.create_task(hold_lock())
+        await asyncio.wait_for(entered.wait(), timeout=1.0)
+        assert "lock:triage:RHEL-123" in fake._store
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert "lock:triage:RHEL-123" not in fake._store
+
+    @pytest.mark.asyncio
+    async def test_yields_none_when_lock_already_held(self):
+        fake = FakeRedis()
+        fake.inject("lock:triage:RHEL-123", "other-holder")
+
+        async with issue_lock(fake, "RHEL-123", ttl_ms=300) as token:
+            assert token is None
+
+        assert fake._store["lock:triage:RHEL-123"] == "other-holder"
+
+    @pytest.mark.asyncio
+    async def test_two_concurrent_locks_on_same_issue(self):
+        fake = FakeRedis()
+        winner_entered = asyncio.Event()
+
+        async def winner():
+            async with issue_lock(fake, "RHEL-123", ttl_ms=300):
+                winner_entered.set()
+                await asyncio.sleep(0.1)
+
+        async def loser():
+            await winner_entered.wait()
+            async with issue_lock(fake, "RHEL-123", ttl_ms=300) as token:
+                assert token is None
+
+        await asyncio.gather(
+            asyncio.create_task(winner()),
+            asyncio.create_task(loser()),
+        )
+
+    @pytest.mark.asyncio
+    async def test_different_issues_do_not_conflict(self):
+        fake = FakeRedis()
+
+        async with (
+            issue_lock(fake, "RHEL-111", ttl_ms=300) as tok1,
+            issue_lock(fake, "RHEL-222", ttl_ms=300) as tok2,
+        ):
+            assert tok1 != tok2
+            assert "lock:triage:RHEL-111" in fake._store
+            assert "lock:triage:RHEL-222" in fake._store
+
+        assert "lock:triage:RHEL-111" not in fake._store
+        assert "lock:triage:RHEL-222" not in fake._store
+
+    @pytest.mark.asyncio
+    async def test_custom_prefix(self):
+        fake = FakeRedis()
+
+        async with issue_lock(fake, "RHEL-123", ttl_ms=300, prefix="lock:rebase:") as token:
+            assert token is not None
+            assert "lock:rebase:RHEL-123" in fake._store
+            assert "lock:triage:RHEL-123" not in fake._store
+
+        assert "lock:rebase:RHEL-123" not in fake._store
+
+    @pytest.mark.asyncio
+    async def test_different_prefixes_do_not_conflict(self):
+        fake = FakeRedis()
+
+        async with (
+            issue_lock(fake, "RHEL-123", ttl_ms=300, prefix="lock:triage:") as tok1,
+            issue_lock(fake, "RHEL-123", ttl_ms=300, prefix="lock:rebase:") as tok2,
+        ):
+            assert tok1 is not None
+            assert tok2 is not None
+            assert tok1 != tok2

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -33,6 +33,7 @@ import requests
 
 from ymir.common.base_utils import fix_await, get_jira_auth_headers, redis_client
 from ymir.common.constants import JIRA_SEARCH_PATH, JiraLabels, RedisQueues
+from ymir.common.issue_lock import LOCK_KEY_PREFIX
 from ymir.common.logging_setup import configure_logging
 from ymir.common.merge_queue import submit_merge_job
 from ymir.common.models import (
@@ -524,6 +525,18 @@ class JiraIssueFetcher:
             logger.error(f"Error checking existing queue items: {e}")
             return set()
 
+    async def _get_locked_issue_keys(self, redis_conn: redis.Redis) -> set[str]:
+        """Return issue keys that currently have an active triage lock.
+
+        Scans Redis for lock:triage:* keys, indicating an issue is being
+        actively processed by a triage agent pod.
+        """
+        locked_keys: set[str] = set()
+        async for key in redis_conn.scan_iter(match=f"{LOCK_KEY_PREFIX}*", count=100):
+            issue_key = key.decode().removeprefix(LOCK_KEY_PREFIX)
+            locked_keys.add(issue_key)
+        return locked_keys
+
     async def push_issues_to_queue(self, issues: list[dict[str, Any]]) -> int:
         """
         Push each issue to the Redis triage_queue, but only if it doesn't already exist
@@ -535,6 +548,10 @@ class JiraIssueFetcher:
         async with redis_client(self.redis_url) as redis_conn:
             # Get existing issue keys to avoid duplicates
             existing_keys = await self._get_existing_issue_keys(redis_conn)
+            locked_keys = await self._get_locked_issue_keys(redis_conn)
+            existing_keys |= locked_keys
+            if locked_keys:
+                logger.info("Found %d locked issues, will skip them", len(locked_keys))
 
             remove_issues_for_retry = set()
             user_triggered_keys = set()

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -533,7 +533,7 @@ class JiraIssueFetcher:
         """
         locked_keys: set[str] = set()
         async for key in redis_conn.scan_iter(match=f"{LOCK_KEY_PREFIX}*", count=100):
-            issue_key = key.decode().removeprefix(LOCK_KEY_PREFIX)
+            issue_key = key.decode().removeprefix(LOCK_KEY_PREFIX).upper()
             locked_keys.add(issue_key)
         return locked_keys
 
@@ -549,9 +549,8 @@ class JiraIssueFetcher:
             # Get existing issue keys to avoid duplicates
             existing_keys = await self._get_existing_issue_keys(redis_conn)
             locked_keys = await self._get_locked_issue_keys(redis_conn)
-            existing_keys |= locked_keys
             if locked_keys:
-                logger.info("Found %d locked issues, will skip them", len(locked_keys))
+                logger.info("Found %d locked issues, will skip enqueue for them", len(locked_keys))
 
             remove_issues_for_retry = set()
             user_triggered_keys = set()
@@ -742,6 +741,14 @@ class JiraIssueFetcher:
                                     f"after retries; skipping enqueue to avoid duplicate processing: {e}"
                                 )
                                 continue
+
+                    if issue_key in locked_keys:
+                        logger.info(
+                            "Issue %s is currently locked - trigger label consumed but skipping enqueue",
+                            issue_key,
+                        )
+                        skipped_count += 1
+                        continue
 
                     # Create task using shared Pydantic model
                     task = Task.from_issue(issue_key, user_triggered=user_triggered)

--- a/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -11,6 +11,7 @@ from flexmock import flexmock
 
 import ymir.jira_issue_fetcher.jira_issue_fetcher as jira_issue_fetcher_impl
 from ymir.common.constants import JIRA_SEARCH_PATH, JiraLabels, RedisQueues
+from ymir.common.issue_lock import LOCK_KEY_PREFIX
 from ymir.common.models import (
     BackportData,
     ClarificationNeededData,
@@ -38,11 +39,25 @@ def fetcher(mock_env_vars):
     return JiraIssueFetcher()
 
 
+async def _empty_async_iter(*_args, **_kwargs):
+    return
+    yield
+
+
+def _lock_keys_async_iter(*issue_keys):
+    async def _iter(*_args, **_kwargs):
+        for key in issue_keys:
+            yield f"{LOCK_KEY_PREFIX}{key}".encode()
+
+    return _iter
+
+
 @pytest.fixture
 def mock_redis_context():
     """Create a mock Redis context manager for testing."""
     # Create mock Redis object
     mock_redis = flexmock()
+    mock_redis.should_receive("scan_iter").and_return(_empty_async_iter())
 
     @asynccontextmanager
     async def mock_context_manager(*_, **__):
@@ -1302,6 +1317,7 @@ async def test_push_stale_reenqueue_dry_run_skips_flip_but_still_pushes(monkeypa
     fetcher = JiraIssueFetcher()
 
     mock_redis = flexmock()
+    mock_redis.should_receive("scan_iter").and_return(_empty_async_iter())
 
     @asynccontextmanager
     async def mock_context_manager(*_, **__):
@@ -1329,6 +1345,57 @@ async def test_push_stale_reenqueue_dry_run_skips_flip_but_still_pushes(monkeypa
     result = await fetcher.push_issues_to_queue(issues)
 
     assert result == 1
+
+
+@pytest.mark.asyncio
+async def test_locked_todo_consumes_label_but_skips_enqueue(fetcher, mock_redis_context):
+    """ymir_todo on a locked issue: flip the label but do not push to Redis."""
+    mock_redis, _ = mock_redis_context
+    mock_redis.should_receive("scan_iter").and_return(_lock_keys_async_iter("TODO-LOCKED")())
+
+    issues = [{"key": "TODO-LOCKED", "fields": {"labels": [JiraLabels.TODO.value]}}]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+    flexmock(fetcher).should_receive("_label_added_by_rh_employee").with_args("TODO-LOCKED").and_return(
+        True
+    ).once()
+    flexmock(fetcher).should_receive("_edit_jira_labels").with_args(
+        "TODO-LOCKED",
+        add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+        remove=[JiraLabels.TODO.value],
+    ).once()
+
+    mock_redis.should_receive("lpush").never()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_locked_retry_needed_consumes_label_but_skips_enqueue(fetcher, mock_redis_context):
+    """ymir_retry_needed on a locked issue: flip the label but do not push to Redis."""
+    mock_redis, _ = mock_redis_context
+    mock_redis.should_receive("scan_iter").and_return(_lock_keys_async_iter("RETRY-LOCKED")())
+
+    issues = [{"key": "RETRY-LOCKED", "fields": {"labels": [JiraLabels.RETRY_NEEDED.value]}}]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+    flexmock(fetcher).should_receive("_edit_jira_labels").with_args(
+        "RETRY-LOCKED",
+        add=[JiraLabels.TRIAGE_IN_PROGRESS.value],
+        remove=[JiraLabels.RETRY_NEEDED.value],
+    ).once()
+
+    mock_redis.should_receive("lpush").never()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 0
 
 
 def test_label_added_by_rh_employee_walks_paginated_changelog(fetcher):


### PR DESCRIPTION
- Introduce a per-issue Redis lock module using `SET NX PX` with a heartbeat loop and Lua-based release/extend, so two workers never process the same Jira issue concurrently
- Wire the lock into the triage agent (both task processing and fetcher-side pre-check) and into the rebase, backport, and rebuild agents, each with its own lock prefix
- Lower default `poll_timeout` from 30s to 5s for faster graceful shutdown across all agents
- Update all 6 agent deployments: `terminationGracePeriodSeconds`: 45 → 90, `strategy`: `Recreate` → `RollingUpdate` (`maxSurge`: 1, `maxUnavailable`: 0)
