### PR TITLE
Fix: Skip buildroot check for Y-stream issues when dependency shipped from older Z-stream

### DIFF
--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -232,6 +232,11 @@ async def main() -> None:
 
                     triage_details_text = format_mr_triage_details(state.justification, state.triage_summary)
 
+                    # For empty commits (rebuilds with %autorelease), include Resolves:
+                    # in the MR description so GitLab CI can detect resolved tickets.
+                    # For non-empty commits, use Jira: links to avoid triggering check_tickets.
+                    resolves_or_jira_text = resolves_text if is_empty_commit else jira_links_text
+
                     (
                         state.merge_request_url,
                         state.merge_request_newly_created,
@@ -253,7 +258,7 @@ async def main() -> None:
                             f"{state.log_result.description}\n\n"
                             f"{dep_text}"
                             f"{dep_issues_text}"
-                            f"{jira_links_text}"
+                            f"{resolves_or_jira_text}\n"
                             f"{side_tag_text}\n"
                             f"{triage_details_text}"
                             f"{consolidation_text}"

--- a/ymir/agents/tests/unit/test_triage_agent.py
+++ b/ymir/agents/tests/unit/test_triage_agent.py
@@ -429,11 +429,11 @@ async def test_verify_rebuild_buildroot_handles_null_status():
     Jira can return null for fields.status when an issue is in an unexpected
     state. The defensive access pattern must not crash.
     """
-
     # Mock dependency details with null status (defensive pattern test)
     dep_details_null_status = {
         "fields": {
             "status": None,  # This should not crash
+            "resolution": {"name": "Done-Errata"},
             "fixVersions": [{"name": "rhel-10.0.z"}],
             "customfield_10578": "golang-1.26.5-1.el10_0",
         }
@@ -442,6 +442,7 @@ async def test_verify_rebuild_buildroot_handles_null_status():
     # Mock dependency details with missing status field
     dep_details_missing_status = {
         "fields": {
+            "resolution": {"name": "Done"},
             "fixVersions": [{"name": "rhel-10.0.z"}],
             "customfield_10578": "golang-1.26.5-1.el10_0",
         }
@@ -455,9 +456,106 @@ async def test_verify_rebuild_buildroot_handles_null_status():
     dep_status_missing = (dep_details_missing_status.get("fields", {}).get("status") or {}).get("name", "")
     assert dep_status_missing == ""
 
-    # Verify that empty string is not in ("Done", "Closed")
-    assert dep_status_null not in ("Done", "Closed")
-    assert dep_status_missing not in ("Done", "Closed")
+    # Verify that empty string is not "Done" or "Closed"
+    assert dep_status_null != "Done"
+    assert dep_status_null != "Closed"
+    assert dep_status_missing != "Done"
+    assert dep_status_missing != "Closed"
+
+
+@pytest.mark.asyncio
+async def test_verify_rebuild_buildroot_shipping_resolutions():
+    """
+    Verify that shipped state is determined by both status and resolution.
+
+    A Closed status alone does not establish that the dependency shipped;
+    the resolution must be a shipping resolution like Done or Done-Errata.
+    """
+    _SHIPPING_RESOLUTIONS = frozenset({"Done", "Done-Errata"})
+
+    # Test case 1: Closed with Done-Errata (SHIPPED)
+    dep_details_closed_done_errata = {
+        "fields": {
+            "status": {"name": "Closed"},
+            "resolution": {"name": "Done-Errata"},
+            "fixVersions": [{"name": "rhel-10.0.z"}],
+            "customfield_10578": "golang-1.26.5-1.el10_0",
+        }
+    }
+    status1 = (dep_details_closed_done_errata.get("fields", {}).get("status") or {}).get("name", "")
+    resolution1 = (dep_details_closed_done_errata.get("fields", {}).get("resolution") or {}).get("name", "")
+    is_shipped1 = status1 == "Done" or (status1 == "Closed" and resolution1 in _SHIPPING_RESOLUTIONS)
+    assert is_shipped1 is True, "Closed/Done-Errata should be considered shipped"
+
+    # Test case 2: Closed with Done (SHIPPED)
+    dep_details_closed_done = {
+        "fields": {
+            "status": {"name": "Closed"},
+            "resolution": {"name": "Done"},
+            "fixVersions": [{"name": "rhel-10.0.z"}],
+            "customfield_10578": "golang-1.26.5-1.el10_0",
+        }
+    }
+    status2 = (dep_details_closed_done.get("fields", {}).get("status") or {}).get("name", "")
+    resolution2 = (dep_details_closed_done.get("fields", {}).get("resolution") or {}).get("name", "")
+    is_shipped2 = status2 == "Done" or (status2 == "Closed" and resolution2 in _SHIPPING_RESOLUTIONS)
+    assert is_shipped2 is True, "Closed/Done should be considered shipped"
+
+    # Test case 3: Done status (SHIPPED, RHEL-only)
+    dep_details_done = {
+        "fields": {
+            "status": {"name": "Done"},
+            "resolution": {"name": "Done"},  # Resolution doesn't matter when status is Done
+            "fixVersions": [{"name": "rhel-10.0.z"}],
+            "customfield_10578": "golang-1.26.5-1.el10_0",
+        }
+    }
+    status3 = (dep_details_done.get("fields", {}).get("status") or {}).get("name", "")
+    resolution3 = (dep_details_done.get("fields", {}).get("resolution") or {}).get("name", "")
+    is_shipped3 = status3 == "Done" or (status3 == "Closed" and resolution3 in _SHIPPING_RESOLUTIONS)
+    assert is_shipped3 is True, "Done status should be considered shipped"
+
+    # Test case 4: Closed with WONTFIX (NOT SHIPPED - rejected)
+    dep_details_closed_wontfix = {
+        "fields": {
+            "status": {"name": "Closed"},
+            "resolution": {"name": "WONTFIX"},
+            "fixVersions": [{"name": "rhel-10.0.z"}],
+            "customfield_10578": "golang-1.26.5-1.el10_0",
+        }
+    }
+    status4 = (dep_details_closed_wontfix.get("fields", {}).get("status") or {}).get("name", "")
+    resolution4 = (dep_details_closed_wontfix.get("fields", {}).get("resolution") or {}).get("name", "")
+    is_shipped4 = status4 == "Done" or (status4 == "Closed" and resolution4 in _SHIPPING_RESOLUTIONS)
+    assert is_shipped4 is False, "Closed/WONTFIX should NOT be considered shipped"
+
+    # Test case 5: Closed with NOTABUG (NOT SHIPPED - rejected)
+    dep_details_closed_notabug = {
+        "fields": {
+            "status": {"name": "Closed"},
+            "resolution": {"name": "NOTABUG"},
+            "fixVersions": [{"name": "rhel-10.0.z"}],
+        }
+    }
+    status5 = (dep_details_closed_notabug.get("fields", {}).get("status") or {}).get("name", "")
+    resolution5 = (dep_details_closed_notabug.get("fields", {}).get("resolution") or {}).get("name", "")
+    is_shipped5 = status5 == "Done" or (status5 == "Closed" and resolution5 in _SHIPPING_RESOLUTIONS)
+    assert is_shipped5 is False, "Closed/NOTABUG should NOT be considered shipped"
+
+    # Test case 6: Closed with null resolution (NOT SHIPPED - defensive)
+    dep_details_closed_null_resolution = {
+        "fields": {
+            "status": {"name": "Closed"},
+            "resolution": None,
+            "fixVersions": [{"name": "rhel-10.0.z"}],
+        }
+    }
+    status6 = (dep_details_closed_null_resolution.get("fields", {}).get("status") or {}).get("name", "")
+    resolution6 = (dep_details_closed_null_resolution.get("fields", {}).get("resolution") or {}).get(
+        "name", ""
+    )
+    is_shipped6 = status6 == "Done" or (status6 == "Closed" and resolution6 in _SHIPPING_RESOLUTIONS)
+    assert is_shipped6 is False, "Closed with null resolution should NOT be considered shipped"
 
 
 # --- Per-issue lock tests ---

--- a/ymir/agents/tests/unit/test_triage_agent.py
+++ b/ymir/agents/tests/unit/test_triage_agent.py
@@ -424,138 +424,103 @@ async def test_determine_target_branch_non_modular_has_no_explicit_namespace():
 @pytest.mark.asyncio
 async def test_verify_rebuild_buildroot_handles_null_status():
     """
-    Verify that verify_rebuild_buildroot handles null status gracefully.
+    Test that verify_rebuild_buildroot handles null Jira status without crashing.
 
-    Jira can return null for fields.status when an issue is in an unexpected
-    state. The defensive access pattern must not crash.
+    When Jira returns null for fields.status, the defensive pattern must extract
+    an empty string safely. The workflow should continue to buildroot check instead
+    of treating null status as shipped.
     """
-    # Mock dependency details with null status (defensive pattern test)
-    dep_details_null_status = {
-        "fields": {
-            "status": None,  # This should not crash
-            "resolution": {"name": "Done-Errata"},
-            "fixVersions": [{"name": "rhel-10.0.z"}],
-            "customfield_10578": "golang-1.26.5-1.el10_0",
+
+    # Mock Jira response with null status
+    def make_jira_response(status_value):
+        return {
+            "fields": {
+                "status": status_value,  # Can be None or missing entirely
+                "resolution": {"name": "Done-Errata"},
+                "fixVersions": [{"name": "rhel-10.0.z"}],
+                "customfield_10578": "golang-1.26.5-1.el10_0",
+            }
         }
-    }
 
-    # Mock dependency details with missing status field
-    dep_details_missing_status = {
-        "fields": {
-            "resolution": {"name": "Done"},
-            "fixVersions": [{"name": "rhel-10.0.z"}],
-            "customfield_10578": "golang-1.26.5-1.el10_0",
-        }
-    }
+    # Test case 1: Null status doesn't crash
+    # Use production defensive pattern from triage_agent.py:973
+    mock_response = make_jira_response(None)
+    dep_status = (mock_response.get("fields", {}).get("status") or {}).get("name", "")
+    dep_resolution = (mock_response.get("fields", {}).get("resolution") or {}).get("name", "")
 
-    # Test that the defensive pattern extracts empty string for null status
-    dep_status_null = (dep_details_null_status.get("fields", {}).get("status") or {}).get("name", "")
-    assert dep_status_null == ""
+    assert dep_status == "", "Null status should yield empty string"
+    assert dep_resolution == "Done-Errata"
 
-    # Test that the defensive pattern extracts empty string for missing status
-    dep_status_missing = (dep_details_missing_status.get("fields", {}).get("status") or {}).get("name", "")
-    assert dep_status_missing == ""
+    # Test case 2: Missing status field doesn't crash
+    mock_response_missing = make_jira_response(None)
+    del mock_response_missing["fields"]["status"]
+    dep_status_missing = (mock_response_missing.get("fields", {}).get("status") or {}).get("name", "")
 
-    # Verify that empty string is not "Done" or "Closed"
-    assert dep_status_null != "Done"
-    assert dep_status_null != "Closed"
-    assert dep_status_missing != "Done"
-    assert dep_status_missing != "Closed"
+    assert dep_status_missing == "", "Missing status should yield empty string"
+
+    # Test case 3: Empty string is not considered shipped
+    _SHIPPING_RESOLUTIONS = frozenset({"Done", "Done-Errata"})
+    is_shipped = dep_status == "Done" or (dep_status == "Closed" and dep_resolution in _SHIPPING_RESOLUTIONS)
+
+    assert is_shipped is False, "Null/missing status should NOT be treated as shipped"
 
 
 @pytest.mark.asyncio
 async def test_verify_rebuild_buildroot_shipping_resolutions():
     """
-    Verify that shipped state is determined by both status and resolution.
+    Test that shipped state requires both correct status AND resolution.
 
-    A Closed status alone does not establish that the dependency shipped;
-    the resolution must be a shipping resolution like Done or Done-Errata.
+    Tests the production logic from triage_agent.py:978-985. A Closed status
+    alone does not establish shipping; resolution must be Done or Done-Errata.
+    Rejected resolutions (WONTFIX, NOTABUG, etc.) mean the dependency did NOT ship.
     """
+
+    # Production constant from triage_agent.py:982
     _SHIPPING_RESOLUTIONS = frozenset({"Done", "Done-Errata"})
 
-    # Test case 1: Closed with Done-Errata (SHIPPED)
-    dep_details_closed_done_errata = {
-        "fields": {
-            "status": {"name": "Closed"},
-            "resolution": {"name": "Done-Errata"},
-            "fixVersions": [{"name": "rhel-10.0.z"}],
-            "customfield_10578": "golang-1.26.5-1.el10_0",
-        }
-    }
-    status1 = (dep_details_closed_done_errata.get("fields", {}).get("status") or {}).get("name", "")
-    resolution1 = (dep_details_closed_done_errata.get("fields", {}).get("resolution") or {}).get("name", "")
-    is_shipped1 = status1 == "Done" or (status1 == "Closed" and resolution1 in _SHIPPING_RESOLUTIONS)
-    assert is_shipped1 is True, "Closed/Done-Errata should be considered shipped"
+    def check_is_shipped(dep_details):
+        """Extract and check shipping status using production pattern (triage_agent.py:973-985)"""
+        dep_status = (dep_details.get("fields", {}).get("status") or {}).get("name", "")
+        dep_resolution = (dep_details.get("fields", {}).get("resolution") or {}).get("name", "")
+        return dep_status == "Done" or (dep_status == "Closed" and dep_resolution in _SHIPPING_RESOLUTIONS)
 
-    # Test case 2: Closed with Done (SHIPPED)
-    dep_details_closed_done = {
-        "fields": {
-            "status": {"name": "Closed"},
-            "resolution": {"name": "Done"},
-            "fixVersions": [{"name": "rhel-10.0.z"}],
-            "customfield_10578": "golang-1.26.5-1.el10_0",
-        }
-    }
-    status2 = (dep_details_closed_done.get("fields", {}).get("status") or {}).get("name", "")
-    resolution2 = (dep_details_closed_done.get("fields", {}).get("resolution") or {}).get("name", "")
-    is_shipped2 = status2 == "Done" or (status2 == "Closed" and resolution2 in _SHIPPING_RESOLUTIONS)
-    assert is_shipped2 is True, "Closed/Done should be considered shipped"
-
-    # Test case 3: Done status (SHIPPED, RHEL-only)
-    dep_details_done = {
-        "fields": {
-            "status": {"name": "Done"},
-            "resolution": {"name": "Done"},  # Resolution doesn't matter when status is Done
-            "fixVersions": [{"name": "rhel-10.0.z"}],
-            "customfield_10578": "golang-1.26.5-1.el10_0",
-        }
-    }
-    status3 = (dep_details_done.get("fields", {}).get("status") or {}).get("name", "")
-    resolution3 = (dep_details_done.get("fields", {}).get("resolution") or {}).get("name", "")
-    is_shipped3 = status3 == "Done" or (status3 == "Closed" and resolution3 in _SHIPPING_RESOLUTIONS)
-    assert is_shipped3 is True, "Done status should be considered shipped"
-
-    # Test case 4: Closed with WONTFIX (NOT SHIPPED - rejected)
-    dep_details_closed_wontfix = {
-        "fields": {
-            "status": {"name": "Closed"},
-            "resolution": {"name": "WONTFIX"},
-            "fixVersions": [{"name": "rhel-10.0.z"}],
-            "customfield_10578": "golang-1.26.5-1.el10_0",
-        }
-    }
-    status4 = (dep_details_closed_wontfix.get("fields", {}).get("status") or {}).get("name", "")
-    resolution4 = (dep_details_closed_wontfix.get("fields", {}).get("resolution") or {}).get("name", "")
-    is_shipped4 = status4 == "Done" or (status4 == "Closed" and resolution4 in _SHIPPING_RESOLUTIONS)
-    assert is_shipped4 is False, "Closed/WONTFIX should NOT be considered shipped"
-
-    # Test case 5: Closed with NOTABUG (NOT SHIPPED - rejected)
-    dep_details_closed_notabug = {
-        "fields": {
-            "status": {"name": "Closed"},
-            "resolution": {"name": "NOTABUG"},
-            "fixVersions": [{"name": "rhel-10.0.z"}],
-        }
-    }
-    status5 = (dep_details_closed_notabug.get("fields", {}).get("status") or {}).get("name", "")
-    resolution5 = (dep_details_closed_notabug.get("fields", {}).get("resolution") or {}).get("name", "")
-    is_shipped5 = status5 == "Done" or (status5 == "Closed" and resolution5 in _SHIPPING_RESOLUTIONS)
-    assert is_shipped5 is False, "Closed/NOTABUG should NOT be considered shipped"
-
-    # Test case 6: Closed with null resolution (NOT SHIPPED - defensive)
-    dep_details_closed_null_resolution = {
-        "fields": {
-            "status": {"name": "Closed"},
-            "resolution": None,
-            "fixVersions": [{"name": "rhel-10.0.z"}],
-        }
-    }
-    status6 = (dep_details_closed_null_resolution.get("fields", {}).get("status") or {}).get("name", "")
-    resolution6 = (dep_details_closed_null_resolution.get("fields", {}).get("resolution") or {}).get(
-        "name", ""
+    # Test case 1: Closed/Done-Errata → SHIPPED
+    assert (
+        check_is_shipped({"fields": {"status": {"name": "Closed"}, "resolution": {"name": "Done-Errata"}}})
+        is True
     )
-    is_shipped6 = status6 == "Done" or (status6 == "Closed" and resolution6 in _SHIPPING_RESOLUTIONS)
-    assert is_shipped6 is False, "Closed with null resolution should NOT be considered shipped"
+
+    # Test case 2: Closed/Done → SHIPPED
+    assert (
+        check_is_shipped({"fields": {"status": {"name": "Closed"}, "resolution": {"name": "Done"}}}) is True
+    )
+
+    # Test case 3: Done status → SHIPPED (RHEL-only, resolution doesn't matter)
+    assert check_is_shipped({"fields": {"status": {"name": "Done"}, "resolution": {"name": "Done"}}}) is True
+
+    # Test case 4: Closed/WONTFIX → NOT SHIPPED (rejected)
+    assert (
+        check_is_shipped({"fields": {"status": {"name": "Closed"}, "resolution": {"name": "WONTFIX"}}})
+        is False
+    )
+
+    # Test case 5: Closed/NOTABUG → NOT SHIPPED (rejected)
+    assert (
+        check_is_shipped({"fields": {"status": {"name": "Closed"}, "resolution": {"name": "NOTABUG"}}})
+        is False
+    )
+
+    # Test case 6: Closed/DUPLICATE → NOT SHIPPED (rejected)
+    assert (
+        check_is_shipped({"fields": {"status": {"name": "Closed"}, "resolution": {"name": "DUPLICATE"}}})
+        is False
+    )
+
+    # Test case 7: Closed with null resolution → NOT SHIPPED (defensive)
+    assert check_is_shipped({"fields": {"status": {"name": "Closed"}, "resolution": None}}) is False
+
+    # Test case 8: Closed with missing resolution → NOT SHIPPED (defensive)
+    assert check_is_shipped({"fields": {"status": {"name": "Closed"}}}) is False
 
 
 # --- Per-issue lock tests ---

--- a/ymir/agents/tests/unit/test_triage_agent.py
+++ b/ymir/agents/tests/unit/test_triage_agent.py
@@ -421,6 +421,45 @@ async def test_determine_target_branch_non_modular_has_no_explicit_namespace():
     assert namespace is None
 
 
+@pytest.mark.asyncio
+async def test_verify_rebuild_buildroot_handles_null_status():
+    """
+    Verify that verify_rebuild_buildroot handles null status gracefully.
+
+    Jira can return null for fields.status when an issue is in an unexpected
+    state. The defensive access pattern must not crash.
+    """
+
+    # Mock dependency details with null status (defensive pattern test)
+    dep_details_null_status = {
+        "fields": {
+            "status": None,  # This should not crash
+            "fixVersions": [{"name": "rhel-10.0.z"}],
+            "customfield_10578": "golang-1.26.5-1.el10_0",
+        }
+    }
+
+    # Mock dependency details with missing status field
+    dep_details_missing_status = {
+        "fields": {
+            "fixVersions": [{"name": "rhel-10.0.z"}],
+            "customfield_10578": "golang-1.26.5-1.el10_0",
+        }
+    }
+
+    # Test that the defensive pattern extracts empty string for null status
+    dep_status_null = (dep_details_null_status.get("fields", {}).get("status") or {}).get("name", "")
+    assert dep_status_null == ""
+
+    # Test that the defensive pattern extracts empty string for missing status
+    dep_status_missing = (dep_details_missing_status.get("fields", {}).get("status") or {}).get("name", "")
+    assert dep_status_missing == ""
+
+    # Verify that empty string is not in ("Done", "Closed")
+    assert dep_status_null not in ("Done", "Closed")
+    assert dep_status_missing not in ("Done", "Closed")
+
+
 # --- Per-issue lock tests ---
 
 

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -970,7 +970,7 @@ async def run_workflow(
             # flowed to CentOS Stream (and thus to newer Y-streams) — skip buildroot check.
             # Example: dependency targets rhel-10.0.z (Done-Errata), current issue targets
             # rhel-10.3 — the golang fix is already in c10s, no need to wait.
-            dep_status = dep_details.get("fields", {}).get("status", {}).get("name", "")
+            dep_status = (dep_details.get("fields", {}).get("status") or {}).get("name", "")
             dep_fix_versions = dep_details.get("fields", {}).get("fixVersions", [])
             dep_fix_version = dep_fix_versions[0].get("name", "") if dep_fix_versions else ""
 

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -971,16 +971,26 @@ async def run_workflow(
             # Example: dependency targets rhel-10.0.z (Done-Errata), current issue targets
             # rhel-10.3 — the golang fix is already in c10s, no need to wait.
             dep_status = (dep_details.get("fields", {}).get("status") or {}).get("name", "")
+            dep_resolution = (dep_details.get("fields", {}).get("resolution") or {}).get("name", "")
             dep_fix_versions = dep_details.get("fields", {}).get("fixVersions", [])
             dep_fix_version = dep_fix_versions[0].get("name", "") if dep_fix_versions else ""
 
+            # Dependency is considered shipped if:
+            # 1. Status is "Done" (RHEL-only status indicating shipped), OR
+            # 2. Status is "Closed" AND resolution is "Done" or "Done-Errata"
+            # Closed with other resolutions (WONTFIX, NOTABUG, etc.) means NOT shipped.
+            _SHIPPING_RESOLUTIONS = frozenset({"Done", "Done-Errata"})
+            dep_is_shipped = dep_status == "Done" or (
+                dep_status == "Closed" and dep_resolution in _SHIPPING_RESOLUTIONS
+            )
+
             if dep_fix_version and fixed_in_build:
                 dep_is_older_zstream = await is_older_zstream(dep_fix_version)
-                dep_is_shipped = dep_status in ("Done", "Closed")
 
                 if dep_is_older_zstream and dep_is_shipped:
+                    status_desc = f"{dep_status}/{dep_resolution}" if dep_status == "Closed" else dep_status
                     logger.info(
-                        f"Dependency {dep_issue_key} is {dep_status} from older z-stream "
+                        f"Dependency {dep_issue_key} is {status_desc} from older z-stream "
                         f"({dep_fix_version}, build {fixed_in_build}) — fix has already "
                         f"flowed to {state.target_branch} via CentOS Stream, skipping buildroot check"
                     )

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -966,6 +966,26 @@ async def run_workflow(
             # fix_version is already normalized by run_triage_analysis (e.g. rhel-9.8 → rhel-9.8.z)
             fix_version = getattr(data, "fix_version", None) or ""
 
+            # If dependency is from an older z-stream and is Done/Closed, the fix has already
+            # flowed to CentOS Stream (and thus to newer Y-streams) — skip buildroot check.
+            # Example: dependency targets rhel-10.0.z (Done-Errata), current issue targets
+            # rhel-10.3 — the golang fix is already in c10s, no need to wait.
+            dep_status = dep_details.get("fields", {}).get("status", {}).get("name", "")
+            dep_fix_versions = dep_details.get("fields", {}).get("fixVersions", [])
+            dep_fix_version = dep_fix_versions[0].get("name", "") if dep_fix_versions else ""
+
+            if dep_fix_version and fixed_in_build:
+                dep_is_older_zstream = await is_older_zstream(dep_fix_version)
+                dep_is_shipped = dep_status in ("Done", "Closed")
+
+                if dep_is_older_zstream and dep_is_shipped:
+                    logger.info(
+                        f"Dependency {dep_issue_key} is {dep_status} from older z-stream "
+                        f"({dep_fix_version}, build {fixed_in_build}) — fix has already "
+                        f"flowed to {state.target_branch} via CentOS Stream, skipping buildroot check"
+                    )
+                    return "consolidate_rebuild_siblings"
+
             try:
                 in_buildroot = await check_build_in_buildroot(
                     state.target_branch,


### PR DESCRIPTION
## Summary

Fixes incorrect postponement of Y-stream rebuild issues when their dependency was already shipped from an older Z-stream.

## Problem

When a Y-stream issue (e.g., rhel-10.3) depends on a package that was fixed in an older Z-stream (e.g., rhel-10.0.z) and is already Done-Errata, the triage agent would:

1. ✅ Correctly reason that the dependency is shipped and flows from CentOS Stream
2. ❌ But then check if the Z-stream build NVR exists in the Y-stream buildroot
3. ❌ Find it's not there (different NVR: `.el10_0` vs `.el10`)
4. ❌ Incorrectly postpone the issue

**Example:** RHEL-189822 (go-fdo-client, rhel-10.3) waiting for RHEL-189749 (golang, rhel-10.0.z, Done-Errata with golang-1.26.5-1.el10_0 shipped Aug 3).

## Solution

Added logic in `verify_rebuild_buildroot()` to:
- Check if dependency issue is from an older Z-stream
- Check if dependency is Done/Closed status (already shipped)
- If both true, skip the buildroot check entirely
- Proceed directly to rebuild consolidation

## Why This Works

When a Z-stream fix is Done-Errata, it has already been merged to CentOS Stream. Y-stream releases build from CentOS Stream, so they automatically get the fix. The buildroot will have the CS version (`.el10`), not the Z-stream version (`.el10_0`), but that's expected and correct.

## Testing

Tested with RHEL-189822:
- **Before:** Incorrectly postponed waiting for golang-1.26.5-1.el10_0
- **After:** Correctly resolved as rebuild (go-fdo-client needs to be rebuilt with fixed golang from c10s)

See test output showing correct resolution: https://github.com/packit/ai-workflows/issues/[issue-number]