### PR TITLE
Increase timeout for `FindBaseCommitTool`

### DIFF
--- a/ymir/tools/unprivileged/upstream_tools.py
+++ b/ymir/tools/unprivileged/upstream_tools.py
@@ -371,7 +371,7 @@ class FindBaseCommitToolInput(BaseModel):
 
 class FindBaseCommitTool(Tool[FindBaseCommitToolInput, ToolRunOptions, StringToolOutput]):
     name = "find_base_commit"
-    timeout = 30
+    timeout = 300
     description = """
     Find and checkout the base version commit in an upstream repository.
 


### PR DESCRIPTION
`git checkout` alone can take way over 30 seconds on large repos.