### PR TITLE
Multiple fixes found during development of reproducer agent

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -100,6 +100,10 @@ services:
       - KEYTAB_FILE=/home/mcp/keytab
       # default cache location is a keyring
       - KRB5CCNAME=FILE:/tmp/krb5cc
+      # Point requests at the system CA bundle (includes RH IT Root CAs from
+      # files/Current-IT-Root-CAs.pem via update-ca-trust in Containerfile.mcp).
+      # Without this, requests uses certifi and fails on internal HTTPS (e.g. artifacts.osci).
+      - REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
       # SAFETY: These default to false for production agents, but MUST be true for E2E tests.
       # The E2E Makefile targets set them in the environment before invoking compose
       # (e.g., MOCK_JIRA=true DRY_RUN=true make run-triage-agent-e2e-tests) so the

--- a/ymir/agents/reasoning_agent/_runner.py
+++ b/ymir/agents/reasoning_agent/_runner.py
@@ -413,7 +413,7 @@ class ReasoningAgentRunner:
                 tools=tools_for_llm,
                 tool_choice="auto",
                 stream_partial_tool_calls=True,
-                parallel_tool_calls=self._llm.allow_parallel_tool_calls or None,
+                parallel_tool_calls=self._llm.allow_parallel_tool_calls,
                 fallback_tool=self._final_answer if evaluation.can_stop else None,
             )
             cache_index = 0
@@ -437,7 +437,7 @@ class ReasoningAgentRunner:
                 tools=tools_for_llm,
                 tool_choice=evaluation.tool_choice,
                 stream_partial_tool_calls=True,
-                parallel_tool_calls=self._llm.allow_parallel_tool_calls or None,
+                parallel_tool_calls=self._llm.allow_parallel_tool_calls,
                 fallback_tool=self._final_answer if evaluation.can_stop else None,
             )
             cache_index = 1 if self._requirements else 0

--- a/ymir/agents/reasoning_agent/_runner.py
+++ b/ymir/agents/reasoning_agent/_runner.py
@@ -1,4 +1,7 @@
+import asyncio
 import json
+import logging
+import os
 import uuid
 from collections.abc import Sequence
 from typing import Any, Self
@@ -342,15 +345,25 @@ class ReasoningAgentRunner:
 
     async def _run_llm(self, evaluation: RequirementEvaluation) -> ChatModelOutput:
         stream_middleware = self._create_final_answer_stream()
+        llm_timeout = int(os.getenv("CHAT_MODEL_TIMEOUT", 1200))
 
         try:
             messages, options = self._prepare_llm_request(evaluation)
-            response = await self._llm.run(messages, **options).middleware(stream_middleware)
+            # Hard kill if the provider ignores ChatModel.timeout (same CHAT_MODEL_TIMEOUT env).
+            async with asyncio.timeout(llm_timeout):
+                response = await self._llm.run(messages, **options).middleware(stream_middleware)
 
             self._state.usage.merge(response.usage)
             self._state.cost.merge(response.cost)
 
             return response
+        except TimeoutError:
+            logging.getLogger(__name__).error(
+                "LLM call timed out after %ds (iteration %d)",
+                llm_timeout,
+                self._state.iteration,
+            )
+            raise AgentError(f"LLM call timed out after {llm_timeout}s") from None
         except ChatModelToolCallError as e:
             generated_content = e.generated_content or (e.response.get_text_content() if e.response else "")
             if not generated_content:

--- a/ymir/agents/reasoning_agent/agent.py
+++ b/ymir/agents/reasoning_agent/agent.py
@@ -64,7 +64,6 @@ class ReasoningAgent(BaseAgent[ReasoningAgentOutput]):
         final_answer_as_tool: bool = True,
         save_intermediate_steps: bool = True,
         enable_context_management: bool = False,
