### PR TITLE
Filter out modular and regular issues when looking for duplicates

### DIFF
--- a/ymir/agents/tests/unit/test_triage_agent.py
+++ b/ymir/agents/tests/unit/test_triage_agent.py
@@ -209,7 +209,7 @@ async def test_process_task_proceeds_for_open_issues():
         ("postgresql:12/postgresql:vuln", "", False),
     ],
 )
-def testis_modular(summary, downstream_component, expected):
+def test_is_modular(summary, downstream_component, expected):
     assert is_modular(summary, downstream_component) is expected
 
 

--- a/ymir/agents/tests/unit/test_triage_agent.py
+++ b/ymir/agents/tests/unit/test_triage_agent.py
@@ -4,13 +4,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from ymir.agents.triage_agent import (
-    _is_modular,
     _map_version_to_module_branch,
     _parse_module_summary,
     _should_update_jira,
     determine_target_branch,
 )
 from ymir.common.models import BackportData, CVEEligibilityResult, Resolution, Task, TriageEligibility
+from ymir.common.version_utils import is_modular
 
 
 @pytest.mark.parametrize(
@@ -209,8 +209,8 @@ async def test_process_task_proceeds_for_open_issues():
         ("postgresql:12/postgresql:vuln", "", False),
     ],
 )
