### PR TITLE
Skip downstream dispatch for modular issues after triage

### DIFF
--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1599,7 +1599,8 @@ async def main() -> None:
                     Resolution.CLARIFICATION_NEEDED,
                     Resolution.OPEN_ENDED_ANALYSIS,
                 ):
-                    if auto_chain:
+                    _modular_component = "/" in (state.downstream_component or "")
+                    if auto_chain and not _modular_component:
                         if output.resolution == Resolution.OPEN_ENDED_ANALYSIS:
                             queue = RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value
                             downstream_payload = output.data.model_dump_json()
@@ -1651,11 +1652,17 @@ async def main() -> None:
                         if queue is not None:
                             await fix_await(redis.lpush(queue, downstream_payload))
                             logger.info(f"Pushed {input.issue} to {queue}")
+                    elif _modular_component:
+                        logger.info(
+                            f"Modular issue {input.issue} — stopping after triage, skipping downstream queue"
+                        )
                     else:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
 
                 if output.resolution in _REPRODUCER_ELIGIBLE_RESOLUTIONS:
-                    if enqueue_reproducer:
+                    if _modular_component:
+                        logger.info("Modular issue %s — skipping reproducer queue", input.issue)
+                    elif enqueue_reproducer:
                         async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
                             await _enqueue_reproducer(redis, state, user_triggered, gateway_tools)
                     else:


### PR DESCRIPTION
## Summary

- Modular issues (detected via `is_modular()`) now stop after triage — no rebase, backport, rebuild, clarification, or reproducer jobs are enqueued.
- Non-modular issues are completely unaffected and follow the existing `AUTO_CHAIN` / `TRIAGE_ENQUEUE_REPRODUCER` behavior.
- This lets us validate triage results for modular packages in production before enabling the full pipeline.

Depends on [#773](https://github.com/packit/ai-workflows/pull/773) (fetcher + downstream_component parsing) and [#756](https://github.com/packit/ai-workflows/pull/756) (stream-aware duplicate detection).

## Test plan

- [ ] Deploy to staging — verify modular issues are triaged and commented but not dispatched downstream
- [ ] Verify non-modular issues still flow through rebase/backport/rebuild as before
- [ ] Check logs for `"Modular issue RHEL-XXXXX — stopping after triage"` messages

Made with [Cursor](https://cursor.com)