-        sequential_tool_calls: bool = True,
         templates: dict[ReasoningAgentTemplatesKeys, PromptTemplate[Any] | ReasoningAgentTemplateFactory]
         | ReasoningAgentTemplates
         | None = None,
@@ -78,20 +77,18 @@ class ReasoningAgent(BaseAgent[ReasoningAgentOutput]):
         self._tool_call_checker = tool_call_checker
         self._final_answer_as_tool = final_answer_as_tool
         self._enable_context_management = enable_context_management
-        self._sequential_tool_calls = sequential_tool_calls
         self._unconstrained = unconstrained
         self._requirements = [] if unconstrained else list(requirements or [])
-        template_defaults: dict[str, Any] = {}
+        template_defaults: dict[str, Any] = {
+            "allow_parallel_tool_calls": bool(self._llm.allow_parallel_tool_calls),
+        }
         if role:
             template_defaults["role"] = role
         if instructions:
             template_defaults["instructions"] = "\n -".join(cast_list(instructions))
         if notes:
             template_defaults["notes"] = "\n -".join(cast_list(notes))
-        if not sequential_tool_calls:
-            template_defaults["sequential_tool_calls"] = False
-        if template_defaults:
-            self._templates.system.update(defaults=template_defaults)
+        self._templates.system.update(defaults=template_defaults)
         tools_list = list(tools or [])
         if unconstrained:
             tools_list = [t for t in tools_list if not isinstance(t, ThinkTool)]
@@ -220,7 +217,6 @@ class ReasoningAgent(BaseAgent[ReasoningAgentOutput]):
             save_intermediate_steps=self._save_intermediate_steps,
             final_answer_as_tool=self._final_answer_as_tool,
             enable_context_management=self._enable_context_management,
-            sequential_tool_calls=self._sequential_tool_calls,
             name=self._meta.name,
             description=self._meta.description,
             middlewares=self.middlewares.copy(),

