### PR TITLE
Abort early when z-stream dist-git branches lag Brew builds

### DIFF
--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -969,6 +969,18 @@ async def main() -> None:
                         f"success: {state.backport_result.success}"
                     )
 
+            except tasks.ZStreamBranchStaleError as e:
+                await tasks.handle_zstream_branch_stale_error(
+                    e,
+                    jira_issues=[backport_data.jira_issue],
+                    primary_jira_issue=backport_data.jira_issue,
+                    agent_type="Backport",
+                    errored_label=JiraLabels.BACKPORT_ERRORED.value,
+                    triaged_label=JiraLabels.TRIAGED_BACKPORT.value,
+                    dry_run=dry_run,
+                    user_triggered=user_triggered,
+                    redis_conn=redis,
+                )
             except Exception as e:
                 error = "".join(traceback.format_exception(e))
                 logger.error(f"Exception during backport processing for {backport_data.jira_issue}: {error}")

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -557,6 +557,18 @@ async def main() -> None:
                         f"success: {state.rebase_result.success}"
                     )
 
+            except tasks.ZStreamBranchStaleError as e:
+                await tasks.handle_zstream_branch_stale_error(
+                    e,
+                    jira_issues=[rebase_data.jira_issue],
+                    primary_jira_issue=rebase_data.jira_issue,
+                    agent_type="Rebase",
+                    errored_label=JiraLabels.REBASE_ERRORED.value,
+                    triaged_label=JiraLabels.TRIAGED_REBASE.value,
+                    dry_run=dry_run,
+                    user_triggered=user_triggered,
+                    redis_conn=redis,
+                )
             except Exception as e:
                 error = "".join(traceback.format_exception(e))
                 logger.error(f"Exception during rebase processing for {rebase_data.jira_issue}: {error}")

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -524,6 +524,18 @@ async def main() -> None:
                         f"success: {state.rebuild_success}"
                     )
 
+            except tasks.ZStreamBranchStaleError as e:
+                await tasks.handle_zstream_branch_stale_error(
+                    e,
+                    jira_issues=list(rebuild_data.all_jira_issues),
+                    primary_jira_issue=rebuild_data.jira_issue,
+                    agent_type="Rebuild",
+                    errored_label=JiraLabels.REBUILD_ERRORED.value,
+                    triaged_label=JiraLabels.TRIAGED_REBUILD.value,
+                    dry_run=dry_run,
+                    user_triggered=user_triggered,
+                    redis_conn=redis,
+                )
             except Exception as e:
                 error = "".join(traceback.format_exception(e))
                 logger.error(f"Exception during rebuild processing for {rebuild_data.jira_issue}: {error}")

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -12,8 +12,9 @@ from specfile import Specfile
 
 from ymir.agents.constants import BRANCH_PREFIX, JIRA_COMMENT_TEMPLATE
 from ymir.agents.utils import check_subprocess, mcp_tools, run_subprocess, run_tool
-from ymir.common.base_utils import is_cs_branch, is_modular_branch, resolve_dist_git_namespace
+from ymir.common.base_utils import fix_await, is_cs_branch, is_modular_branch, resolve_dist_git_namespace
 from ymir.common.config import load_rhel_config
