### PR TITLE
Add bare bones LangFuse integration

### DIFF
--- a/openshift/configmap-otel-collector-config.yml
+++ b/openshift/configmap-otel-collector-config.yml
@@ -17,6 +17,11 @@ data:
       otlphttp/trace-server:
         endpoint: http://localhost:8080
         encoding: json
+      otlphttp/langfuse:
+        endpoint: https://us.cloud.langfuse.com/api/public/otel
+        headers:
+          Authorization: "Basic ${env:LANGFUSE_AUTH}"
+          x-langfuse-ingestion-version: "4"
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133
@@ -25,4 +30,4 @@ data:
       pipelines:
         traces:
           receivers: [otlp]
-          exporters: [otlphttp/phoenix, otlphttp/trace-server]
+          exporters: [otlphttp/phoenix, otlphttp/trace-server, otlphttp/langfuse]

--- a/openshift/deployment-otel-collector.yml
+++ b/openshift/deployment-otel-collector.yml
@@ -32,6 +32,12 @@ spec:
       - name: otel-collector
         image: docker.io/otel/opentelemetry-collector-contrib
         imagePullPolicy: IfNotPresent
+        env:
+        - name: LANGFUSE_AUTH
+          valueFrom:
+            secretKeyRef:
+              name: langfuse-credentials
+              key: auth
         ports:
         - containerPort: 4318
           protocol: TCP

--- a/ymir/agents/observability.py
+++ b/ymir/agents/observability.py
@@ -57,6 +57,7 @@ class AgentSpanProcessor(SpanProcessor):
             jira_issue = current_jira_issue.get()
             if jira_issue:
                 span.set_attribute("jira.issue", jira_issue)
+                span.set_attribute("langfuse.session.id", jira_issue)
             workflow = current_workflow.get()
             if workflow:
                 span.set_attribute("workflow.name", workflow)


### PR DESCRIPTION
This adds export to LangFuse Cloud OTEL endpoint and Session ID markers to aggregate Sessions by JIRA.

I'm keeping this as DRAFT for now as enabling it by default and without on-boarded LangFuse account  and egress rule/s would likely spam the logs with trace export failures so feel free to slice and dice it as needed.