-def test_is_modular(summary, downstream_component, expected):
-    assert _is_modular(summary, downstream_component) is expected
+def testis_modular(summary, downstream_component, expected):
+    assert is_modular(summary, downstream_component) is expected
 
 
 # --- Module summary parsing tests ---

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -68,7 +68,9 @@ from ymir.common.utils import (
     get_latest_candidate_build,
 )
 from ymir.common.version_utils import (
+    MODULAR_SUMMARY_PREFIX,
     construct_internal_branch_name,
+    is_modular,
     is_older_zstream,
     normalize_fix_version,
     parse_rhel_version,
@@ -117,28 +119,9 @@ _RESOLUTION_TO_LABEL: dict[Resolution, JiraLabels] = {
 }
 
 
-# Optional CVE-YYYY-NNNNN prefix, then module:stream/<package>:
-# The package segment is the Downstream Component Name (not a free word match).
-_MODULAR_SUMMARY_PREFIX = r"^(?:CVE-\d{4}-\d+\s+)?([\w.+-]+):([^/\s]+)/"
-
-
 def _modular_summary_re(downstream_component: str) -> re.Pattern[str]:
     """Build a modular-summary regex anchored on the Downstream Component Name."""
-    return re.compile(_MODULAR_SUMMARY_PREFIX + re.escape(downstream_component) + r":")
-
-
-def _is_modular(jira_summary: str | None, downstream_component: str | None) -> bool:
-    """Detect whether the Jira ticket targets a modular package.
-
-    Modular summaries follow ``module:stream/<package>:Title`` (optionally
-    CVE-prefixed), where ``<package>`` is the Downstream Component Name
-    (customfield_10669), e.g. summary ``postgresql:12/postgresql:…`` with
-    downstream component ``postgresql``. Non-modular summaries are
-    ``package:Title`` or ``CVE-... package:Title``.
-    """
-    if not jira_summary or not downstream_component:
-        return False
-    return bool(_modular_summary_re(downstream_component).match(jira_summary))
+    return re.compile(MODULAR_SUMMARY_PREFIX + re.escape(downstream_component) + r":")
 
 
 def _parse_module_summary(summary: str, downstream_component: str) -> tuple[str, str] | None:
@@ -212,7 +195,7 @@ async def determine_target_branch(
 
     package = triage_data.package if hasattr(triage_data, "package") else None
 
-    if _is_modular(jira_summary, downstream_component):
+    if is_modular(jira_summary, downstream_component):
         branch = _map_version_to_module_branch(triage_data.fix_version, jira_summary, downstream_component)
         if not branch:
             return None, None
@@ -325,7 +308,7 @@ async def render_prompt(
         cve_eligibility_result and cve_eligibility_result.is_cve and cve_eligibility_result.needs_internal_fix
     )
     if cve_needs_internal_fix and fix_version:
-        if _is_modular(jira_summary, downstream_component):
+        if is_modular(jira_summary, downstream_component):
             internal_branch = _map_version_to_module_branch(fix_version, jira_summary, downstream_component)
             if internal_branch:
                 updates["needs_internal_fix"] = True

--- a/ymir/common/version_utils.py
+++ b/ymir/common/version_utils.py
@@ -247,3 +247,12 @@ async def is_older_zstream(
     current_minor = int(current_parsed[1])
     target_minor = int(minor_str)
     return target_minor < current_minor
+
+
+MODULAR_SUMMARY_PREFIX = r"^(?:CVE-\d{4}-\d+\s+)?([\w.+-]+):([^/\s]+)/"
+
+
+def is_modular(summary: str | None, component: str | None) -> bool:
+    if not summary or not component:
+        return False
+    return bool(re.match(MODULAR_SUMMARY_PREFIX + re.escape(component) + r":", summary))

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -536,7 +536,7 @@ async def _check_duplicate_tracker(
         input={"jql": jql, "fields": ["status", "resolution", "summary"], "max_results": 50}
     )
     issues = [
-        i for i in output.result if is_modular(i.get("fields", {}).get("summary", ""), component) == modular
+        i for i in output.result if is_modular(i.get("fields", {}).get("summary"), component) == modular
     ]
 
     if not issues:

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -25,6 +25,7 @@ from ymir.common.utils import _get_koji_build
 from ymir.common.version_utils import (
     get_fix_version_variants,
     get_maintenance_majors,
+    is_modular,
     normalize_fix_version,
     nvr_to_cs_nvr,
     parse_rhel_version,
@@ -392,16 +393,10 @@ class AddJiraCommentTool(Tool[AddJiraCommentToolInput, ToolRunOptions, StringToo
 
 CVE_ID_PATTERN = re.compile(r"(CVE-\d{4}-\d{4,})")
 
-_MODULAR_SUMMARY_PREFIX = r"^(?:CVE-\d{4}-\d+\s+)?([\w.+-]+):([^/\s]+)/"
-
 
 def extract_cve_id(summary: str) -> str | None:
     match = CVE_ID_PATTERN.search(summary)
     return match.group(1) if match else None
-
-
-def _is_modular_summary(summary: str, component: str) -> bool:
-    return bool(re.match(_MODULAR_SUMMARY_PREFIX + re.escape(component) + r":", summary))
 
 
 async def _check_zstream_clones_shipped(
@@ -515,7 +510,7 @@ async def _check_duplicate_tracker(
     component: str,
     fix_version: str,
     issue_key: str,
-    is_modular: bool = False,
+    modular: bool = False,
 ) -> tuple[str | None, bool]:
     """Check for duplicate CVE trackers (same CVE + component + fix version).
 
@@ -541,9 +536,7 @@ async def _check_duplicate_tracker(
         input={"jql": jql, "fields": ["status", "resolution", "summary"], "max_results": 50}
     )
     issues = [
-        i
-        for i in output.result
-        if _is_modular_summary(i.get("fields", {}).get("summary", ""), component) == is_modular
+        i for i in output.result if is_modular(i.get("fields", {}).get("summary", ""), component) == modular
     ]
 
     if not issues:
@@ -968,7 +961,7 @@ class CheckCveTriageEligibilityTool(
                 component,
                 target_version,
                 issue_key,
-                is_modular=_is_modular_summary(summary, component),
+                modular=is_modular(summary, component),
             )
         except Exception as e:
             logger.warning(f"Duplicate tracker check failed for {issue_key}: {e}")

--- a/ymir/tools/privileged/jira.py
+++ b/ymir/tools/privileged/jira.py
@@ -392,10 +392,16 @@ class AddJiraCommentTool(Tool[AddJiraCommentToolInput, ToolRunOptions, StringToo
 
 CVE_ID_PATTERN = re.compile(r"(CVE-\d{4}-\d{4,})")
 
+_MODULAR_SUMMARY_PREFIX = r"^(?:CVE-\d{4}-\d+\s+)?([\w.+-]+):([^/\s]+)/"
+
 
 def extract_cve_id(summary: str) -> str | None:
     match = CVE_ID_PATTERN.search(summary)
     return match.group(1) if match else None
+
+
+def _is_modular_summary(summary: str, component: str) -> bool:
+    return bool(re.match(_MODULAR_SUMMARY_PREFIX + re.escape(component) + r":", summary))
 
 
 async def _check_zstream_clones_shipped(
@@ -505,7 +511,11 @@ def _issue_number(key: str) -> int:
 
 
 async def _check_duplicate_tracker(
-    cve_id: str, component: str, fix_version: str, issue_key: str
+    cve_id: str,
+    component: str,
+    fix_version: str,
+    issue_key: str,
+    is_modular: bool = False,
 ) -> tuple[str | None, bool]:
     """Check for duplicate CVE trackers (same CVE + component + fix version).
 
@@ -527,8 +537,14 @@ async def _check_duplicate_tracker(
     logger.info(f"Checking for duplicate trackers with JQL: {jql}")
 
     tool = SearchJiraIssuesTool()
-    output = await tool.run(input={"jql": jql, "fields": ["status", "resolution"], "max_results": 50})
-    issues = output.result
+    output = await tool.run(
+        input={"jql": jql, "fields": ["status", "resolution", "summary"], "max_results": 50}
+    )
+    issues = [
+        i
+        for i in output.result
+        if _is_modular_summary(i.get("fields", {}).get("summary", ""), component) == is_modular
+    ]
 
     if not issues:
         logger.info(f"No duplicate trackers found for {cve_id} in {component}/{fix_version}")
@@ -952,6 +968,7 @@ class CheckCveTriageEligibilityTool(
                 component,
                 target_version,
                 issue_key,
+                is_modular=_is_modular_summary(summary, component),
             )
         except Exception as e:
             logger.warning(f"Duplicate tracker check failed for {issue_key}: {e}")

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -23,6 +23,7 @@ from ymir.tools.privileged.jira import (
     _check_duplicate_tracker,
     _check_zstream_clones_shipped,
     _check_zstream_fix_approach,
+    _is_modular_summary,
     extract_cve_id,
 )
 
@@ -520,6 +521,21 @@ async def test_verify_issue_author(user_groups, expected_result, use_account_id)
 )
 def test_extract_cve_id(summary, expected):
     assert extract_cve_id(summary) == expected
+
+
+@pytest.mark.parametrize(
+    "summary, component, expected",
+    [
+        ("CVE-2025-1234 postgresql:15/postgresql: overflow", "postgresql", True),
+        ("postgresql:12/postgresql: some vuln", "postgresql", True),
+        ("CVE-2025-1234 postgresql: overflow", "postgresql", False),
+        ("postgresql: some vuln", "postgresql", False),
+        ("CVE-2025-1234 nginx:1.22/nginx: bug", "nginx", True),
+        ("CVE-2025-1234 nginx: bug", "nginx", False),
+    ],
+)
+def test_is_modular_summary(summary, component, expected):
+    assert _is_modular_summary(summary, component) is expected
 
 
 # --- Z-stream clone check tests ---
@@ -1546,6 +1562,34 @@ async def test_check_duplicate_wont_do_not_blocked():
     assert should_block is False
 
 
+@pytest.mark.asyncio
+async def test_check_duplicate_modular_candidate_filtered_out():
+    """Non-modular issue should not match a modular candidate as duplicate."""
+    search_result = [
+        {
+            "key": "RHEL-100",
+            "fields": {
+                "status": {"name": "New"},
+                "resolution": None,
+                "summary": "CVE-2025-12345 postgresql:15/postgresql: overflow",
+            },
+        },
+    ]
+    flexmock(SearchJiraIssuesTool).should_receive("run").and_return(
+        _create_async_return(JSONToolOutput(result=search_result))
+    ).once()
+
+    dup_key, should_block = await _check_duplicate_tracker(
+        "CVE-2025-12345",
+        "postgresql",
+        "rhel-9.2.0.z",
+        "RHEL-500",
+        is_modular=False,
+    )
+    assert dup_key is None
+    assert should_block is False
+
+
 # --- Eligibility tool: duplicate tracker integration tests ---
 
 
@@ -1570,7 +1614,7 @@ async def test_eligibility_zstream_blocking_duplicate():
         )
     ).once()
     flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
-        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345"
+        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345", is_modular=False
     ).and_return(_create_async_return(("RHEL-100", True))).once()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
@@ -1600,7 +1644,7 @@ async def test_eligibility_zstream_nonblocking_duplicate():
         )
     ).once()
     flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
-        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345"
+        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345", is_modular=False
     ).and_return(_create_async_return(("RHEL-100", False))).once()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
@@ -1629,7 +1673,36 @@ async def test_eligibility_no_duplicate():
         )
     ).once()
     flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
