### PR TITLE
Freeze pre-commit repo references and update secrets baseline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: '\.patch$'
@@ -11,12 +11,12 @@ repos:
       - id: check-merge-conflict
       - id: mixed-line-ending
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+    rev: 68e8b45440415753fff70a312ece8da92ba85b4a  # frozen: v1.5.0
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: 65dbdb59d2f2d9c3bdc343c566821ad3319ddaa3  # frozen: v0.16.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,10 +91,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -127,14 +123,36 @@
     }
   ],
   "results": {
+    ".pre-commit-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "26f89e75489173ffe046cc843b9a983e65020901",
+        "is_verified": false,
+        "line_number": 3
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "86242b7a7b67c1fd83514757a6b319602d648e94",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "5a85fbd9e785723f57d7b44d7919b2bf8543b0bf",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
     "openshift/cronjob-supervisor-collector.yml": [
       {
         "type": "Secret Keyword",
         "filename": "openshift/cronjob-supervisor-collector.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 81,
-        "is_secret": false
+        "line_number": 81
       }
     ],
     "openshift/deployment-backport-agent-c10s.yml": [
@@ -143,8 +161,7 @@
         "filename": "openshift/deployment-backport-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 84,
-        "is_secret": false
+        "line_number": 84
       }
     ],
     "openshift/deployment-backport-agent-c9s.yml": [
@@ -153,8 +170,7 @@
         "filename": "openshift/deployment-backport-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 84,
-        "is_secret": false
+        "line_number": 84
       }
     ],
     "openshift/deployment-rebase-agent-c10s.yml": [
@@ -163,8 +179,7 @@
         "filename": "openshift/deployment-rebase-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 84,
-        "is_secret": false
+        "line_number": 84
       }
     ],
     "openshift/deployment-rebase-agent-c9s.yml": [
@@ -173,8 +188,7 @@
         "filename": "openshift/deployment-rebase-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 84,
-        "is_secret": false
+        "line_number": 84
       }
     ],
     "openshift/deployment-rebuild-agent-c10s.yml": [
@@ -183,8 +197,7 @@
         "filename": "openshift/deployment-rebuild-agent-c10s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 84,
-        "is_secret": false
+        "line_number": 84
       }
     ],
     "openshift/deployment-rebuild-agent-c9s.yml": [
@@ -193,8 +206,7 @@
         "filename": "openshift/deployment-rebuild-agent-c9s.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 84,
-        "is_secret": false
+        "line_number": 84
       }
     ],
     "openshift/deployment-supervisor-processor.yml": [
@@ -203,8 +215,7 @@
         "filename": "openshift/deployment-supervisor-processor.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 73,
-        "is_secret": false
+        "line_number": 73
       }
     ],
     "openshift/deployment-triage-agent.yml": [
@@ -213,8 +224,7 @@
         "filename": "openshift/deployment-triage-agent.yml",
         "hashed_secret": "e00a4cd07445154f8d1b589ad5b7152fdf7d88d0",
         "is_verified": false,
-        "line_number": 83,
-        "is_secret": false
+        "line_number": 83
       }
     ],
     "ymir/tools/privileged/tests/unit/test_gateway.py": [
@@ -223,90 +233,79 @@
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "f68bd4ab942f012db29f09bbcc991e17768aaafa",
         "is_verified": false,
-        "line_number": 14,
-        "is_secret": false
+        "line_number": 14
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "db33a8c712a01e26f3209fda54abe878e40d574f",
         "is_verified": false,
-        "line_number": 33,
-        "is_secret": false
+        "line_number": 33
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "b015d7de724f9aaf5b147f4076a59d41d032f4e3",
         "is_verified": false,
-        "line_number": 40,
-        "is_secret": false
+        "line_number": 40
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "337dcdf7061ca519f39de8dd4f606f5737f746c9",
         "is_verified": false,
-        "line_number": 49,
-        "is_secret": false
+        "line_number": 49
       },
       {
         "type": "Secret Keyword",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "d2f474a79c11ab6b0f222860701c9cb95a809cf9",
         "is_verified": false,
-        "line_number": 51,
-        "is_secret": false
+        "line_number": 51
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "d8c2d22cd8f05317aa6300a3bfbc35a1fe3eabb0",
         "is_verified": false,
-        "line_number": 77,
-        "is_secret": false
+        "line_number": 77
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "8398e9e58a137e35845548126743f3e7bb1b3045",
         "is_verified": false,
-        "line_number": 78,
-        "is_secret": false
+        "line_number": 78
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "d1af3d84986acb596032080abf01216893ccd65e",
         "is_verified": false,
-        "line_number": 79,
-        "is_secret": false
+        "line_number": 79
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "9f771c6ac6b7404172b5f961b8fc7c202bebf1e2",
         "is_verified": false,
-        "line_number": 80,
-        "is_secret": false
+        "line_number": 80
       },
       {
         "type": "Basic Auth Credentials",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "923100d19a2d3c043764179cee83d6667696cf19",
         "is_verified": false,
-        "line_number": 116,
-        "is_secret": false
+        "line_number": 116
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "ymir/tools/privileged/tests/unit/test_gateway.py",
         "hashed_secret": "4aadfe8a2cfc564a0ebb79d694b73abfb28e1c17",
         "is_verified": false,
-        "line_number": 140,
-        "is_secret": false
+        "line_number": 140
       }
     ]
   },
-  "generated_at": "2026-08-12T13:25:26Z"
+  "generated_at": "2026-08-18T07:50:10Z"
 }

--- a/ymir/common/tests/unit/test_base_utils.py
+++ b/ymir/common/tests/unit/test_base_utils.py
@@ -30,7 +30,7 @@ class FakeRedis:
         self._results = list(brpop_results or [])
         self.brpop_calls = 0
         self.rpush_calls: list[tuple[bytes, bytes]] = []
-        self._delayed_result: tuple[bytes, bytes] | None | object = _NO_DELAYED_RESULT
+        self._delayed_result: tuple[bytes, bytes] | object | None = _NO_DELAYED_RESULT
         self._release_delayed = asyncio.Event()
         self._rpush_failures: set[tuple[bytes, bytes]] = set()
 


### PR DESCRIPTION
By pinning repos to hashes instead of tag we prevent potential supply chain attack on developer machines. This also counts as an upgrade of the ruff pre commit. 

Since the hashes do look somewhat like secrets, they have to be included in the baseline. New `.secrects.baseline` was generated with `detect-secrets` version 1.5.0, which is the same one as used by the pre-commit.