+from ymir.common.constants import RedisQueues
 from ymir.common.merge_queue import (  # noqa: F401 — re-exported for agents and tests
     _CONSOLIDATION_HASH_KEY,
     _consolidation_field_key,
@@ -24,13 +25,14 @@ from ymir.common.merge_queue import (  # noqa: F401 — re-exported for agents a
 )
 from ymir.common.models import (
     CachedMRMetadata,
+    ErrorData,
     LogOutputSchema,
     MergeRequestDetails,
     OpenMergeRequestResult,
     PackageConsolidationConfig,
     Task,
 )
-from ymir.common.utils import get_all_sources
+from ymir.common.utils import get_all_sources, get_latest_candidate_build, get_latest_z_pending_build
 from ymir.common.version_utils import (
     construct_internal_branch_name,
     is_older_zstream,
@@ -42,6 +44,126 @@ from ymir.tools.unprivileged.specfile import UpdateReleaseTool
 from ymir.tools.unprivileged.wicked_git import RunPackagePrepTool
 
 logger = logging.getLogger(__name__)
+
+
+class ZStreamBranchStaleError(Exception):
+    """Raised when a z-stream branch is behind the latest Brew build."""
+
+    def __init__(self, package: str, branch: str, build_ref: str, branch_head: str):
+        self.package = package
+        self.branch = branch
+        self.build_ref = build_ref
+        self.branch_head = branch_head
+        super().__init__(
+            f"Z-stream branch {branch} for {package} is out of sync with compose. "
+            f"Branch HEAD ({branch_head[:12]}) does not contain the latest "
+            f"build ref ({build_ref[:12]}). "
+            f"The branch maintainer needs to update it before Ymir can proceed. "
+            f"Please fix the branch and re-trigger by removing all ymir_ labels "
+            f"and adding ymir_todo."
+        )
+
+
+async def _check_zstream_branch_consistency(package: str, dist_git_branch: str, local_clone: Path) -> None:
+    """Verify that a z-stream branch contains the latest Brew build's source commit.
+
+    Raises ZStreamBranchStaleError if the branch is behind.
+    Logs a warning and returns normally if the check cannot be performed
+    (e.g. Brew unreachable, no builds in tag).
+    """
+    if not parse_zstream_branch_name(dist_git_branch):
+        return
+
+    try:
+        if await is_older_zstream(dist_git_branch):
+            _, build_source_ref = await get_latest_z_pending_build(package, dist_git_branch)
+        else:
+            _, build_source_ref = await get_latest_candidate_build(package, dist_git_branch)
+    except Exception as e:
+        logger.warning(
+            f"Could not query Brew for z-stream branch consistency ({package}/{dist_git_branch}): {e}"
+        )
+        return
+
+    exit_code, _, stderr = await run_subprocess(
+        ["git", "merge-base", "--is-ancestor", build_source_ref, "HEAD"],
+        cwd=local_clone,
+    )
+    if exit_code == 0:
+        return
+
+    # exit 1 = not ancestor; exit 128 = "not a valid commit" (ref not in repo).
+    # Both mean the branch is stale. Any other non-zero is an unexpected git
+    # failure — soft-fail so we don't post a misleading maintainer message.
+    if exit_code not in (1, 128):
+        logger.warning(
+            f"Unexpected git merge-base exit {exit_code} checking z-stream "
+            f"consistency ({package}/{dist_git_branch}): {stderr}"
+        )
+        return
+
+    _, head_stdout, _ = await run_subprocess(["git", "rev-parse", "HEAD"], cwd=local_clone)
+    raise ZStreamBranchStaleError(package, dist_git_branch, build_source_ref, (head_stdout or "").strip())
+
+
+async def handle_zstream_branch_stale_error(
+    exc: ZStreamBranchStaleError,
+    *,
+    jira_issues: list[str],
+    primary_jira_issue: str,
+    agent_type: str,
+    errored_label: str,
+    triaged_label: str,
+    dry_run: bool,
+    user_triggered: bool,
+    redis_conn,
+) -> None:
+    """Terminal handling for a stale z-stream branch: label, comment, ERROR_LIST.
+
+    Does not re-queue. Always posts the Jira comment (unless dry_run) because
+    only the maintainer can fix the branch.
+    """
+    issues = list(dict.fromkeys(jira_issues))
+    logger.error(f"Stale z-stream branch for {primary_jira_issue}: {exc}")
+    for issue_key in issues:
+        try:
+            await set_jira_labels(
+                jira_issue=issue_key,
+                labels_to_add=[errored_label],
+                labels_to_remove=[triaged_label],
+                dry_run=dry_run,
+                user_triggered=user_triggered,
+            )
+        except Exception as label_error:
+            logger.warning(f"Failed to set labels on {issue_key}: {label_error}")
+    if not dry_run:
+        try:
+            async with mcp_tools(
+                os.environ["MCP_GATEWAY_URL"],
+                call_meta={"jira_issue": primary_jira_issue},
+            ) as gateway_tools:
+                for issue_key in issues:
+                    try:
+                        await comment_in_jira(
+                            jira_issue=issue_key,
+                            agent_type=agent_type,
+                            comment_text=str(exc),
+                            available_tools=gateway_tools,
+                            is_error=True,
+                            user_triggered=True,  # force-post regardless of actual trigger
+                        )
+                    except Exception as comment_error:
+                        logger.warning(
+                            f"Failed to post stale-branch comment for {issue_key}: {comment_error}"
+                        )
+        except Exception as gateway_error:
+            logger.warning(f"Failed to post stale-branch comment: {gateway_error}")
+    await fix_await(
+        redis_conn.lpush(
+            RedisQueues.ERROR_LIST.value,
+            ErrorData(details=str(exc), jira_issue=primary_jira_issue).model_dump_json(),
+        )
+    )
 
 
 async def needs_zstream_target_label(dist_git_branch: str, fix_version: str | None) -> bool:
@@ -144,6 +266,7 @@ async def fork_and_prepare_dist_git(
             clone_path=str(local_clone),
             available_tools=available_tools,
         )
+    await _check_zstream_branch_consistency(package, dist_git_branch, local_clone)
     update_branch = f"{BRANCH_PREFIX}-{jira_issue}"
     await check_subprocess(["git", "checkout", "-B", update_branch], cwd=local_clone)
     fedora_clone = None

--- a/ymir/agents/tests/unit/test_tasks.py
+++ b/ymir/agents/tests/unit/test_tasks.py
@@ -4,18 +4,22 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from ymir.agents.tasks import (
+    ZStreamBranchStaleError,
+    _check_zstream_branch_consistency,
     change_jira_status,
     commit_push_and_open_mr,
     fork_and_prepare_dist_git,
     get_jira_issue_metadata,
+    handle_zstream_branch_stale_error,
     needs_zstream_target_label,
     post_user_ack_once,
 )
+from ymir.common.constants import JiraLabels, RedisQueues
 from ymir.common.models import Task
 
 
 @asynccontextmanager
-async def _fake_mcp_tools(_url):
+async def _fake_mcp_tools(_url, **_kwargs):
     yield []
 
 
@@ -52,6 +56,7 @@ async def test_fork_and_prepare_dist_git_wipes_stale_working_dir(git_repo_basepa
         patch("ymir.agents.tasks.run_tool", new_callable=AsyncMock) as mock_run_tool,
         patch("ymir.agents.tasks.check_subprocess", new_callable=AsyncMock),
         patch("ymir.agents.tasks.is_older_zstream", new_callable=AsyncMock, return_value=False),
+        patch("ymir.agents.tasks._check_zstream_branch_consistency", new_callable=AsyncMock),
     ):
         mock_run_tool.return_value = "https://fork.example.com"
 
@@ -456,3 +461,219 @@ async def test_commit_push_and_open_mr_no_reviewers_without_package(tmp_path):
     assert is_new is True
     reviewer_calls = [n for n, _ in tool_calls if n == "set_merge_request_reviewers"]
     assert len(reviewer_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_zstream_consistency_stale_not_ancestor(tmp_path):
+    """Branch HEAD does not contain the build ref (exit 1) -> stale."""
+    with (
+        patch("ymir.agents.tasks.is_older_zstream", new_callable=AsyncMock, return_value=False),
+        patch(
+            "ymir.agents.tasks.get_latest_candidate_build",
+            new_callable=AsyncMock,
+            return_value=("1.0-1", "build-ref-sha"),
+        ),
+        patch(
+            "ymir.agents.tasks.run_subprocess",
+            new_callable=AsyncMock,
+            side_effect=[
+                (1, None, None),  # merge-base --is-ancestor
+                (0, "branch-head-sha\n", None),  # rev-parse HEAD
+            ],
+        ),
+        pytest.raises(ZStreamBranchStaleError) as exc_info,
+    ):
+        await _check_zstream_branch_consistency("golang", "rhel-9.8.0", tmp_path)
+
+    assert exc_info.value.package == "golang"
+    assert exc_info.value.branch == "rhel-9.8.0"
+    assert exc_info.value.build_ref == "build-ref-sha"
+    assert exc_info.value.branch_head == "branch-head-sha"
+
+
+@pytest.mark.asyncio
+async def test_zstream_consistency_stale_ref_not_in_repo(tmp_path):
+    """Build ref missing from clone (exit 128) -> stale."""
+    with (
+        patch("ymir.agents.tasks.is_older_zstream", new_callable=AsyncMock, return_value=False),
+        patch(
+            "ymir.agents.tasks.get_latest_candidate_build",
+            new_callable=AsyncMock,
+            return_value=("1.0-1", "missing-build-ref"),
+        ),
+        patch(
+            "ymir.agents.tasks.run_subprocess",
+            new_callable=AsyncMock,
+            side_effect=[
+                (128, None, "fatal: Not a valid commit name missing-build-ref"),
+                (0, "branch-head-sha\n", None),
+            ],
+        ),
+        pytest.raises(ZStreamBranchStaleError),
+    ):
+        await _check_zstream_branch_consistency("golang", "rhel-9.8.0", tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_zstream_consistency_up_to_date(tmp_path):
+    """Build ref is ancestor of HEAD (exit 0) -> no error."""
+    with (
+        patch("ymir.agents.tasks.is_older_zstream", new_callable=AsyncMock, return_value=False),
+        patch(
+            "ymir.agents.tasks.get_latest_candidate_build",
+            new_callable=AsyncMock,
+            return_value=("1.0-1", "build-ref-sha"),
+        ),
+        patch(
+            "ymir.agents.tasks.run_subprocess",
+            new_callable=AsyncMock,
+            return_value=(0, None, None),
+        ) as mock_run,
+    ):
+        await _check_zstream_branch_consistency("golang", "rhel-9.8.0", tmp_path)
+
+    mock_run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_zstream_consistency_skips_non_zstream(tmp_path):
+    """CentOS Stream branches skip the check entirely."""
+    with (
+        patch("ymir.agents.tasks.get_latest_candidate_build", new_callable=AsyncMock) as mock_brew,
+        patch("ymir.agents.tasks.get_latest_z_pending_build", new_callable=AsyncMock) as mock_pending,
+    ):
+        await _check_zstream_branch_consistency("bash", "c10s", tmp_path)
+
+    mock_brew.assert_not_awaited()
+    mock_pending.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_zstream_consistency_brew_unreachable_soft_fails(tmp_path, caplog):
+    """Brew query failure logs a warning and does not raise."""
+    with (
+        patch("ymir.agents.tasks.is_older_zstream", new_callable=AsyncMock, return_value=False),
+        patch(
+            "ymir.agents.tasks.get_latest_candidate_build",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Brew unreachable"),
+        ),
+        patch("ymir.agents.tasks.run_subprocess", new_callable=AsyncMock) as mock_run,
+    ):
+        await _check_zstream_branch_consistency("golang", "rhel-9.8.0", tmp_path)
+
+    mock_run.assert_not_awaited()
+    assert "Could not query Brew" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_zstream_consistency_older_uses_z_pending(tmp_path):
+    """Older z-streams query z-pending, not candidate."""
+    with (
+        patch("ymir.agents.tasks.is_older_zstream", new_callable=AsyncMock, return_value=True),
+        patch(
+            "ymir.agents.tasks.get_latest_z_pending_build",
+            new_callable=AsyncMock,
+            return_value=("1.0-1", "build-ref-sha"),
+        ) as mock_pending,
+        patch(
+            "ymir.agents.tasks.get_latest_candidate_build",
+            new_callable=AsyncMock,
+        ) as mock_candidate,
+        patch(
+            "ymir.agents.tasks.run_subprocess",
+            new_callable=AsyncMock,
+            return_value=(0, None, None),
+        ),
+    ):
+        await _check_zstream_branch_consistency("bash", "rhel-9.6.0", tmp_path)
+
+    mock_pending.assert_awaited_once_with("bash", "rhel-9.6.0")
+    mock_candidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_zstream_consistency_unexpected_git_exit_soft_fails(tmp_path, caplog):
+    """Unexpected merge-base exit codes log a warning and do not raise."""
+    with (
+        patch("ymir.agents.tasks.is_older_zstream", new_callable=AsyncMock, return_value=False),
+        patch(
+            "ymir.agents.tasks.get_latest_candidate_build",
+            new_callable=AsyncMock,
+            return_value=("1.0-1", "build-ref-sha"),
+        ),
+        patch(
+            "ymir.agents.tasks.run_subprocess",
+            new_callable=AsyncMock,
+            return_value=(2, None, "fatal: not a git repository"),
+        ) as mock_run,
+    ):
+        await _check_zstream_branch_consistency("golang", "rhel-9.8.0", tmp_path)
+
+    mock_run.assert_awaited_once()
+    assert "Unexpected git merge-base exit 2" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_zstream_branch_stale_error_labels_comments_and_error_list():
+    exc = ZStreamBranchStaleError("golang", "rhel-9.8.0", "build-ref-sha", "branch-head-sha")
+    redis = AsyncMock()
+    redis.lpush = AsyncMock()
+
+    with (
+        patch("ymir.agents.tasks.set_jira_labels", new_callable=AsyncMock) as mock_labels,
+        patch("ymir.agents.tasks.comment_in_jira", new_callable=AsyncMock) as mock_comment,
+        patch("ymir.agents.tasks.mcp_tools", _fake_mcp_tools),
+    ):
+        await handle_zstream_branch_stale_error(
+            exc,
+            jira_issues=["RHEL-1", "RHEL-2", "RHEL-1"],
+            primary_jira_issue="RHEL-1",
+            agent_type="Rebuild",
+            errored_label=JiraLabels.REBUILD_ERRORED.value,
+            triaged_label=JiraLabels.TRIAGED_REBUILD.value,
+            dry_run=False,
+            user_triggered=False,
+            redis_conn=redis,
+        )
+
+    assert mock_labels.await_count == 2
+    assert mock_comment.await_count == 2
+    mock_comment.assert_any_await(
+        jira_issue="RHEL-1",
+        agent_type="Rebuild",
+        comment_text=str(exc),
+        available_tools=[],
+        is_error=True,
+        user_triggered=True,
+    )
+    redis.lpush.assert_awaited_once()
+    assert redis.lpush.await_args.args[0] == RedisQueues.ERROR_LIST.value
+
+
+@pytest.mark.asyncio
+async def test_handle_zstream_branch_stale_error_skips_comment_on_dry_run():
+    exc = ZStreamBranchStaleError("golang", "rhel-9.8.0", "build-ref-sha", "branch-head-sha")
+    redis = AsyncMock()
+    redis.lpush = AsyncMock()
+
+    with (
+        patch("ymir.agents.tasks.set_jira_labels", new_callable=AsyncMock) as mock_labels,
+        patch("ymir.agents.tasks.comment_in_jira", new_callable=AsyncMock) as mock_comment,
+        patch("ymir.agents.tasks.mcp_tools", _fake_mcp_tools),
+    ):
+        await handle_zstream_branch_stale_error(
+            exc,
+            jira_issues=["RHEL-1"],
+            primary_jira_issue="RHEL-1",
+            agent_type="Rebase",
+            errored_label=JiraLabels.REBASE_ERRORED.value,
+            triaged_label=JiraLabels.TRIAGED_REBASE.value,
+            dry_run=True,
+            user_triggered=False,
+            redis_conn=redis,
+        )
+
+    mock_labels.assert_awaited_once()
+    mock_comment.assert_not_awaited()
+    redis.lpush.assert_awaited_once()


### PR DESCRIPTION
Verify branch HEAD contains the latest candidate/z-pending source ref after clone so rebase, backport, and rebuild do not open MRs on stale z-stream state. Fail with ymir_*_errored, always comment (unless dry-run), and skip retries.

Assisted-by: Composer (Cursor)