### PR TITLE
Fix a couple of issues

### DIFF
--- a/ymir/agents/issue_verification_agent.py
+++ b/ymir/agents/issue_verification_agent.py
@@ -38,7 +38,6 @@ from ymir.common.models import (
     TestingState,
     WorkflowResult,
 )
-from ymir.tools.privileged.jira import GetJiraAttachmentTool
 from ymir.tools.unprivileged.analyze_ewa_testrun import AnalyzeEwaTestRunTool
 from ymir.tools.unprivileged.read_logfile import ReadLogfileTool
 from ymir.tools.unprivileged.read_readme import ReadReadmeTool
@@ -92,7 +91,7 @@ async def _analyze_testing_results(
     """Run the testing analyst sub-agent to analyze test results."""
     tools = [
         ThinkTool(),
-        GetJiraAttachmentTool(),
+        *[t for t in gateway_tools if t.name == "get_jira_attachment"],
         ReadLogfileTool(),
         ReadReadmeTool(),
         SearchResultsdbTool(),

--- a/ymir/tools/unprivileged/tests/unit/test_upstream_tools.py
+++ b/ymir/tools/unprivileged/tests/unit/test_upstream_tools.py
@@ -395,17 +395,29 @@ class TestCloneUpstreamRepositoryTool:
         assert "mypackage-upstream" in result.result
 
     @pytest.mark.asyncio
-    async def test_clone_directory_already_exists(self, tool, tmp_path):
+    async def test_clone_removes_stale_existing_directory(self, tool, tmp_path):
+        """A leftover directory from a previous failed attempt should be removed, not refused."""
         clone_dir = tmp_path / "mypackage"
-        (tmp_path / "mypackage-upstream").mkdir()
+        expected_path = tmp_path / "mypackage-upstream"
+        expected_path.mkdir()
+        (expected_path / "stale").write_text("old", encoding="utf-8")
 
-        with pytest.raises(ToolError, match="Clone directory already exists"):
-            await tool.run(
-                input=CloneUpstreamRepositoryToolInput(
-                    repo_url="https://github.com/owner/repo.git",
-                    clone_directory=str(clone_dir),
-                )
-            ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+        async def mock_run_subprocess(cmd, **kwargs):
+            expected_path.mkdir(parents=True, exist_ok=True)
+            (expected_path / ".git").mkdir(exist_ok=True)
+            return (0, "", "")
+
+        flexmock(upstream_tools_mod).should_receive("run_subprocess").replace_with(mock_run_subprocess).once()
+
+        result = await tool.run(
+            input=CloneUpstreamRepositoryToolInput(
+                repo_url="https://github.com/owner/repo.git",
+                clone_directory=str(clone_dir),
+            )
+        ).middleware(GlobalTrajectoryMiddleware(pretty=True))
+
+        assert "Successfully cloned" in result.result
+        assert not (expected_path / "stale").exists()
 
     @pytest.mark.asyncio
     async def test_clone_git_failure(self, tool, tmp_path):

--- a/ymir/tools/unprivileged/upstream_tools.py
+++ b/ymir/tools/unprivileged/upstream_tools.py
@@ -320,9 +320,10 @@ class CloneUpstreamRepositoryTool(Tool[CloneUpstreamRepositoryToolInput, ToolRun
             # Always append -upstream suffix to avoid conflicts with dist-git
             clone_path = tool_input.clone_directory.parent / f"{tool_input.clone_directory.name}-upstream"
 
-            # Check if directory already exists
+            # Remove any stale directory left behind by a previous failed
+            # attempt so retries with the same arguments are idempotent.
             if clone_path.exists():
-                raise ToolError(f"Clone directory already exists: {clone_path}")
+                shutil.rmtree(clone_path)
 
             # Create parent directory if needed
             clone_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
- Make `CloneUpstreamRepositoryTool` recover when a local clone already exists
- Do not use a privileged tool directly in issue verification agent