### PR TITLE
Add SKIP_MODULAR flag to enable modular issue triage

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -126,7 +126,7 @@ Two CronJobs run the fetcher with different JQL queries:
 | `jira-issue-fetcher` | `0 8 * * *` (daily, 8am UTC) | Main CVE batch — processes up to `MAX_ISSUES` issues from the filter in `jira-issue-fetcher-filter-env` | `jira-issue-fetcher-filter-env` |
 | `jira-issue-fetcher-todo` | `*/5 * * * *` | `labels = "ymir_todo"` OR consolidation labels (`ymir_consolidate_base`, `ymir_consolidate_next`) | `jira-issue-fetcher-todo-env` |
 
-Both share the common knobs (`MAX_ISSUES`, `LOGLEVEL`) from `jira-issue-fetcher-env`. Components excluded from scope are part of the Jira filter itself, maintained (with rationale per component) in the separate [`cve-scope`](https://gitlab.cee.redhat.com/jotnar-project/cve-scope) repo — not in a configmap or env var.
+Both share the common knobs (`MAX_ISSUES`, `LOGLEVEL`, `SKIP_MODULAR`) from `jira-issue-fetcher-env`. `SKIP_MODULAR` controls whether modular issues (Downstream Component matching `module:stream/pkg`) are enqueued for triage (`false`) or silently dropped (`true`; code default). Components excluded from scope are part of the Jira filter itself, maintained (with rationale per component) in the separate [`cve-scope`](https://gitlab.cee.redhat.com/jotnar-project/cve-scope) repo — not in a configmap or env var.
 
 The `jira-issue-fetcher-todo` runs every 5 minutes and processes:
 - **User-triggered issues**: Any issue tagged with `ymir_todo` by a maintainer (not filtered by component, processes regardless of scope exclusions)

--- a/openshift/configmap-jira-issue-fetcher-env.yml
+++ b/openshift/configmap-jira-issue-fetcher-env.yml
@@ -7,6 +7,12 @@ data:
   # jira_issue_fetcher.py. Shared by both cronjobs (daily + todo) since it's a
   # property of agent task duration, not of which query triggered the sweep.
   STALE_LABEL_THRESHOLD_HOURS: "24"
+  # Controls the fetcher-level filter for modular issues (Downstream Component
+  # matching module:stream/pkg, e.g. postgresql:16/postgresql). When "true"
+  # (default), the fetcher skips these issues before they reach the triage
+  # queue. When "false", modular issues pass through and are enqueued for
+  # triage like any other issue.
+  SKIP_MODULAR: "false"
 immutable: false
 kind: ConfigMap
 metadata:

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -122,6 +122,15 @@ class JiraIssueFetcher:
                 "skipped; Redis pushes will proceed normally"
             )
 
+        # Rollout flag: code defaults to "true" (safe for local runs without the
+        # ConfigMap); the cluster ConfigMap sets "false" to enable modular triage.
+        self.skip_modular = os.getenv("SKIP_MODULAR", "true").lower() == "true"
+        logger.info(
+            "SKIP_MODULAR=%s — modular issues will be %s",
+            self.skip_modular,
+            "skipped" if self.skip_modular else "enqueued for triage",
+        )
+
     async def _rate_limit(self):
         """Enforce rate limiting of RATE_LIMIT_CALLS_PER_SECOND calls per second"""
         current_time = time.time()
@@ -717,7 +726,7 @@ class JiraIssueFetcher:
                     fields = issue.get("fields") or {}
 
                     downstream_component = fields.get("customfield_10669") or ""
-                    if self.MODULAR_COMPONENT_PATTERN.match(downstream_component):
+                    if self.skip_modular and self.MODULAR_COMPONENT_PATTERN.match(downstream_component):
                         logger.info(f"Skipping issue {issue_key} - modular issue: {downstream_component}")
                         modular_count += 1
                         continue

--- a/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -86,6 +86,7 @@ def test_init(mock_env_vars):
     assert fetcher.query == 'filter = "Jotnar_1000_packages"'
     assert fetcher.max_results_per_page == 500
     assert fetcher.headers["Authorization"].startswith("Basic ")
+    assert fetcher.skip_modular is True
 
 
 @pytest.mark.asyncio
@@ -413,6 +414,36 @@ async def test_push_issues_to_queue_skip_modular(fetcher, mock_redis_context):
     mock_redis.should_receive("lpush").with_args(RedisQueues.TRIAGE_QUEUE.value, task2.to_json()).and_return(
         create_async_mock_return_value(1)
     ).once()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_push_issues_to_queue_enqueue_modular(mock_env_vars, monkeypatch, mock_redis_context):
+    """Test that modular issues are enqueued when SKIP_MODULAR=false."""
+    monkeypatch.setenv("SKIP_MODULAR", "false")
+    fetcher = JiraIssueFetcher()
+    mock_redis, _ = mock_redis_context
+
+    issues = [
+        {"key": "MOD-1", "fields": {"labels": [], "customfield_10669": "perl:5.32/perl-IO-Socket-SSL"}},
+        {"key": "REG-1", "fields": {"labels": [], "customfield_10669": "regular-component"}},
+    ]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+
+    task_mod = Task.from_issue("MOD-1")
+    task_reg = Task.from_issue("REG-1")
+    mock_redis.should_receive("lpush").with_args(
+        RedisQueues.TRIAGE_QUEUE.value, task_mod.to_json()
+    ).and_return(create_async_mock_return_value(1)).once()
+    mock_redis.should_receive("lpush").with_args(
+        RedisQueues.TRIAGE_QUEUE.value, task_reg.to_json()
+    ).and_return(create_async_mock_return_value(1)).once()
 
     result = await fetcher.push_issues_to_queue(issues)
 


### PR DESCRIPTION
## Summary

- Adds `SKIP_MODULAR` env var to gate the fetcher's modular-component filter. Code defaults to `"true"` (skip modular, safe for local runs); the cluster ConfigMap sets `"false"` to enqueue modular issues for triage.
- Logs the resolved `SKIP_MODULAR` value on every startup for easy cluster vs local debugging.
- Documents the new knob in the ConfigMap (with rationale comment) and in `openshift/README.md`.
- Fixes modular `downstream_component` parsing: `customfield_10669` stores `module:stream/package` (e.g. `postgresql:16/postgis`) but `is_modular()` / `parse_module_stream()` expect just the package name. Adds `extract_downstream_package()` utility to normalize the value so modular issues get the correct stream-specific branch (e.g. `stream-postgresql-16-rhel-9.8.0`) instead of falling through to `rhel-9.8.0`.

Resolves: PACKIT-5260

Depends on [#756](https://github.com/packit/ai-workflows/pull/756) for stream-aware duplicate detection — without it, modular issues with different streams would be incorrectly flagged as duplicates.

## Test plan

- [x] Existing `test_push_issues_to_queue_skip_modular` still passes (default skip behavior)
- [x] New `test_push_issues_to_queue_enqueue_modular` verifies `SKIP_MODULAR=false` enqueues modular issues
- [x] `test_init` asserts `skip_modular is True` by default
- [x] `test_extract_downstream_package` covers modular, non-modular, None, and empty inputs
- [x] `test_is_modular_requires_package_not_full_modular_string` proves the raw value fails, extracted value works
- [x] `test_map_version_to_module_branch_extracts_package_from_raw_field` end-to-end proof
- [ ] Deploy to staging with `SKIP_MODULAR=false` and verify modular issues get correct stream branches