### PR TITLE
Reproducer fixes

### DIFF
--- a/ymir/agents/reasoning_agent/context_management.py
+++ b/ymir/agents/reasoning_agent/context_management.py
@@ -129,26 +129,25 @@ def partition_exchanges(messages: list[AnyMessage]) -> tuple[list[AnyMessage], l
     return protected, exchanges
 
 
-def _assistant_has_provider_visible_output(msg: AssistantMessage) -> bool:
-    """Return True if the message has text or tool_calls (not reasoning-only).
-
-    Anthropic/Vertex reject assistant messages whose final block is ``thinking``.
-    Extended thinking is round-tripped via signed ``meta['thinking_blocks']``
-    (Vertex/Anthropic's format); ``MessageReasoningContent`` in content alone is
-    not sent as a valid assistant block. A message with only reasoning content
-    (or empty content + ``thinking_blocks``) is therefore an invalid
-    thinking-only turn.
-    """
-    return bool(msg.get_tool_calls() or msg.get_texts())
+def _is_manage_context_only_exchange(exchange: list[AnyMessage]) -> bool:
+    """Return True when every tool call in the exchange is manage_context."""
+    tool_calls: list[MessageToolCallContent] = []
+    for msg in exchange:
+        if isinstance(msg, AssistantMessage):
+            tool_calls.extend(msg.get_tool_calls())
+    return bool(tool_calls) and all(call.tool_name == MANAGE_CONTEXT_TOOL_NAME for call in tool_calls)
 
 
 def strip_manage_context_from_exchange(exchange: list[AnyMessage]) -> list[AnyMessage]:
     """Remove manage_context tool-call/result pairs from a kept exchange.
 
-    Mutates assistant content in place so ``meta['thinking_blocks']`` (signed
-    Anthropic thinking) stays attached to the same message object. Drops the
-    assistant message entirely when stripping would leave a thinking-only turn
-    (no text/tool_calls), which Vertex/Claude reject.
+    When manage_context was the only tool in the exchange, drop the whole
+    exchange: the durable summary already carries what matters, and keeping
+    assistant text/thinking would leave history ending on an assistant turn
+    (Vertex rejects that on the next LLM call).
+
+    When manage_context was batched with other tools, strip only its call/result
+    pair and keep the rest of the exchange.
     """
     manage_ids: set[str] = set()
     for msg in exchange:
@@ -159,6 +158,9 @@ def strip_manage_context_from_exchange(exchange: list[AnyMessage]) -> list[AnyMe
 
     if not manage_ids:
         return list(exchange)
+
+    if _is_manage_context_only_exchange(exchange):
+        return []
 
     cleaned: list[AnyMessage] = []
     for msg in exchange:
@@ -171,11 +173,7 @@ def strip_manage_context_from_exchange(exchange: list[AnyMessage]) -> list[AnyMe
                     and content.tool_name == MANAGE_CONTEXT_TOOL_NAME
                 )
             ]
-            # Drop the assistant if stripping manage_context left only thinking:
-            # meta['thinking_blocks'] would still serialize, but with no text or
-            # tool_calls Vertex rejects the message as thinking-only.
-            if _assistant_has_provider_visible_output(msg):
-                cleaned.append(msg)
+            cleaned.append(msg)
         elif isinstance(msg, ToolMessage):
             msg.content[:] = [
                 content
@@ -188,15 +186,6 @@ def strip_manage_context_from_exchange(exchange: list[AnyMessage]) -> list[AnyMe
         else:
             cleaned.append(msg)
     return cleaned
-
-
-def sanitize_assistant_messages(messages: list[AnyMessage]) -> list[AnyMessage]:
-    """Drop assistant messages that would serialize as thinking-only."""
-    return [
-        msg
-        for msg in messages
-        if not (isinstance(msg, AssistantMessage) and not _assistant_has_provider_visible_output(msg))
-    ]
 
 
 async def apply_pending_context_compaction(state: ReasoningAgentRunState) -> bool:
@@ -229,7 +218,6 @@ async def apply_pending_context_compaction(state: ReasoningAgentRunState) -> boo
             )
         )
     new_messages.extend(cleaned_kept)
-    new_messages = sanitize_assistant_messages(new_messages)
 
     state.memory.reset()
     await state.memory.add_many(new_messages)

--- a/ymir/agents/tests/unit/test_context_management.py
+++ b/ymir/agents/tests/unit/test_context_management.py
@@ -10,6 +10,7 @@ from beeai_framework.backend import (
     ToolMessage,
     UserMessage,
 )
+from beeai_framework.backend.message import MessageTextContent
 from beeai_framework.memory import UnconstrainedMemory
 
 from ymir.agents.reasoning_agent.context_management import (
@@ -301,6 +302,47 @@ async def test_apply_with_nothing_to_drop_still_strips_manage_context():
     await apply_pending_context_compaction(state)
     assert not any(m.meta.get(YMIR_CONTEXT_SUMMARY_META_KEY) for m in state.memory.messages)
     assert any(isinstance(m, ToolMessage) and m.content[0].result == "data" for m in state.memory.messages)
+
+
+def test_strip_manage_context_only_exchange_drops_entire_exchange_with_text():
+    exchange = [
+        AssistantMessage(
+            [
+                MessageTextContent(text="Valgrind confirmed the OOB write."),
+                _tool_call(MANAGE_CONTEXT_TOOL_NAME, "c1"),
+            ],
+            meta={"thinking_blocks": [{"type": "thinking", "thinking": "compact", "signature": "sig"}]},
+        ),
+        _tool_result(MANAGE_CONTEXT_TOOL_NAME, "c1", "scheduled"),
+    ]
+    assert strip_manage_context_from_exchange(exchange) == []
+
+
+@pytest.mark.asyncio
+async def test_apply_compaction_drops_manage_context_only_kept_exchange():
+    task = _task_message()
+    old = _exchange("shell", "old", "noise")
+    kept = [
+        AssistantMessage(
+            [
+                MessageTextContent(text="Valgrind confirmed the OOB write."),
+                _tool_call(MANAGE_CONTEXT_TOOL_NAME, "c1"),
+            ],
+            meta={"thinking_blocks": [{"type": "thinking", "thinking": "compact", "signature": "sig"}]},
+        ),
+        _tool_result(MANAGE_CONTEXT_TOOL_NAME, "c1", "scheduled"),
+    ]
+    state = _state_with_messages([task, *old, *kept])
+    state.pending_context_compaction = ManageContextSchema(
+        durable_summary="Valgrind confirmed OOB write; update runtest.sh next.",
+        keep_recent_exchanges=1,
+    )
+
+    await apply_pending_context_compaction(state)
+
+    assert state.memory.messages[-1].meta.get(YMIR_CONTEXT_SUMMARY_META_KEY)
+    assert "Valgrind confirmed OOB write" in state.memory.messages[-1].text
+    assert not any(isinstance(m, AssistantMessage) for m in state.memory.messages)
 
 
 @pytest.mark.asyncio

--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -98,6 +98,56 @@ async def _run_git_cmd(
 # Maintainer (40), Owner (50)
 DEVELOPER_ACCESS_LEVEL = 30
 
+_FORK_READY_IMPORT_STATUSES = frozenset({"finished", "none"})
+_FORK_READY_POLL_INTERVAL_SEC = 2.0
+_FORK_READY_TIMEOUT_SEC = 110  # leave margin under fork_repository tool timeout
+
+
+def _fork_api_project(fork: GitlabProject):
+    """Return a python-gitlab Project object suitable for import_status polling.
+
+    ``forks.create()`` returns a ``ProjectFork`` without ``refresh()``; always
+    fetch the full project by path for status polling.
+    """
+    return fork.service.gitlab_instance.projects.get(f"{fork.namespace}/{fork.repo}")
+
+
+def _wait_for_fork_ready(fork: GitlabProject) -> None:
+    """Block until GitLab finishes provisioning a fork's git repository.
+
+    Fork creation is asynchronous: the API returns before the repository
+    accepts git pushes. Poll ``import_status`` until the fork is ready.
+    """
+    fork_path = f"{fork.namespace}/{fork.repo}"
+    deadline = time.monotonic() + _FORK_READY_TIMEOUT_SEC
+    while True:
+        try:
+            repo = _fork_api_project(fork)
+            repo.refresh()
+        except gitlab.GitlabError as exc:
+            raise ToolError(f"Failed to query fork project {fork_path}") from exc
+
+        status = repo.attributes.get("import_status", "none")
+        if status in _FORK_READY_IMPORT_STATUSES:
+            logger.info("Fork %s is ready (import_status=%s)", fork_path, status)
+            return
+        if status == "failed":
+            import_error = repo.attributes.get("import_error") or "unknown error"
+            raise ToolError(f"Fork {fork_path} failed to import: {import_error}")
+        if time.monotonic() >= deadline:
+            raise ToolError(
+                f"Fork {fork_path} did not become ready within {_FORK_READY_TIMEOUT_SEC}s "
+                f"(import_status={status})"
+            )
+
+        logger.info(
+            "Fork %s not ready yet (import_status=%s), waiting %.0fs",
+            fork_path,
+            status,
+            _FORK_READY_POLL_INTERVAL_SEC,
+        )
+        time.sleep(_FORK_READY_POLL_INTERVAL_SEC)
+
 
 _GITLAB_COMMIT_RE = re.compile(r"^/(.+?)/-/commit/([0-9a-f]+)\.(?:patch|diff)$", re.IGNORECASE)
 _REDHAT_WEB_PREFIX = "/redhat/"
@@ -392,6 +442,7 @@ class ForkRepositoryTool(Tool[ForkRepositoryToolInput, ToolRunOptions, StringToo
         fork = await asyncio.to_thread(create_fork)
         if not fork:
             raise ToolError("Failed to fork the specified repository")
+        await asyncio.to_thread(_wait_for_fork_ready, fork)
         return StringToolOutput(result=fork.get_git_urls()["git"])
 
 

--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -27,8 +27,34 @@ from ymir.tools.privileged.gitlab import (
     RetryPipelineJobTool,
     SetMergeRequestReviewersTool,
     _get_git_auth_args,
+    _wait_for_fork_ready,
 )
 from ymir.tools.privileged.utils import sanitize_url
+
+
+def _fork_project_mock(
+    *,
+    target_namespace: str,
+    fork_name: str,
+    clone_url: str,
+    import_status: str = "finished",
+):
+    gitlab_repo = flexmock(
+        namespace={"full_path": target_namespace},
+        path=fork_name,
+        attributes={"import_status": import_status},
+    )
+    gitlab_repo.should_receive("refresh")
+    service = flexmock(
+        gitlab_instance=flexmock(projects=flexmock(get=lambda _path: gitlab_repo)),
+    )
+    return flexmock(
+        namespace=target_namespace,
+        repo=fork_name,
+        gitlab_repo=gitlab_repo,
+        service=service,
+        get_git_urls=lambda: {"git": clone_url},
+    )
 
 
 @pytest.mark.parametrize(
@@ -59,9 +85,10 @@ async def test_fork_repository(repository, fork_exists, fork_namespace):
     expected_data = {"name": fork_name, "path": fork_name}
     if fork_namespace:
         expected_data["namespace"] = fork_namespace
-    fork = flexmock(
-        gitlab_repo=flexmock(namespace={"full_path": target_namespace}, path=fork_name),
-        get_git_urls=lambda: {"git": clone_url},
+    fork = _fork_project_mock(
+        target_namespace=target_namespace,
+        fork_name=fork_name,
+        clone_url=clone_url,
     )
     flexmock(GitlabProject).new_instances(fork)
     flexmock(GitlabService).should_receive("get_project_from_url").with_args(url=repository).and_return(
@@ -86,6 +113,112 @@ async def test_fork_repository(repository, fork_exists, fork_namespace):
         )
     )
     assert (await ForkRepositoryTool().run(input={"repository": repository})).result == clone_url
+
+
+def test_wait_for_fork_ready_returns_when_import_finished():
+    fork = _fork_project_mock(
+        target_namespace="redhat/rhel/bot-branches",
+        fork_name="rhel_tests_expat",
+        clone_url="https://gitlab.com/redhat/rhel/bot-branches/rhel_tests_expat.git",
+        import_status="finished",
+    )
+    _wait_for_fork_ready(fork)
+
+
+def test_wait_for_fork_ready_polls_until_finished(monkeypatch):
+    class Repo:
+        def __init__(self):
+            self.namespace = {"full_path": "redhat/rhel/bot-branches"}
+            self.path = "rhel_tests_expat"
+            self.attributes = {"import_status": "started"}
+            self.refresh_count = 0
+
+        def refresh(self):
+            self.refresh_count += 1
+            if self.refresh_count >= 2:
+                self.attributes["import_status"] = "finished"
+
+    repo = Repo()
+    fork = flexmock(
+        namespace="redhat/rhel/bot-branches",
+        repo="rhel_tests_expat",
+        gitlab_repo=repo,
+        service=flexmock(
+            gitlab_instance=flexmock(projects=flexmock(get=lambda _path: repo)),
+        ),
+        get_git_urls=lambda: {"git": "https://gitlab.com/redhat/rhel/bot-branches/rhel_tests_expat.git"},
+    )
+    monkeypatch.setattr(
+        "ymir.tools.privileged.gitlab._FORK_READY_POLL_INTERVAL_SEC",
+        0,
+    )
+    _wait_for_fork_ready(fork)
+    assert repo.refresh_count == 2
+
+
+def test_wait_for_fork_ready_raises_on_failed_import():
+    fork = _fork_project_mock(
+        target_namespace="redhat/rhel/bot-branches",
+        fork_name="rhel_tests_expat",
+        clone_url="https://gitlab.com/redhat/rhel/bot-branches/rhel_tests_expat.git",
+        import_status="failed",
+    )
+    fork.gitlab_repo.attributes["import_error"] = "fork import blew up"
+    with pytest.raises(ToolError, match="failed to import"):
+        _wait_for_fork_ready(fork)
+
+
+def test_wait_for_fork_ready_wraps_gitlab_error_from_project_get():
+    fork = flexmock(
+        namespace="redhat/rhel/bot-branches",
+        repo="rhel_tests_foo",
+        service=flexmock(
+            gitlab_instance=flexmock(
+                projects=flexmock(
+                    get=lambda _path: (_ for _ in ()).throw(gitlab.GitlabGetError("404", 404, b""))
+                )
+            ),
+        ),
+    )
+    with pytest.raises(ToolError, match="Failed to query fork project"):
+        _wait_for_fork_ready(fork)
+
+
+def test_wait_for_fork_ready_wraps_gitlab_error_from_refresh():
+    class Repo:
+        def __init__(self):
+            self.attributes = {"import_status": "started"}
+
+        def refresh(self):
+            raise gitlab.GitlabGetError("403", 403, b"")
+
+    repo = Repo()
+    fork = flexmock(
+        namespace="redhat/rhel/bot-branches",
+        repo="rhel_tests_foo",
+        service=flexmock(gitlab_instance=flexmock(projects=flexmock(get=lambda _path: repo))),
+    )
+    with pytest.raises(ToolError, match="Failed to query fork project"):
+        _wait_for_fork_ready(fork)
+
+
+def test_wait_for_fork_ready_raises_on_timeout(monkeypatch):
+    fork = _fork_project_mock(
+        target_namespace="redhat/rhel/bot-branches",
+        fork_name="rhel_tests_expat",
+        clone_url="https://gitlab.com/redhat/rhel/bot-branches/rhel_tests_expat.git",
+        import_status="started",
+    )
+    monkeypatch.setattr(
+        "ymir.tools.privileged.gitlab._FORK_READY_POLL_INTERVAL_SEC",
+        0,
+    )
+    monkeypatch.setattr(
+        "ymir.tools.privileged.gitlab._FORK_READY_TIMEOUT_SEC",
+        0,
+    )
+    with pytest.raises(ToolError, match="did not become ready"):
+        _wait_for_fork_ready(fork)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Fix wrong retrieval of jira labels in reproducer_agent
- Fix context compaction when manage_context is called alone
- Wait for GitLab fork provisioning before returning fork URL
