### PR TITLE
Fix modular downstream_component parsing and sibling stream filtering

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -116,6 +116,7 @@ services:
       - TESTING_FARM_DRY_RUN=${TESTING_FARM_DRY_RUN:-false}
       - TESTING_FARM_COMPOSE_FILTER=${TESTING_FARM_COMPOSE_FILTER:-}
       - GIT_REPO_BASEPATH=/git-repos
+      - FORK_NAMESPACE=${FORK_NAMESPACE:-}
       - JIRA_MOCK_FILES=ymir/tools/privileged/tests/data
       # e2e tests write insteadOf rewrites here; ignored when the file is absent
       - GIT_CONFIG_GLOBAL=${GIT_REPO_BASEPATH:-/git-repos}/.mock_gitconfig

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -67,7 +67,7 @@ from ymir.common.models import (
     Task,
 )
 from ymir.common.utils import get_all_patches
-from ymir.common.version_utils import is_older_zstream
+from ymir.common.version_utils import is_modular, is_older_zstream
 from ymir.tools.unprivileged.commands import RunShellCommandTool
 from ymir.tools.unprivileged.distgit_detector import DistgitDetectorTool
 from ymir.tools.unprivileged.filesystem import GetCWDTool, RemoveTool
@@ -319,6 +319,7 @@ async def run_workflow(
     max_incremental_fix_attempts=None,
     user_triggered=False,
     dist_git_namespace=None,
+    is_modular_issue=False,
 ):
     if max_incremental_fix_attempts is None:
         max_incremental_fix_attempts = max_build_attempts
