### PR TITLE
Enable modular issue triage with guarded downstream rollout

### DIFF
--- a/agents_as_skills/triage/SKILL.md
+++ b/agents_as_skills/triage/SKILL.md
@@ -559,6 +559,10 @@ Ensure the `jira_issue` field in the result data is upper-case.
 
 After obtaining the triage result, normalize the `fix_version` if present: if the fix_version is a Y-stream version (e.g., `rhel-9.8`) that has already transitioned to Z-stream (the Z-stream version exists per `map_version`), update it to the Z-stream form (e.g., `rhel-9.8.z`).
 
+### Modular Issues Rollout Note
+
+During the current rollout phase, modular issues are triaged and commented as usual, but downstream dispatch (rebase/backport/rebuild/open-ended/clarification queues) and reproducer enqueueing may be intentionally skipped by the orchestrator after triage. Continue producing the same high-quality triage output; orchestration policy is applied outside this skill.
+
 #### 3.6. General Investigation Instructions
 
 - Be proactive in your search for fixes and do not give up easily.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -126,7 +126,7 @@ Two CronJobs run the fetcher with different JQL queries:
 | `jira-issue-fetcher` | `0 8 * * *` (daily, 8am UTC) | Main CVE batch — processes up to `MAX_ISSUES` issues from the filter in `jira-issue-fetcher-filter-env` | `jira-issue-fetcher-filter-env` |
 | `jira-issue-fetcher-todo` | `*/5 * * * *` | `labels = "ymir_todo"` OR consolidation labels (`ymir_consolidate_base`, `ymir_consolidate_next`) | `jira-issue-fetcher-todo-env` |
 
