### PR TITLE
Add missing tools for rust packages to c9s container

### DIFF
--- a/Containerfile.c9s
+++ b/Containerfile.c9s
@@ -54,6 +54,7 @@ RUN dnf -y install --allowerasing \
       python-srpm-macros \
       pyproject-srpm-macros \
       rust-srpm-macros \
+      rust-toolset \
       perl-srpm-macros \
       perl-ExtUtils-MakeMaker \
       javapackages-tools \


### PR DESCRIPTION
c10s has rust-toolset-srpm-macros but that package doesn't exist in c9s and the required macrofile is in rust-toolset.