### PR TITLE
The resolution is not an optional argument

### DIFF
--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -84,7 +84,7 @@ logger = logging.getLogger(__file__)
 redis_logger = logging.getLogger("agent.redis")
 
 
-def _should_update_jira(resolution: Resolution = None, user_triggered: bool = False) -> bool:
+def _should_update_jira(resolution: Resolution, user_triggered: bool = False) -> bool:
     """Whether to post a user-facing Jira comment for this run.
 
     Used only for comments — labels are dedup anchors and are written


### PR DESCRIPTION
This bothered me a bit. The `resolution` argument is supplied in all call locations. It also doesn't make sense to keep it with `None` as a default. 