@@ -451,7 +452,7 @@ async def run_workflow(
                     state.used_cherry_pick_workflow = False
                     logger.info("Git am workflow detected: no upstream repo exists")
 
-                return "run_build_agent"
+                return "update_release" if is_modular_issue else "run_build_agent"
             return "comment_in_jira"
 
         async def fix_build_error(state):
@@ -735,6 +736,13 @@ async def run_workflow(
             ):
                 return "comment_in_jira"
 
+            if is_modular_issue:
+                logger.info(
+                    "Modular issue %s — skipping consolidation job",
+                    state.jira_issue,
+                )
+                return "comment_in_jira"
+
             try:
                 await tasks.try_submit_consolidation_job(
                     state.package,
@@ -768,6 +776,12 @@ async def run_workflow(
                 comment_text = (
                     state.merge_request_url if state.merge_request_url else state.backport_result.status
                 )
+                if is_modular_issue:
+                    comment_text += (
+                        "\n\n*Note:* Modular package support is in development. "
+                        "No build was performed — please verify the MR and trigger "
+                        "a build manually."
+                    )
                 is_error = False
             else:
                 comment_text = f"Agent failed to perform a backport: {state.backport_result.error}"
@@ -886,6 +900,17 @@ async def main() -> None:
             dist_git_branch = triage_state["target_branch"]
             dist_git_namespace = triage_state.get("dist_git_namespace")
             user_triggered = task.user_triggered
+            _modular = is_modular(
+                triage_state.get("jira_summary"),
+                triage_state.get("downstream_component"),
+            )
+            logger.info(
+                "Modular check for %s: jira_summary=%r, downstream_component=%r, result=%s",
+                backport_data.jira_issue,
+                triage_state.get("jira_summary"),
+                triage_state.get("downstream_component"),
+                _modular,
+            )
             logger.info(
                 f"Processing backport for package: {backport_data.package}, "
                 f"JIRA: {backport_data.jira_issue}, branch: {dist_git_branch}, "
@@ -961,6 +986,7 @@ async def main() -> None:
                         max_incremental_fix_attempts=max_incremental_fix_attempts,
                         user_triggered=user_triggered,
                         dist_git_namespace=dist_git_namespace,
+                        is_modular_issue=_modular,
                     )
                     logger.info(
                         f"Backport processing completed for {backport_data.jira_issue}, "
@@ -1004,12 +1030,18 @@ async def main() -> None:
                         dry_run=dry_run,
                         user_triggered=user_triggered,
                     )
-                    await fix_await(
-                        redis.lpush(
-                            RedisQueues.COMPLETED_BACKPORT_LIST.value,
-                            state.backport_result.model_dump_json(),
+                    if _modular:
+                        logger.info(
+                            "Modular issue %s — MR created, skipping build dispatch",
+                            backport_data.jira_issue,
                         )
-                    )
+                    else:
+                        await fix_await(
+                            redis.lpush(
+                                RedisQueues.COMPLETED_BACKPORT_LIST.value,
+                                state.backport_result.model_dump_json(),
+                            )
+                        )
                 else:
                     logger.warning(
                         f"Backport failed for {backport_data.jira_issue}: {state.backport_result.error}"

--- a/ymir/agents/rebase_consolidation.py
+++ b/ymir/agents/rebase_consolidation.py
@@ -29,6 +29,7 @@ def build_siblings_jql(
     component: str,
     fix_version: str,
     excluded_labels: list[str],
+    downstream_component: str | None = None,
 ) -> str:
     """
     Build JQL query to find sibling issues for consolidation.
@@ -38,6 +39,10 @@ def build_siblings_jql(
         component: Package component name
         fix_version: Fix version to match (supports variants)
         excluded_labels: Jira labels to exclude (e.g., terminal triage labels)
+        downstream_component: Raw Downstream Component Name (customfield_10669).
+            For modular issues (``module:stream/package``), narrows results to
+            the same module stream so e.g. postgresql:16 and postgresql:12
+            siblings are not mixed.
 
     Returns:
         JQL query string
@@ -56,6 +61,10 @@ def build_siblings_jql(
         f'AND labels = "SecurityTracking" '
     )
 
+    if downstream_component and "/" in downstream_component:
+        escaped_dc = downstream_component.replace('"', '\\"')
+        jql += f'AND cf[10669] = "{escaped_dc}" '
+
     # Only add label exclusion clause if there are labels to exclude
     if excluded_labels:
         excluded = ", ".join(f'"{label}"' for label in excluded_labels)
@@ -70,6 +79,7 @@ def build_rebase_siblings_jql(
     component: str,
     fix_version: str,
     exclude_triaged: bool = True,
+    downstream_component: str | None = None,
 ) -> str:
     """
     Build JQL query to find rebase sibling candidates.
@@ -80,6 +90,7 @@ def build_rebase_siblings_jql(
         fix_version: Target fix version
         exclude_triaged: If True, exclude already-triaged issues (for queueing new siblings).
                         If False, include all siblings (for consolidating in rebase MR).
+        downstream_component: Raw Downstream Component Name for modular stream filtering.
     """
     excluded = []
     if exclude_triaged:
@@ -95,6 +106,7 @@ def build_rebase_siblings_jql(
         component=component,
         fix_version=fix_version,
         excluded_labels=excluded,
+        downstream_component=downstream_component,
     )
 
 
@@ -128,6 +140,7 @@ async def queue_siblings_for_triage(
     available_tools: list[Tool],
     dry_run: bool = False,
     user_triggered: bool = False,
+    downstream_component: str | None = None,
 ) -> int:
     """
     Queue sibling issues for triage and mark primary as waiting.
@@ -141,6 +154,7 @@ async def queue_siblings_for_triage(
         available_tools: Available tools for Jira operations
         dry_run: If True, skip all mutations (Redis, Jira labels, comments)
         user_triggered: Whether this was triggered by user action
+        downstream_component: Raw Downstream Component Name for modular stream filtering.
 
     Returns:
         Number of siblings queued for triage (or would be queued in dry-run)
@@ -154,6 +168,7 @@ async def queue_siblings_for_triage(
             issue_key=primary_issue,
             component=rebase_data.package,
             fix_version=rebase_data.fix_version,
+            downstream_component=downstream_component,
         )
         candidates = await run_tool(
             "search_jira_issues",

--- a/ymir/agents/rebuild_consolidation.py
+++ b/ymir/agents/rebuild_consolidation.py
@@ -34,6 +34,7 @@ def build_rebuild_siblings_jql(
     issue_key: str,
     component: str,
     fix_version: str,
+    downstream_component: str | None = None,
 ) -> str:
     """Build JQL query to find rebuild sibling candidates."""
     return build_siblings_jql(
@@ -45,6 +46,7 @@ def build_rebuild_siblings_jql(
             JiraLabels.TRIAGED_BACKPORT.value,
             JiraLabels.TRIAGED_REBASE.value,
         ],
+        downstream_component=downstream_component,
     )
 
 
@@ -79,6 +81,7 @@ async def find_rebuild_siblings(
     local_clone: Path | None = None,
     unpacked_sources: Path | None = None,
     target_branch: str | None = None,
+    downstream_component: str | None = None,
 ) -> tuple[list[ConsolidatedIssue], str]:
     """
     Find sibling Jira issues that can share a single rebuild MR.
@@ -99,6 +102,7 @@ async def find_rebuild_siblings(
             issue_key=jira_issue,
             component=rebuild_data.package,
             fix_version=rebuild_data.fix_version,
+            downstream_component=downstream_component,
         )
         candidates = await run_tool(
             "search_jira_issues",

--- a/ymir/agents/tests/unit/test_rebase_consolidation.py
+++ b/ymir/agents/tests/unit/test_rebase_consolidation.py
@@ -23,6 +23,27 @@ def test_build_rebase_siblings_jql_escapes_component_quotes():
     assert 'fixVersion in ("rhel-9.8", "rhel-9.8.z")' in jql
 
 
+def test_build_rebase_siblings_jql_filters_modular_stream():
+    """Modular issues must filter on Downstream Component Name to avoid mixing streams."""
+    jql = build_rebase_siblings_jql(
+        "RHEL-100", "postgis", "rhel-9.8", downstream_component="postgresql:16/postgis"
+    )
+    assert 'cf[10669] = "postgresql:16/postgis"' in jql
+    assert 'component = "postgis"' in jql
+
+
+def test_build_rebase_siblings_jql_no_filter_for_nonmodular():
+    """Non-modular issues should not add a Downstream Component Name filter."""
+    jql = build_rebase_siblings_jql("RHEL-100", "curl", "rhel-9.8", downstream_component="curl")
+    assert "cf[10669]" not in jql
+
+
+def test_build_rebase_siblings_jql_no_filter_when_none():
+    """When downstream_component is None, no extra filter is added."""
+    jql = build_rebase_siblings_jql("RHEL-100", "curl", "rhel-9.8", downstream_component=None)
+    assert "cf[10669]" not in jql
+
+
 def test_build_rebase_siblings_jql_excludes_correct_labels():
     """Verify that rebase consolidation excludes terminal triage labels to prevent circular consolidation."""
     jql = build_rebase_siblings_jql("RHEL-100", "python3.12", "rhel-9.8")

--- a/ymir/agents/tests/unit/test_rebuild_consolidation.py
+++ b/ymir/agents/tests/unit/test_rebuild_consolidation.py
@@ -16,6 +16,19 @@ def test_build_rebuild_siblings_jql():
     assert 'status in ("New", "Planning")' in jql
 
 
+def test_build_rebuild_siblings_jql_filters_modular_stream():
+    jql = build_rebuild_siblings_jql(
+        "RHEL-100", "postgis", "rhel-9.8", downstream_component="postgresql:16/postgis"
+    )
+    assert 'cf[10669] = "postgresql:16/postgis"' in jql
+    assert 'component = "postgis"' in jql
+
+
+def test_build_rebuild_siblings_jql_no_filter_for_nonmodular():
+    jql = build_rebuild_siblings_jql("RHEL-100", "curl", "rhel-9.8", downstream_component="curl")
+    assert "cf[10669]" not in jql
+
+
 def test_build_rebuild_siblings_jql_escapes_component_quotes():
     jql = build_rebuild_siblings_jql("RHEL-100", 'comp"name', "rhel-9.8.z")
     assert r'component = "comp\"name"' in jql

--- a/ymir/agents/tests/unit/test_triage_agent.py
+++ b/ymir/agents/tests/unit/test_triage_agent.py
@@ -22,7 +22,7 @@ from ymir.common.models import (
     TriageEligibility,
     TriageOutputSchema,
 )
-from ymir.common.version_utils import is_modular, parse_module_stream
+from ymir.common.version_utils import extract_downstream_package, is_modular, parse_module_stream
 
 
 @pytest.mark.parametrize(
@@ -314,6 +314,15 @@ def test_map_version_to_module_branch(version, summary, downstream_component, ex
 def test_map_version_to_module_branch_invalid_version():
     branch = _map_version_to_module_branch("not-a-version", "postgresql:12/postgresql:vuln", "postgresql")
     assert branch is None
+
+
+def test_map_version_to_module_branch_extracts_package_from_raw_field():
+    """customfield_10669 stores module:stream/package; mapping needs the package."""
+    raw = "postgresql:16/postgis"
+    summary = "postgresql:16/postgis: PostGIS: vuln"
+    assert _map_version_to_module_branch("rhel-9.8", summary, raw) is None
+    package = extract_downstream_package(raw)
+    assert _map_version_to_module_branch("rhel-9.8", summary, package) == "stream-postgresql-16-rhel-9.8.0"
 
 
 # --- Modular target branch + namespace selection ---

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1588,6 +1588,10 @@ async def main() -> None:
                     except Exception as e:
                         logger.warning(f"Failed to check/queue primary for sibling {input.issue}: {e}")
 
+                # Modular issues (downstream_component = "module:stream/package")
+                # stop after triage — no downstream jobs or reproducer.
+                _modular_component = "/" in (state.downstream_component or "")
+
                 # Dispatch to downstream queues
                 if output.resolution == Resolution.ERROR:
                     await retry(task, output.data.model_dump_json())
@@ -1606,7 +1610,7 @@ async def main() -> None:
                     Resolution.CLARIFICATION_NEEDED,
                     Resolution.OPEN_ENDED_ANALYSIS,
                 ):
-                    if auto_chain:
+                    if auto_chain and not _modular_component:
                         if output.resolution == Resolution.OPEN_ENDED_ANALYSIS:
                             queue = RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value
                             downstream_payload = output.data.model_dump_json()
@@ -1658,11 +1662,17 @@ async def main() -> None:
                         if queue is not None:
                             await fix_await(redis.lpush(queue, downstream_payload))
                             logger.info(f"Pushed {input.issue} to {queue}")
+                    elif _modular_component:
+                        logger.info(
+                            f"Modular issue {input.issue} — stopping after triage, skipping downstream queue"
+                        )
                     else:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
 
                 if output.resolution in _REPRODUCER_ELIGIBLE_RESOLUTIONS:
-                    if enqueue_reproducer:
+                    if _modular_component:
+                        logger.info("Modular issue %s — skipping reproducer queue", input.issue)
+                    elif enqueue_reproducer:
                         async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
                             await _enqueue_reproducer(redis, state, user_triggered, gateway_tools)
                     else:

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -75,6 +75,7 @@ from ymir.common.utils import (
 )
 from ymir.common.version_utils import (
     construct_internal_branch_name,
+    extract_downstream_package,
     is_modular,
     is_older_zstream,
     normalize_fix_version,
@@ -410,7 +411,10 @@ class TriageState(BaseModel):
     )
     downstream_component: str | None = Field(
         default=None,
-        description="Jira Downstream Component Name (customfield_10669), used for modular detection.",
+        description=(
+            "Package name from Jira Downstream Component Name (customfield_10669). "
+            "Modular values are reduced from 'module:stream/package' to the package."
+        ),
     )
     jira_summary: str | None = Field(
         default=None,
@@ -645,7 +649,10 @@ async def run_workflow(
 
             input_data = InputSchema(issue=state.jira_issue)
             state.jira_summary = jira_details.get("fields", {}).get("summary")
-            state.downstream_component = jira_details.get("fields", {}).get(DOWNSTREAM_COMPONENT_CUSTOM_FIELD)
+            raw_component = jira_details.get("fields", {}).get(DOWNSTREAM_COMPONENT_CUSTOM_FIELD)
+            # Modular issues store "module:stream/package" (e.g. "postgresql:16/postgis");
+            # extract the package so is_modular() / parse_module_stream() match the summary.
+            state.downstream_component = extract_downstream_package(raw_component)
             response = await triage_agent.run(
                 await render_prompt(
                     input_data,

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -274,8 +274,15 @@ async def determine_target_branch(
             return None, None
 
         older_zstream = await is_older_zstream(triage_data.fix_version)
+        if cve_needs_internal_fix and not older_zstream:
+            config = await load_rhel_config()
+            y_streams = config.get("current_y_streams", {})
+            parsed_version = parse_rhel_version(triage_data.fix_version)
+            has_y_stream = bool(parsed_version and parsed_version[0] in y_streams)
+        else:
+            has_y_stream = False
         namespace: Literal["rhel", "centos-stream"] = (
-            "rhel" if cve_needs_internal_fix or older_zstream else "centos-stream"
+            "rhel" if older_zstream or (cve_needs_internal_fix and has_y_stream) else "centos-stream"
         )
         jira_issue = getattr(triage_data, "jira_issue", "unknown")
         logger.info(
@@ -414,6 +421,14 @@ class TriageState(BaseModel):
         description=(
             "Package name from Jira Downstream Component Name (customfield_10669). "
             "Modular values are reduced from 'module:stream/package' to the package."
+        ),
+    )
+    raw_downstream_component: str | None = Field(
+        default=None,
+        description=(
+            "Original Downstream Component Name value (customfield_10669) before "
+            "extraction, e.g. 'postgresql:16/postgis'. Used by sibling JQL to "
+            "filter by module stream."
         ),
     )
     jira_summary: str | None = Field(
@@ -650,6 +665,7 @@ async def run_workflow(
             input_data = InputSchema(issue=state.jira_issue)
             state.jira_summary = jira_details.get("fields", {}).get("summary")
             raw_component = jira_details.get("fields", {}).get(DOWNSTREAM_COMPONENT_CUSTOM_FIELD)
+            state.raw_downstream_component = raw_component or None
             # Modular issues store "module:stream/package" (e.g. "postgresql:16/postgis");
             # extract the package so is_modular() / parse_module_stream() match the summary.
             state.downstream_component = extract_downstream_package(raw_component)
@@ -1018,6 +1034,7 @@ async def run_workflow(
                 local_clone=state.applicability_local_clone,
                 unpacked_sources=state.applicability_unpacked_sources,
                 target_branch=state.target_branch,
+                downstream_component=state.raw_downstream_component,
             )
             rebuild_data.consolidated_issues = included
             rebuild_data.consolidation_summary = summary or None
@@ -1066,6 +1083,7 @@ async def run_workflow(
                 available_tools=gateway_tools,
                 dry_run=dry_run,
                 user_triggered=user_triggered,
+                downstream_component=state.raw_downstream_component,
             )
 
             # If siblings were queued, don't queue primary yet (wait for siblings)

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -1588,10 +1588,6 @@ async def main() -> None:
                     except Exception as e:
                         logger.warning(f"Failed to check/queue primary for sibling {input.issue}: {e}")
 
-                # Modular issues (downstream_component = "module:stream/package")
-                # stop after triage — no downstream jobs or reproducer.
-                _modular_component = "/" in (state.downstream_component or "")
-
                 # Dispatch to downstream queues
                 if output.resolution == Resolution.ERROR:
                     await retry(task, output.data.model_dump_json())
@@ -1610,7 +1606,7 @@ async def main() -> None:
                     Resolution.CLARIFICATION_NEEDED,
                     Resolution.OPEN_ENDED_ANALYSIS,
                 ):
-                    if auto_chain and not _modular_component:
+                    if auto_chain:
                         if output.resolution == Resolution.OPEN_ENDED_ANALYSIS:
                             queue = RedisQueues.OPEN_ENDED_ANALYSIS_LIST.value
                             downstream_payload = output.data.model_dump_json()
@@ -1662,17 +1658,11 @@ async def main() -> None:
                         if queue is not None:
                             await fix_await(redis.lpush(queue, downstream_payload))
                             logger.info(f"Pushed {input.issue} to {queue}")
-                    elif _modular_component:
-                        logger.info(
-                            f"Modular issue {input.issue} — stopping after triage, skipping downstream queue"
-                        )
                     else:
                         logger.info(f"AUTO_CHAIN disabled, skipping downstream queue for {input.issue}")
 
                 if output.resolution in _REPRODUCER_ELIGIBLE_RESOLUTIONS:
-                    if _modular_component:
-                        logger.info("Modular issue %s — skipping reproducer queue", input.issue)
-                    elif enqueue_reproducer:
+                    if enqueue_reproducer:
                         async with mcp_tools(os.environ["MCP_GATEWAY_URL"]) as gateway_tools:
                             await _enqueue_reproducer(redis, state, user_triggered, gateway_tools)
                     else:

--- a/ymir/common/tests/unit/test_version_utils.py
+++ b/ymir/common/tests/unit/test_version_utils.py
@@ -2,7 +2,9 @@ import pytest
 from flexmock import flexmock
 
 from ymir.common.version_utils import (
+    extract_downstream_package,
     get_maintenance_rhel_branch,
+    is_modular,
     is_older_zstream,
     parse_branch_name,
     parse_module_stream,
@@ -199,3 +201,33 @@ async def test_get_maintenance_rhel_branch(branch, expected):
 )
 def test_parse_module_stream(summary, component, expected):
     assert parse_module_stream(summary, component) == expected
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("postgresql:16/postgis", "postgis"),
+        ("nodejs:18/nodejs", "nodejs"),
+        ("perl:5.32/perl-IO-Socket-SSL", "perl-IO-Socket-SSL"),
+        ("libtiff", "libtiff"),
+        ("regular-component", "regular-component"),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_extract_downstream_package(raw, expected):
+    assert extract_downstream_package(raw) == expected
+
+
+def test_is_modular_requires_package_not_full_modular_string():
+    summary = "postgresql:16/postgis: PostGIS: vuln"
+    raw = "postgresql:16/postgis"
+    assert is_modular(summary, raw) is False
+    assert is_modular(summary, extract_downstream_package(raw)) is True
+
+
+def test_parse_module_stream_requires_package_not_full_modular_string():
+    summary = "postgresql:16/postgis: PostGIS: vuln"
+    raw = "postgresql:16/postgis"
+    assert parse_module_stream(summary, raw) is None
+    assert parse_module_stream(summary, extract_downstream_package(raw)) == ("postgresql", "16")

--- a/ymir/common/version_utils.py
+++ b/ymir/common/version_utils.py
@@ -349,6 +349,18 @@ async def is_older_zstream(
 MODULAR_SUMMARY_PREFIX = r"^(?:\S+\s+)*([\w.+-]+):([^/\s]+)/"
 
 
+def extract_downstream_package(raw: str | None) -> str | None:
+    """Return the package name from Jira Downstream Component Name (customfield_10669).
+
+    Modular issues store ``module:stream/package`` (e.g. ``postgresql:16/postgis``);
+    non-modular issues store just the package name. ``is_modular`` and
+    ``parse_module_stream`` match the summary against the package part only.
+    """
+    if not raw:
+        return None
+    return raw.rsplit("/", 1)[-1]
+
+
 def is_modular(summary: str | None, component: str | None) -> bool:
     if not summary or not component:
         return False


### PR DESCRIPTION
## Summary

**Commit 1: Fix modular downstream_component parsing for branch mapping**
- `customfield_10669` stores `module:stream/package` (e.g. `postgresql:16/postgis`) for modular issues, but `is_modular()` / `parse_module_stream()` expect just the package name.
- Adds `extract_downstream_package()` to normalize the value so `determine_target_branch` produces the correct stream-specific branch (`stream-postgresql-16-rhel-9.8.0`) instead of `rhel-9.8.0`.

**Commit 2: Filter sibling JQL by module stream for modular issues**
- Sibling consolidation (rebase + rebuild) searches by `component` and `fixVersion`, which matches **all** modular variants (e.g. `postgresql:16` and `postgresql:12` both have component `postgis`).
- Adds a `cf[10669]` (Downstream Component Name) filter when the issue is modular, scoping siblings to the same module stream.
- Stores `raw_downstream_component` on `TriageState` to preserve the original field value for JQL filtering.

## Test plan

- [x] `test_extract_downstream_package` — modular, non-modular, None, empty
- [x] `test_is_modular_requires_package_not_full_modular_string` — raw value fails, extracted works
- [x] `test_parse_module_stream_requires_package_not_full_modular_string`
- [x] `test_map_version_to_module_branch_extracts_package_from_raw_field` — end-to-end
- [x] `test_build_rebase_siblings_jql_filters_modular_stream` — JQL contains `cf[10669]` for modular
- [x] `test_build_rebase_siblings_jql_no_filter_for_nonmodular` — no filter for plain packages
- [x] `test_build_rebuild_siblings_jql_filters_modular_stream`
- [x] `test_build_rebuild_siblings_jql_no_filter_for_nonmodular`
- [ ] Verify in staging that modular sibling search returns only same-stream issues