-        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345"
+        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345", is_modular=False
+    ).and_return(_create_async_return((None, False))).once()
+
+    result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
+    assert result["eligibility"] == TriageEligibility.IMMEDIATELY
+    assert result["duplicate_of"] is None
+
+
+@pytest.mark.asyncio
+async def test_eligibility_modular_filters_nonmodular_duplicates():
+    """Modular issue should not match non-modular candidates as duplicates."""
+    issue = _make_jira_issue(
+        labels=["SecurityTracking"],
+        fix_versions=[{"name": "rhel-9.6.z"}],
+        summary="CVE-2025-12345 postgresql:15/postgresql: overflow [rhel-9.6.z]",
+        severity="moderate",
+        components=[{"name": "postgresql"}],
+    )
+    flexmock(aiohttp.ClientSession).should_receive("get").replace_with(_mock_jira_get(issue))
+    flexmock(jira_tools).should_receive("load_rhel_config").and_return(
+        _create_async_return(
+            {
+                "current_y_streams": {"9": "rhel-9.8"},
+                "current_z_streams": {"9": "rhel-9.6.z"},
+                "upcoming_z_streams": {},
+            }
+        )
+    ).once()
+    flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
+        "CVE-2025-12345", "postgresql", "rhel-9.6.z", "RHEL-12345", is_modular=True
     ).and_return(_create_async_return((None, False))).once()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result