-Both share the common knobs (`MAX_ISSUES`, `LOGLEVEL`) from `jira-issue-fetcher-env`. Components excluded from scope are part of the Jira filter itself, maintained (with rationale per component) in the separate [`cve-scope`](https://gitlab.cee.redhat.com/jotnar-project/cve-scope) repo — not in a configmap or env var.
+Both share the common knobs (`MAX_ISSUES`, `LOGLEVEL`, `SKIP_MODULAR`) from `jira-issue-fetcher-env`. `SKIP_MODULAR` controls whether modular issues (Downstream Component matching `module:stream/pkg`) are enqueued for triage (`false`) or silently dropped (`true`; code default). Components excluded from scope are part of the Jira filter itself, maintained (with rationale per component) in the separate [`cve-scope`](https://gitlab.cee.redhat.com/jotnar-project/cve-scope) repo — not in a configmap or env var.
 
 The `jira-issue-fetcher-todo` runs every 5 minutes and processes:
 - **User-triggered issues**: Any issue tagged with `ymir_todo` by a maintainer (not filtered by component, processes regardless of scope exclusions)

--- a/openshift/configmap-jira-issue-fetcher-env.yml
+++ b/openshift/configmap-jira-issue-fetcher-env.yml
@@ -7,6 +7,12 @@ data:
   # jira_issue_fetcher.py. Shared by both cronjobs (daily + todo) since it's a
   # property of agent task duration, not of which query triggered the sweep.
   STALE_LABEL_THRESHOLD_HOURS: "24"
+  # Controls the fetcher-level filter for modular issues (Downstream Component
+  # matching module:stream/pkg, e.g. postgresql:16/postgresql). When "true"
+  # (default), the fetcher skips these issues before they reach the triage
+  # queue. When "false", modular issues pass through and are enqueued for
+  # triage like any other issue.
+  SKIP_MODULAR: "false"
 immutable: false
 kind: ConfigMap
 metadata:

--- a/ymir/agents/tests/unit/test_triage_agent.py
+++ b/ymir/agents/tests/unit/test_triage_agent.py
@@ -22,7 +22,7 @@ from ymir.common.models import (
     TriageEligibility,
     TriageOutputSchema,
 )
-from ymir.common.version_utils import is_modular, parse_module_stream
+from ymir.common.version_utils import extract_downstream_package, is_modular, parse_module_stream
 
 
 @pytest.mark.parametrize(
@@ -314,6 +314,15 @@ def test_map_version_to_module_branch(version, summary, downstream_component, ex
 def test_map_version_to_module_branch_invalid_version():
     branch = _map_version_to_module_branch("not-a-version", "postgresql:12/postgresql:vuln", "postgresql")
     assert branch is None
+
+
+def test_map_version_to_module_branch_extracts_package_from_raw_field():
+    """customfield_10669 stores module:stream/package; mapping needs the package."""
+    raw = "postgresql:16/postgis"
+    summary = "postgresql:16/postgis: PostGIS: vuln"
+    assert _map_version_to_module_branch("rhel-9.8", summary, raw) is None
+    package = extract_downstream_package(raw)
+    assert _map_version_to_module_branch("rhel-9.8", summary, package) == "stream-postgresql-16-rhel-9.8.0"
 
 
 # --- Modular target branch + namespace selection ---

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -75,6 +75,7 @@ from ymir.common.utils import (
 )
 from ymir.common.version_utils import (
     construct_internal_branch_name,
+    extract_downstream_package,
     is_modular,
     is_older_zstream,
     normalize_fix_version,
@@ -410,7 +411,10 @@ class TriageState(BaseModel):
     )
     downstream_component: str | None = Field(
         default=None,
-        description="Jira Downstream Component Name (customfield_10669), used for modular detection.",
+        description=(
+            "Package name from Jira Downstream Component Name (customfield_10669). "
+            "Modular values are reduced from 'module:stream/package' to the package."
+        ),
     )
     jira_summary: str | None = Field(
         default=None,
@@ -645,7 +649,10 @@ async def run_workflow(
 
             input_data = InputSchema(issue=state.jira_issue)
             state.jira_summary = jira_details.get("fields", {}).get("summary")
-            state.downstream_component = jira_details.get("fields", {}).get(DOWNSTREAM_COMPONENT_CUSTOM_FIELD)
+            raw_component = jira_details.get("fields", {}).get(DOWNSTREAM_COMPONENT_CUSTOM_FIELD)
+            # Modular issues store "module:stream/package" (e.g. "postgresql:16/postgis");
+            # extract the package so is_modular() / parse_module_stream() match the summary.
+            state.downstream_component = extract_downstream_package(raw_component)
             response = await triage_agent.run(
                 await render_prompt(
                     input_data,

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1606,7 +1606,7 @@ async def main() -> None:
                     Resolution.CLARIFICATION_NEEDED,
                     Resolution.OPEN_ENDED_ANALYSIS,
                 ):
-                    if auto_chain:
+                    if auto_chain and not is_modular(state.jira_summary, state.downstream_component):
                         if output.resolution == Resolution.OPEN_ENDED_ANALYSIS:
                             queue = RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value
                             downstream_payload = output.data.model_dump_json()
@@ -1658,11 +1658,17 @@ async def main() -> None:
                         if queue is not None:
                             await fix_await(redis.lpush(queue, downstream_payload))
                             logger.info(f"Pushed {input.issue} to {queue}")
+                    elif is_modular(state.jira_summary, state.downstream_component):
+                        logger.info(
+                            f"Modular issue {input.issue} — stopping after triage, skipping downstream queue"
+                        )
                     else:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
 
                 if output.resolution in _REPRODUCER_ELIGIBLE_RESOLUTIONS:
-                    if enqueue_reproducer:
+                    if is_modular(state.jira_summary, state.downstream_component):
+                        logger.info("Modular issue %s — skipping reproducer queue", input.issue)
+                    elif enqueue_reproducer:
                         async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
                             await _enqueue_reproducer(redis, state, user_triggered, gateway_tools)
                     else:

--- a/ymir/common/tests/unit/test_version_utils.py
+++ b/ymir/common/tests/unit/test_version_utils.py
@@ -2,7 +2,9 @@ import pytest
 from flexmock import flexmock
 
 from ymir.common.version_utils import (
+    extract_downstream_package,
     get_maintenance_rhel_branch,
+    is_modular,
     is_older_zstream,
     parse_branch_name,
     parse_module_stream,
@@ -199,3 +201,33 @@ async def test_get_maintenance_rhel_branch(branch, expected):
 )
 def test_parse_module_stream(summary, component, expected):
     assert parse_module_stream(summary, component) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("postgresql:16/postgis", "postgis"),
+        ("nodejs:18/nodejs", "nodejs"),
+        ("perl:5.32/perl-IO-Socket-SSL", "perl-IO-Socket-SSL"),
+        ("libtiff", "libtiff"),
+        ("regular-component", "regular-component"),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_extract_downstream_package(raw, expected):
+    assert extract_downstream_package(raw) == expected
+
+
+def test_is_modular_requires_package_not_full_modular_string():
+    summary = "postgresql:16/postgis: PostGIS: vuln"
+    raw = "postgresql:16/postgis"
+    assert is_modular(summary, raw) is False
+    assert is_modular(summary, extract_downstream_package(raw)) is True
+
+
+def test_parse_module_stream_requires_package_not_full_modular_string():
+    summary = "postgresql:16/postgis: PostGIS: vuln"
+    raw = "postgresql:16/postgis"
+    assert parse_module_stream(summary, raw) is None
+    assert parse_module_stream(summary, extract_downstream_package(raw)) == ("postgresql", "16")

--- a/ymir/common/version_utils.py
+++ b/ymir/common/version_utils.py
@@ -349,6 +349,18 @@ async def is_older_zstream(
 MODULAR_SUMMARY_PREFIX = r"^(?:\S+\s+)*([\w.+-]+):([^/\s]+)/"
 
 
+def extract_downstream_package(raw: str | None) -> str | None:
+    """Return the package name from Jira Downstream Component Name (customfield_10669).
+
+    Modular issues store ``module:stream/package`` (e.g. ``postgresql:16/postgis``);
+    non-modular issues store just the package name. ``is_modular`` and
+    ``parse_module_stream`` match the summary against the package part only.
+    """
+    if not raw:
+        return None
+    return raw.rsplit("/", 1)[-1]
+
+
 def is_modular(summary: str | None, component: str | None) -> bool:
     if not summary or not component:
         return False

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -122,6 +122,15 @@ class JiraIssueFetcher:
                 "skipped; Redis pushes will proceed normally"
             )
 
+        # Rollout flag: code defaults to "true" (safe for local runs without the
+        # ConfigMap); the cluster ConfigMap sets "false" to enable modular triage.
+        self.skip_modular = os.getenv("SKIP_MODULAR", "true").lower() == "true"
+        logger.info(
+            "SKIP_MODULAR=%s — modular issues will be %s",
+            self.skip_modular,
+            "skipped" if self.skip_modular else "enqueued for triage",
+        )
+
     async def _rate_limit(self):
         """Enforce rate limiting of RATE_LIMIT_CALLS_PER_SECOND calls per second"""
         current_time = time.time()
@@ -717,7 +726,7 @@ class JiraIssueFetcher:
                     fields = issue.get("fields") or {}
 
                     downstream_component = fields.get("customfield_10669") or ""
-                    if self.MODULAR_COMPONENT_PATTERN.match(downstream_component):
+                    if self.skip_modular and self.MODULAR_COMPONENT_PATTERN.match(downstream_component):
                         logger.info(f"Skipping issue {issue_key} - modular issue: {downstream_component}")
                         modular_count += 1
                         continue

--- a/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -86,6 +86,7 @@ def test_init(mock_env_vars):
     assert fetcher.query == 'filter = "Jotnar_1000_packages"'
     assert fetcher.max_results_per_page == 500
     assert fetcher.headers["Authorization"].startswith("Basic ")
+    assert fetcher.skip_modular is True
 
 
 @pytest.mark.asyncio
@@ -413,6 +414,36 @@ async def test_push_issues_to_queue_skip_modular(fetcher, mock_redis_context):
     mock_redis.should_receive("lpush").with_args(RedisQueues.TRIAGE_QUEUE.value, task2.to_json()).and_return(
         create_async_mock_return_value(1)
     ).once()
+
+    result = await fetcher.push_issues_to_queue(issues)
+
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_push_issues_to_queue_enqueue_modular(mock_env_vars, monkeypatch, mock_redis_context):
+    """Test that modular issues are enqueued when SKIP_MODULAR=false."""
+    monkeypatch.setenv("SKIP_MODULAR", "false")
+    fetcher = JiraIssueFetcher()
+    mock_redis, _ = mock_redis_context
+
+    issues = [
+        {"key": "MOD-1", "fields": {"labels": [], "customfield_10669": "perl:5.32/perl-IO-Socket-SSL"}},
+        {"key": "REG-1", "fields": {"labels": [], "customfield_10669": "regular-component"}},
+    ]
+
+    flexmock(fetcher).should_receive("_get_existing_issue_keys").and_return(
+        create_async_mock_return_value(set())
+    )
+
+    task_mod = Task.from_issue("MOD-1")
+    task_reg = Task.from_issue("REG-1")
+    mock_redis.should_receive("lpush").with_args(
+        RedisQueues.TRIAGE_QUEUE.value, task_mod.to_json()
+    ).and_return(create_async_mock_return_value(1)).once()
+    mock_redis.should_receive("lpush").with_args(
+        RedisQueues.TRIAGE_QUEUE.value, task_reg.to_json()
+    ).and_return(create_async_mock_return_value(1)).once()
 
     result = await fetcher.push_issues_to_queue(issues)
 


### PR DESCRIPTION
## Summary
- add `SKIP_MODULAR` fetcher flag (default `true` in code, `false` in OpenShift) so modular issues can be selectively enqueued for triage during rollout
- fix modular branch mapping by normalizing Jira Downstream Component from `module:stream/package` to package name before modular parsing
- stop modular issues after triage by skipping downstream dispatch and reproducer enqueue, and document this orchestrator behavior in the triage skill

## Test plan
- [ ] `uv run pytest -q ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py`
- [ ] `uv run pytest -q ymir/common/tests/unit/test_version_utils.py ymir/agents/tests/unit/test_triage_agent.py`
- [ ] run a dry-run modular Jira issue through triage and verify it is triaged but not dispatched downstream


Made with [Cursor](https://cursor.com)