### PR TITLE
[WIP]Skip downstream dispatch for modular issues after triage

### DIFF
--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1581,6 +1581,10 @@ async def main() -> None:
                     except Exception as e:
                         logger.warning(f"Failed to check/queue primary for sibling {input.issue}: {e}")
 
+                # Modular issues (downstream_component = "module:stream/package")
+                # stop after triage — no downstream jobs or reproducer.
+                _modular_component = "/" in (state.downstream_component or "")
+
                 # Dispatch to downstream queues
                 if output.resolution == Resolution.ERROR:
                     await retry(task, output.data.model_dump_json())
@@ -1599,7 +1603,7 @@ async def main() -> None:
                     Resolution.CLARIFICATION_NEEDED,
                     Resolution.OPEN_ENDED_ANALYSIS,
                 ):
-                    if auto_chain:
+                    if auto_chain and not _modular_component:
                         if output.resolution == Resolution.OPEN_ENDED_ANALYSIS:
                             queue = RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value
                             downstream_payload = output.data.model_dump_json()
@@ -1651,11 +1655,17 @@ async def main() -> None:
                         if queue is not None:
                             await fix_await(redis.lpush(queue, downstream_payload))
                             logger.info(f"Pushed {input.issue} to {queue}")
+                    elif _modular_component:
+                        logger.info(
+                            f"Modular issue {input.issue} — stopping after triage, skipping downstream queue"
+                        )
                     else:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
 
                 if output.resolution in _REPRODUCER_ELIGIBLE_RESOLUTIONS:
-                    if enqueue_reproducer:
+                    if _modular_component:
+                        logger.info("Modular issue %s — skipping reproducer queue", input.issue)
+                    elif enqueue_reproducer:
                         async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
                             await _enqueue_reproducer(redis, state, user_triggered, gateway_tools)
                     else:


### PR DESCRIPTION
## Summary

- Modular issues (detected by `"/"` in `downstream_component` from `customfield_10669`) stop after triage — no rebase, backport, rebuild, clarification, open-ended-analysis, or reproducer jobs are enqueued.
- Non-modular issues are completely unaffected and follow the existing `AUTO_CHAIN` / `TRIAGE_ENQUEUE_REPRODUCER` behavior.
- The full triage workflow (LLM analysis, CVE applicability, branch mapping, Jira comment, labels) still runs for modular issues — only downstream queue dispatch is gated.
- This lets us validate triage results for modular packages in production before enabling the full pipeline.

## Test plan

- [ ] Deploy to staging — verify modular issues are triaged and commented but not dispatched downstream
- [ ] Verify non-modular issues still flow through rebase/backport/rebuild as before
- [ ] Check logs for `"Modular issue RHEL-XXXXX — stopping after triage"` messages

Made with [Cursor](https://cursor.com)