--- a/ymir/agents/reasoning_agent/context_management.py
+++ b/ymir/agents/reasoning_agent/context_management.py
@@ -90,22 +90,22 @@ class ManageContextTool(Tool[ManageContextSchema, ToolRunOptions, StringToolOutp
 
 
 def partition_exchanges(messages: list[AnyMessage]) -> tuple[list[AnyMessage], list[list[AnyMessage]]]:
-    """Split memory into a protected prefix and tool/user exchanges.
+    """Split memory into protected task messages and tool/user exchanges.
 
-    Protected messages (task prompt) are collected only while no non-protected
-    message has been seen yet. An exchange is an assistant message with tool
-    calls plus its following tool results, or a standalone user/assistant text
-    message (e.g. a prior context summary).
+    Every message tagged with ``YMIR_PROTECTED_META_KEY`` is protected, even
+    when memory already contains older unprotected exchanges from a prior
+    ``ReasoningAgent.run()`` (e.g. ``save_intermediate_steps=True``).
+    An exchange is an assistant message with tool calls plus its following tool
+    results, or a standalone user/assistant text message (e.g. a prior context
+    summary).
     """
     protected: list[AnyMessage] = []
     rest: list[AnyMessage] = []
-    seen_unprotected = False
     for msg in messages:
-        if not seen_unprotected and msg.meta.get(YMIR_PROTECTED_META_KEY):
+        if msg.meta.get(YMIR_PROTECTED_META_KEY):
             protected.append(msg)
-            continue
-        seen_unprotected = True
-        rest.append(msg)
+        else:
+            rest.append(msg)
 
     exchanges: list[list[AnyMessage]] = []
     current: list[AnyMessage] = []
@@ -177,14 +177,13 @@ def strip_manage_context_from_exchange(exchange: list[AnyMessage]) -> list[AnyMe
             if _assistant_has_provider_visible_output(msg):
                 cleaned.append(msg)
         elif isinstance(msg, ToolMessage):
-            keep = True
-            for content in msg.content:
-                tool_call_id = getattr(content, "tool_call_id", None)
-                tool_name = getattr(content, "tool_name", None)
-                if tool_call_id in manage_ids or tool_name == MANAGE_CONTEXT_TOOL_NAME:
-                    keep = False
-                    break
-            if keep:
+            msg.content[:] = [
+                content
+                for content in msg.content
+                if getattr(content, "tool_call_id", None) not in manage_ids
+                and getattr(content, "tool_name", None) != MANAGE_CONTEXT_TOOL_NAME
+            ]
+            if msg.content:
                 cleaned.append(msg)
         else:
             cleaned.append(msg)

--- a/ymir/agents/reasoning_agent/prompts.py
+++ b/ymir/agents/reasoning_agent/prompts.py
@@ -38,7 +38,7 @@ class ReasoningAgentSystemPromptInput(BaseModel):
     final_answer_instructions: str | None
     notes: str | None = None
     tool_constraints: str | None = None
-    sequential_tool_calls: bool = True
+    allow_parallel_tool_calls: bool = False
     tools: list[ReasoningAgentToolTemplateDefinition] = Field(default_factory=list)
 
 
@@ -95,13 +95,13 @@ Never use the tool twice with the same input if not stated otherwise.
 - Use markdown syntax to format code snippets, links, JSON, tables, images, and files.
 - If the provided task is unclear, ask the user for clarification.
 - Do not refer to tools or tool outputs by name when responding.
-{{#sequential_tool_calls}}
+{{^allow_parallel_tool_calls}}
 - Always take it one step at a time. Don't try to do multiple things at once.
-{{/sequential_tool_calls}}
-{{^sequential_tool_calls}}
+{{/allow_parallel_tool_calls}}
+{{#allow_parallel_tool_calls}}
 - You may submit multiple independent tool calls in a single turn to save time.
   Only keep calls sequential when one depends on the result of another.
-{{/sequential_tool_calls}}
+{{/allow_parallel_tool_calls}}
 - When the tool doesn't give you what you were asking for, you must either use another tool or a different tool input.
 - You should always try a few different approaches before declaring the problem unsolvable.
 - If you can't fully answer the user's question, answer partially and describe what you couldn't achieve.

--- a/ymir/agents/tests/e2e/backport_agent/test_backport.py
+++ b/ymir/agents/tests/e2e/backport_agent/test_backport.py
@@ -41,6 +41,8 @@ class BackportAgentTestCase:
         self.artifacts: CapturedArtifacts | None = None
         self.error: BaseException | None = None
         self.zstream_override: dict[str, str] | None = None
+        # Used by e2e/conftest.py results.yaml reporting (optional skip note).
+        self.skip_reason: str | None = None
 
     def __repr__(self) -> str:
         return f"BackportTestCase({self.jira_issue})"

--- a/ymir/agents/tests/e2e/conftest.py
+++ b/ymir/agents/tests/e2e/conftest.py
@@ -59,6 +59,26 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_slow)
 
 
+def _e2e_case_id(test_case) -> str:
+    """Stable id for results.yaml name/log entries across e2e suites.
+
+    Triage uses a string ``input`` (jira key). Backport/reproducer use a dict
+    ``input`` plus ``jira_issue``. MR consolidation uses ``name`` only.
+    """
+    jira_issue = getattr(test_case, "jira_issue", None)
+    if jira_issue:
+        return str(jira_issue)
+    name = getattr(test_case, "name", None)
+    if name:
+        return str(name)
+    case_input = getattr(test_case, "input", None)
+    if isinstance(case_input, str):
+        return case_input
+    if isinstance(case_input, dict) and case_input.get("jira_issue"):
+        return str(case_input["jira_issue"])
+    return str(case_input)
+
+
 @pytest.hookimpl(wrapper=True, trylast=True)
 def pytest_runtest_makereport(item, call):
     # execute all other hooks to obtain the report object
@@ -66,36 +86,43 @@ def pytest_runtest_makereport(item, call):
     if rep.when != "call":
         return rep
 
-    test_case = item.callspec.params["test_case"]
+    # Only e2e suites that parametrize ``test_case`` write results.yaml.
+    callspec = getattr(item, "callspec", None)
+    if callspec is None or "test_case" not in callspec.params:
+        return rep
+
+    test_case = callspec.params["test_case"]
+    case_id = _e2e_case_id(test_case)
 
     mode = "a" if os.path.exists("/home/beeai/results.yaml") else "w"
     with open("/home/beeai/results.yaml", mode, encoding="utf-8") as f:
-        f.write(f'\n- name: "/{test_case.input}"\n')
+        f.write(f'\n- name: "/{case_id}"\n')
 
         result = "fail" if rep.failed else "pass" if rep.passed else "skip"
         f.write(f'  result: "{result}"\n')
 
         f.write("  note:\n")
-        if test_case.metrics is not None:
+        metrics = getattr(test_case, "metrics", None)
+        if metrics is not None:
             for note, value in (
-                ("Agent", test_case.metrics.get("agent_name", None)),
-                ("Tool Calls", test_case.metrics.get("tool_calls", None)),
-                ("Prompt Tokens", test_case.metrics.get("prompt_tokens", None)),
-                ("Completion Tokens", test_case.metrics.get("completion_tokens", None)),
+                ("Agent", metrics.get("agent_name", None)),
+                ("Tool Calls", metrics.get("tool_calls", None)),
+                ("Prompt Tokens", metrics.get("prompt_tokens", None)),
+                ("Completion Tokens", metrics.get("completion_tokens", None)),
             ):
                 if value is None:
                     continue
                 f.write(f'    - "{note}: {value}"\n')
 
-        # Add additional note, if the test was skipped
-        if test_case.skip_reason is not None:
-            f.write(f'    - "Skipped because {test_case.skip_reason}"\n')
+        skip_reason = getattr(test_case, "skip_reason", None)
+        if skip_reason is not None:
+            f.write(f'    - "Skipped because {skip_reason}"\n')
 
         f.write("  log:\n")
-        for log in (f"{test_case.input}.html", f"{test_case.input}.json"):
+        for log in (f"{case_id}.html", f"{case_id}.json"):
             f.write(f"    - {log}\n")
 
-        minutes, seconds = divmod(int((test_case.metrics or {}).get("duration", 0)), 60)
+        minutes, seconds = divmod(int((metrics or {}).get("duration", 0)), 60)
         hours, minutes = divmod(minutes, 60)
         f.write(f"  duration: {hours:02d}:{minutes:02d}:{seconds:02d}\n")
 

--- a/ymir/agents/tests/e2e/mr_consolidation/test_mr_consolidation.py
+++ b/ymir/agents/tests/e2e/mr_consolidation/test_mr_consolidation.py
@@ -45,6 +45,9 @@ class ConsolidationTestCase:
         self.consolidation_state: ConsolidationState | None = None
         self.artifacts: ConsolidationArtifacts | None = None
         self.error: BaseException | None = None
+        # Used by e2e/conftest.py results.yaml reporting.
+        self.metrics: dict | None = None
+        self.skip_reason: str | None = None
 
     def __repr__(self) -> str:
         return f"ConsolidationTestCase({self.name})"

--- a/ymir/agents/tests/unit/test_context_management.py
+++ b/ymir/agents/tests/unit/test_context_management.py
@@ -66,6 +66,18 @@ def test_partition_exchanges_keeps_protected_prefix():
     assert exchanges[1] == ex2
 
 
+def test_partition_exchanges_protects_all_tagged_task_messages():
+    task1 = _task_message("Your task: first turn")
+    ex1 = _exchange("view", "c1", "file contents")
+    task2 = _task_message("Your task: second turn")
+    ex2 = _exchange("shell", "c2", "failed")
+    protected, exchanges = partition_exchanges([task1, *ex1, task2, *ex2])
+    assert protected == [task1, task2]
+    assert len(exchanges) == 2
+    assert exchanges[0] == ex1
+    assert exchanges[1] == ex2
+
+
 def test_strip_manage_context_from_exchange():
     assistant = AssistantMessage(
         [
@@ -88,6 +100,31 @@ def test_strip_manage_context_from_exchange():
     assert [c.tool_name for c in cleaned[0].get_tool_calls()] == ["view"]
     assert isinstance(cleaned[1], ToolMessage)
     assert cleaned[1].content[0].tool_name == "view"
+
+
+def test_strip_manage_context_keeps_sibling_results_in_batched_tool_message():
+    assistant = AssistantMessage(
+        [
+            _tool_call("view", "c1"),
+            _tool_call(MANAGE_CONTEXT_TOOL_NAME, "c2", '{"durable_summary":"keep me"}'),
+        ]
+    )
+    batched = ToolMessage(
+        [
+            MessageToolResultContent(tool_name="view", tool_call_id="c1", result="data"),
+            MessageToolResultContent(
+                tool_name=MANAGE_CONTEXT_TOOL_NAME,
+                tool_call_id="c2",
+                result="scheduled",
+            ),
+        ]
+    )
+    cleaned = strip_manage_context_from_exchange([assistant, batched])
+    assert len(cleaned) == 2
+    assert [c.tool_name for c in cleaned[0].get_tool_calls()] == ["view"]
+    assert len(cleaned[1].content) == 1
+    assert cleaned[1].content[0].tool_name == "view"
+    assert cleaned[1].content[0].result == "data"
 
 
 def test_strip_drops_thinking_only_assistant_after_solo_manage_context():
@@ -150,6 +187,27 @@ async def test_manage_context_tool_only_schedules():
     assert state.pending_context_compaction is not None
     assert state.pending_context_compaction.durable_summary == "important fact"
     assert list(state.memory.messages) == before
+
+
+@pytest.mark.asyncio
+async def test_apply_compaction_protects_later_task_messages():
+    task1 = _task_message("Your task: first turn")
+    ex1 = _exchange("view", "c1", "dead end dump " * 20)
+    task2 = _task_message("Your task: second turn")
+    ex2 = _exchange("shell", "c2", "also failed")
+    state = _state_with_messages([task1, *ex1, task2, *ex2])
+    state.pending_context_compaction = ManageContextSchema(
+        durable_summary="CVE-2026-1; approach A failed",
+        keep_recent_exchanges=1,
+    )
+
+    applied = await apply_pending_context_compaction(state)
+    assert applied is True
+
+    protected = [m for m in state.memory.messages if m.meta.get(YMIR_PROTECTED_META_KEY)]
+    assert len(protected) == 2
+    assert "first turn" in protected[0].text
+    assert "second turn" in protected[1].text
 
 
 @pytest.mark.asyncio

--- a/ymir/agents/utils.py
+++ b/ymir/agents/utils.py
@@ -58,7 +58,7 @@ def get_chat_model() -> ChatModel:
             temperature=1 if "claude" in chat_model and reasoning_effort else temperature,
             reasoning_effort=reasoning_effort,
         ),
-        timeout=1200,
+        timeout=int(os.getenv("CHAT_MODEL_TIMEOUT", 1200)),
         # beeai hardcodes max_retries=0 in its litellm adapter; num_retries
         # bypasses that and enables litellm's built-in retry with back-off
         # for transient 429 / rate-limit errors from the provider.


### PR DESCRIPTION
- Enforce CHAT_MODEL_TIMEOUT on reasoning-agent LLM calls - there was no timeout for vertex reply
- Propagate CA to mcp gateway in local deployment - local compose could not access artifacts
- Fix absence of skip_reason crash in test suites - absence of skip reason was crashing test suites
- Address context-management review findings from PR - result of nforro AI review