### PR TITLE
Increment logdetective-mcp dependency and revise uv caching

### DIFF
--- a/Containerfile.c9s-tests
+++ b/Containerfile.c9s-tests
@@ -42,7 +42,7 @@ RUN python3.11 -m venv --system-site-packages /opt/beeai-venv \
        GitPython \
        nitrate \
        tomli-w \
-       "logdetective-mcp>=0.2.0" \
+       "logdetective-mcp>=0.5.0" \
        typer \
        python-dotenv
 

--- a/Containerfile.tests
+++ b/Containerfile.tests
@@ -44,7 +44,7 @@ RUN pip install --no-cache-dir \
       rpm \
       rpkg \
       specfile \
-      "logdetective-mcp>=0.2.0"
+      "logdetective-mcp>=0.5.0"
 
 # Verify no malicious litellm_init.pth was introduced by compromised litellm packages (e.g. 1.82.7, 1.82.8)
 RUN MALICIOUS=$(find /usr /opt -name "litellm_init.pth" 2>/dev/null); \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,14 @@ ymir = "ymir.cli.main:app"
 packages = ["ymir"]
 exclude = ["ymir/common", "ymir/tools"]
 
+[tool.uv]
+cache-keys = [
+    { file = "requirements-global.txt" },
+    { file = "requirements.txt" },
+    { file = "./ymir/common/requirements.txt" },
+    { file = "./ymir/tools/requirements.txt" }
+]
+
 [tool.uv.workspace]
 members = ["ymir/common", "ymir/tools"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ beautifulsoup4>=4.13.4
 beeai-framework[duckduckgo]==0.1.82
 copr>=1.129
 fastmcp>=2.11.3
-logdetective-mcp>=0.2.0
+logdetective-mcp>=0.5.0
 ogr>=0.55.0
 openinference-instrumentation-beeai>=0.1.8
 redis>=6.4.0

--- a/ymir/tools/requirements.txt
+++ b/ymir/tools/requirements.txt
@@ -11,4 +11,4 @@ requests-gssapi>=1.3.0
 rpm>=0.4.0
 rpkg>=1.65
 specfile>=0.36.0
-logdetective-mcp>=0.2.0
+logdetective-mcp>=0.5.0


### PR DESCRIPTION
While setting logdetective-mcp version to 0.5.0 I've noticed that the cache uv uses for builds may be left in invalid state as the configuration doesn't explicitly consider all requirements files..

By setting the [cache-dir](https://docs.astral.sh/uv/reference/settings/#cache-dir) value explicitly, we can make sure that uv always picks up changes in `global-requirements.txt` and other requirements files, preventing dependency conflicts.

PS: I do realize that updating constraint on logdetective-mcp is not strictly necessary, it's just that I like to keep these things explicit.