### PR TITLE
Remove _redact and _kerberos_principal

### DIFF
--- a/ymir/tools/gateway_utils.py
+++ b/ymir/tools/gateway_utils.py
@@ -15,13 +15,21 @@ logger = logging.getLogger(__name__)
 
 # Patterns that match common credential formats in log output
 _REDACT_PATTERNS = [
+    # GitLab PAT
     re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),
+    # Anthropic API key
     re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),
+    # Google API key
     re.compile(r"AIzaSy[A-Za-z0-9_-]{33}"),
+    # Bearer tokens in URLs or strings
     re.compile(r"oauth2:[^@\s]+@"),
+    # Testing Farm API tokens (UUID format)
     re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE),
+    # Jira Cloud API tokens (ATATT3x... pattern)
     re.compile(r"ATATT3x[A-Za-z0-9_-]{20,}"),
+    # Base64 Authorization headers
     re.compile(r"Basic [A-Za-z0-9+/=]{20,}"),
+    # Generic long hex/base64 tokens (e.g. Jira PATs)
     re.compile(
         r"(?:token|key|password|secret|credential)[\"'=:\s]+[A-Za-z0-9+/=_-]{20,}['\"\s]*", re.IGNORECASE
     ),

--- a/ymir/tools/privileged/gateway.py
+++ b/ymir/tools/privileged/gateway.py
@@ -1,8 +1,6 @@
 import asyncio
 import logging
 import os
-import re
-import subprocess
 
 from beeai_framework.adapters.mcp.serve.server import (
     MCPServer,
@@ -10,7 +8,6 @@ from beeai_framework.adapters.mcp.serve.server import (
     MCPSettings,
 )
 
-from ymir.common.base_utils import parse_klist_principals
 from ymir.common.mock_repos import apply_zstream_override_from_env
 from ymir.tools.gateway_utils import get_log_detective_mcp, setup_logging
 from ymir.tools.privileged.copr import BuildPackageTool, DownloadArtifactsTool
@@ -76,48 +73,7 @@ from ymir.tools.privileged.testing_farm import (
 )
 from ymir.tools.privileged.zstream_search import ZStreamSearchTool
 
-# Patterns that match common credential formats in log output
-_REDACT_PATTERNS = [
-    # GitLab PAT
-    re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),
-    # Anthropic API key
-    re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),
-    # Google API key
-    re.compile(r"AIzaSy[A-Za-z0-9_-]{33}"),
-    # Bearer tokens in URLs or strings
-    re.compile(r"oauth2:[^@\s]+@"),
-    # Testing Farm API tokens (UUID format)
-    re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE),
-    # Jira Cloud API tokens (ATATT3x... pattern)
-    re.compile(r"ATATT3x[A-Za-z0-9_-]{20,}"),
-    # Base64 Authorization headers
-    re.compile(r"Basic [A-Za-z0-9+/=]{20,}"),
-    # Generic long hex/base64 tokens (e.g. Jira PATs)
-    re.compile(
-        r"(?:token|key|password|secret|credential)[\"'=:\s]+[A-Za-z0-9+/=_-]{20,}['\"\s]*",
-        re.IGNORECASE,
-    ),
-]
-
 logger = logging.getLogger(__name__)
-
-
-def _redact(text: str) -> str:
-    """Replace credential-like patterns in text with [REDACTED]."""
-    for pattern in _REDACT_PATTERNS:
-        text = pattern.sub("[REDACTED]", text)
-    return text
-
-
-def _kerberos_principal() -> str | None:
-    """Return the first non-expired principal from the Kerberos ticket cache, or None."""
-    try:
-        result = subprocess.run(["klist", "-l"], capture_output=True, text=True, timeout=10)  # noqa: S607
-        principals = parse_klist_principals(result.stdout)
-        return principals[0] if principals else None
-    except Exception:
-        logger.debug("Failed to get kerberos principal", exc_info=True)
-    return None
 
 
 async def _async_main():


### PR DESCRIPTION
These two functions have been without any use for some time now. The `_redact` since c6a1a6a and `_kerberos_principal` since 7214071. Besides removing them, I've inserted comments from original, now also removed, `_REDACT_PATTERNS` into existing `_REDACT_PATTERNS` in gateway_utils.py
