### PR TITLE
Fix Fedora CA bundle path

### DIFF
--- a/agents_as_skills/install-skills.py
+++ b/agents_as_skills/install-skills.py
@@ -218,9 +218,13 @@ def write_mcp_config(client: str, creds: dict):
         "MCP_TRANSPORT": "stdio",
         "UPSTREAM_SEARCH_API_URL": "http://upstream-search.hosted.upshift.rdu2.redhat.com:80/v1",
     }
-    ca_bundle = Path("/etc/pki/tls/certs/ca-bundle.crt")
-    if ca_bundle.exists():
-        unpriv_env["REQUESTS_CA_BUNDLE"] = str(ca_bundle)
+    for ca_bundle in (
+        Path("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"),
+        Path("/etc/pki/tls/certs/ca-bundle.crt"),
+    ):
+        if ca_bundle.exists():
+            unpriv_env["REQUESTS_CA_BUNDLE"] = str(ca_bundle)
+            break
 
     config_path = CLIENT_MCP_CONFIG_PATHS[client]
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -104,7 +104,10 @@ services:
       # Point requests at the system CA bundle (includes RH IT Root CAs from
       # files/Current-IT-Root-CAs.pem via update-ca-trust in Containerfile.mcp).
       # Without this, requests uses certifi and fails on internal HTTPS (e.g. artifacts.osci).
-      - REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+      # Fedora 44 dropped the /etc/pki/tls/certs/ca-bundle.crt compat symlink
+      # (https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile); use the
+      # canonical extracted bundle path instead.
+      - REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
       # SAFETY: These default to false for production agents, but MUST be true for E2E tests.
       # The E2E Makefile targets set them in the environment before invoking compose
       # (e.g., MOCK_JIRA=true DRY_RUN=true make run-triage-agent-e2e-tests) so the

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,7 @@ x-beeai-env: &beeai-env
   ERRATA_ALLOW_STATUS_CHANGES: ${ERRATA_ALLOW_STATUS_CHANGES:-false}
   AUTO_CHAIN: ${AUTO_CHAIN:-true}
   TRIAGE_ENQUEUE_REPRODUCER: ${TRIAGE_ENQUEUE_REPRODUCER:-true}
-  REQUESTS_CA_BUNDLE: /etc/pki/tls/certs/ca-bundle.crt
+  REQUESTS_CA_BUNDLE: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
   SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-development}
 
 # Base template for BeeAI agents

--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -30,7 +30,7 @@ spec:
         - name: CONTAINER_VERSION
           value: "c10s"
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/openshift/deployment-backport-agent-c9s.yml
+++ b/openshift/deployment-backport-agent-c9s.yml
@@ -30,7 +30,7 @@ spec:
         - name: CONTAINER_VERSION
           value: "c9s"
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/openshift/deployment-mcp-gateway.yml
+++ b/openshift/deployment-mcp-gateway.yml
@@ -34,7 +34,7 @@ spec:
         - name: FORK_NAMESPACE
           value: redhat/rhel/bot-branches
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - secretRef:
             name: gitlab-env

--- a/openshift/deployment-mr-consolidation-agent-c10s.yml
+++ b/openshift/deployment-mr-consolidation-agent-c10s.yml
@@ -27,7 +27,7 @@ spec:
         - name: CONTAINER_VERSION
           value: "c10s"
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/openshift/deployment-mr-consolidation-agent-c9s.yml
+++ b/openshift/deployment-mr-consolidation-agent-c9s.yml
@@ -27,7 +27,7 @@ spec:
         - name: CONTAINER_VERSION
           value: "c9s"
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/openshift/deployment-rebase-agent-c10s.yml
+++ b/openshift/deployment-rebase-agent-c10s.yml
@@ -30,7 +30,7 @@ spec:
         - name: CONTAINER_VERSION
           value: "c10s"
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/openshift/deployment-rebase-agent-c9s.yml
+++ b/openshift/deployment-rebase-agent-c9s.yml
@@ -30,7 +30,7 @@ spec:
         - name: CONTAINER_VERSION
           value: "c9s"
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -30,7 +30,7 @@ spec:
         - name: CONTAINER_VERSION
           value: "c10s"
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/openshift/deployment-rebuild-agent-c9s.yml
+++ b/openshift/deployment-rebuild-agent-c9s.yml
@@ -30,7 +30,7 @@ spec:
         - name: CONTAINER_VERSION
           value: "c9s"
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/openshift/deployment-reproducer-agent.yml
+++ b/openshift/deployment-reproducer-agent.yml
@@ -26,7 +26,7 @@ spec:
         - /usr/bin/python
         env:
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/openshift/deployment-triage-agent.yml
+++ b/openshift/deployment-triage-agent.yml
@@ -28,7 +28,7 @@ spec:
         - /usr/bin/python
         env:
         - name: REQUESTS_CA_BUNDLE
-          value: /etc/pki/tls/certs/ca-bundle.crt
+          value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
         envFrom:
         - configMapRef:
             name: agents-env

--- a/skills_installation.md
+++ b/skills_installation.md
@@ -160,7 +160,7 @@ claude mcp add ymir-privileged \
 claude mcp add ymir-unprivileged \
   --env MCP_TRANSPORT=stdio \
   --env UPSTREAM_SEARCH_API_URL=http://upstream-search.hosted.upshift.rdu2.redhat.com:80/v1 \
-  --env REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt \
+  --env REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
   -- "$VENV/bin/ymir-unprivileged-gateway"
 ```
 
@@ -186,7 +186,7 @@ Or edit `~/.claude.json` directly, adding to the top-level `mcpServers` object
       "env": {
         "MCP_TRANSPORT": "stdio",
         "UPSTREAM_SEARCH_API_URL": "http://upstream-search.hosted.upshift.rdu2.redhat.com:80/v1",
-        "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+        "REQUESTS_CA_BUNDLE": "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
       }
     }
   }


### PR DESCRIPTION
See https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile

The new canonical path is guaranteed to exist on CentOS Stream as well, so it is changed there as well to avoid future surprises.