--- a/ymir/tools/privileged/tests/unit/test_jira.py
+++ b/ymir/tools/privileged/tests/unit/test_jira.py
@@ -8,6 +8,7 @@ from beeai_framework.tools import JSONToolOutput
 from flexmock import flexmock
 
 from ymir.common.models import TriageEligibility
+from ymir.common.version_utils import is_modular
 from ymir.tools.privileged import jira as jira_tools
 from ymir.tools.privileged.jira import (
     AddJiraCommentTool,
@@ -23,7 +24,6 @@ from ymir.tools.privileged.jira import (
     _check_duplicate_tracker,
     _check_zstream_clones_shipped,
     _check_zstream_fix_approach,
-    _is_modular_summary,
     extract_cve_id,
 )
 
@@ -532,10 +532,13 @@ def test_extract_cve_id(summary, expected):
         ("postgresql: some vuln", "postgresql", False),
         ("CVE-2025-1234 nginx:1.22/nginx: bug", "nginx", True),
         ("CVE-2025-1234 nginx: bug", "nginx", False),
+        (None, "postgresql", False),
+        ("CVE-2025-1234 postgresql:15/postgresql: overflow", None, False),
+        (None, None, False),
     ],
 )
-def test_is_modular_summary(summary, component, expected):
-    assert _is_modular_summary(summary, component) is expected
+def test_is_modular(summary, component, expected):
+    assert is_modular(summary, component) is expected
 
 
 # --- Z-stream clone check tests ---
@@ -1584,7 +1587,7 @@ async def test_check_duplicate_modular_candidate_filtered_out():
         "postgresql",
         "rhel-9.2.0.z",
         "RHEL-500",
-        is_modular=False,
+        modular=False,
     )
     assert dup_key is None
     assert should_block is False
@@ -1614,7 +1617,7 @@ async def test_eligibility_zstream_blocking_duplicate():
         )
     ).once()
     flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
-        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345", is_modular=False
+        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345", modular=False
     ).and_return(_create_async_return(("RHEL-100", True))).once()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
@@ -1644,7 +1647,7 @@ async def test_eligibility_zstream_nonblocking_duplicate():
         )
     ).once()
     flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
-        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345", is_modular=False
+        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345", modular=False
     ).and_return(_create_async_return(("RHEL-100", False))).once()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
@@ -1673,7 +1676,7 @@ async def test_eligibility_no_duplicate():
         )
     ).once()
     flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
-        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345", is_modular=False
+        "CVE-2025-12345", "curl", "rhel-9.6.z", "RHEL-12345", modular=False
     ).and_return(_create_async_return((None, False))).once()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result
@@ -1702,7 +1705,7 @@ async def test_eligibility_modular_filters_nonmodular_duplicates():
         )
     ).once()
     flexmock(jira_tools).should_receive("_check_duplicate_tracker").with_args(
-        "CVE-2025-12345", "postgresql", "rhel-9.6.z", "RHEL-12345", is_modular=True
+        "CVE-2025-12345", "postgresql", "rhel-9.6.z", "RHEL-12345", modular=True
     ).and_return(_create_async_return((None, False))).once()
 
     result = (await CheckCveTriageEligibilityTool().run(input={"issue_key": "RHEL-12345"})).result


### PR DESCRIPTION
This patch addresses the issue where we might encounter modular Jira issues that would match as duplicates, for example "postgresql" and "postgresql:15" as component would be the only difference. The Jira cannot distinguish between the two because they map to the exact same component id in Jira thus JQL returning 'duplicate' issues which are in fact not duplicates. The fix borrows the same approach as used for filtering out modular issues already.
