### PR TITLE
Revamp error_list

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -80,6 +80,16 @@ show-reproducer-queue:
 show-error-list:
 	@oc exec deployment/valkey -- valkey-cli --no-raw LRANGE error_list 0 -1 | python3 scripts/error_list.py --file -
 
+# Requeue a specific error_list entry (by the [id=...] shown in show-error-list)
+# back onto its original trigger queue, with attempts reset to 0.
+# Required: ERROR_ID
+requeue-error:
+	@if [ -z "$(ERROR_ID)" ]; then \
+		echo "Usage: make requeue-error ERROR_ID=42"; \
+		exit 1; \
+	fi
+	python3 scripts/requeue_error.py $(ERROR_ID)
+
 logs-triage:
 	oc logs -f deployment/triage-agent
 
@@ -204,7 +214,7 @@ unsuspend-sweeps:
 	show-triage-queue show-rebase-queue-c9s show-rebase-queue-c10s \
 	show-backport-queue-c9s show-backport-queue-c10s \
 	show-rebuild-queue-c9s show-rebuild-queue-c10s \
-	show-clarification-queue show-reproducer-queue show-error-list \
+	show-clarification-queue show-reproducer-queue show-error-list requeue-error \
 	logs-triage logs-backport-c9s logs-backport-c10s \
 	logs-rebase-c9s logs-rebase-c10s logs-rebuild-c9s logs-rebuild-c10s \
 	logs-reproducer logs-mcp logs-supervisor logs-valkey logs-phoenix \

--- a/openshift/scripts/error_list.py
+++ b/openshift/scripts/error_list.py
@@ -189,6 +189,12 @@ def issue_of(obj, raw: str) -> str:
         for key in ("jira_issue", "issue", "issue_key"):
             if obj.get(key):
                 return _issue_str(obj[key])
+        # ErrorListEntry wrapper: the real ErrorData is nested under "error".
+        err = obj.get("error")
+        if isinstance(err, dict):
+            for key in ("jira_issue", "issue", "issue_key"):
+                if err.get(key):
+                    return _issue_str(err[key])
     m = RHEL_RE.search(raw)
     return m.group(0) if m else "?"
 
@@ -201,17 +207,39 @@ def reason_of(obj, raw: str) -> str:
     if a:
         return a.group(1)[:100]
     if isinstance(obj, dict):
-        for f in REASON_FIELDS:
-            v = obj.get(f)
-            if v:
-                lines = str(v).splitlines()
-                first = lines[0] if lines else ""
-                if first.strip():
-                    return first[:100]
+        # ErrorListEntry wrapper: look at the top level, then the nested ErrorData.
+        candidates = [obj]
+        if isinstance(obj.get("error"), dict):
+            candidates.append(obj["error"])
+        for candidate in candidates:
+            for f in REASON_FIELDS:
+                v = candidate.get(f)
+                if isinstance(v, dict):
+                    continue  # e.g. the wrapper's own "error" key — recurse via `candidates`, don't stringify
+                if v:
+                    lines = str(v).splitlines()
+                    first = lines[0] if lines else ""
+                    if first.strip():
+                        return first[:100]
         if "attempts" in obj or "metadata" in obj:
             return f"(Task, attempts={obj.get('attempts', '?')}, no error field)"
     line = next((ln for ln in raw.splitlines() if ln.strip()), "")
     return line[:100] or "(empty)"
+
+
+def meta_of(obj) -> dict:
+    """Extract error_id/timestamp/requeueable from an ErrorListEntry wrapper.
+
+    Older entries pushed before ErrorListEntry existed are bare ErrorData
+    objects with no "error_id" key — treated as legacy/non-requeueable.
+    """
+    if isinstance(obj, dict) and "error_id" in obj:
+        return {
+            "error_id": obj.get("error_id"),
+            "timestamp": obj.get("timestamp"),
+            "requeueable": bool(obj.get("queue") and obj.get("task")),
+        }
+    return {"error_id": None, "timestamp": None, "requeueable": False}
 
 
 def signature(reason: str) -> str:
@@ -223,7 +251,9 @@ def analyze(blob: str) -> list[dict]:
     out = []
     for elem in to_elements(blob):
         obj = _try_json(elem)
-        out.append({"issue": issue_of(obj, elem), "reason": reason_of(obj, elem), "parsed": obj is not None})
+        entry = {"issue": issue_of(obj, elem), "reason": reason_of(obj, elem), "parsed": obj is not None}
+        entry.update(meta_of(obj))
+        out.append(entry)
     return out
 
 
@@ -284,6 +314,20 @@ def main() -> None:
     print("\nBy error type:")
     for sig, n in by_sig.most_common():
         print(f"  {n:>3}x  {sig}")
+
+    requeueable = sum(1 for e in entries if e["requeueable"])
+    if total:
+        print(f"\n{requeueable}/{total} entries are requeueable (have error_id + queue + task).")
+        print("\nEntries (use `make requeue-error ERROR_ID=<id>` on [requeueable] rows):")
+        for e in entries:
+            if e["error_id"] is None:
+                id_str, status = "id=-", "legacy"
+            elif e["requeueable"]:
+                id_str, status = f"id={e['error_id']}", "requeueable"
+            else:
+                id_str, status = f"id={e['error_id']}", "non-requeueable"
+            ts = e["timestamp"] or "-"
+            print(f"  [{id_str:<10}] [{status:<15}] {ts}  {e['issue']:<{width}}  {e['reason'][:80]}")
 
 
 if __name__ == "__main__":

--- a/openshift/scripts/requeue_error.py
+++ b/openshift/scripts/requeue_error.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Requeue a specific `error_list` entry back onto its original trigger queue.
+
+Only works for entries pushed by the `ErrorListEntry`-aware agents (i.e. those
+carrying `error_id`/`queue`/`task`). Legacy entries pushed before that change,
+or entries recorded for a payload that never parsed into a `Task` in the first
+place, have no `queue`/`task` to requeue and are reported as non-requeueable.
+
+The task's `attempts` counter is reset to 0 and `user_triggered` is forced to
+True before requeuing, on the assumption that whoever runs this has already
+fixed the underlying issue and wants a fresh retry budget. Forcing
+`user_triggered` also matters functionally: triage and reproducer skip
+processing outright when a terminal `ymir_*_errored`/similar label is still
+on the issue and the task isn't user-triggered — exactly the state a
+just-requeued task is in until it gets a chance to run and clear that label
+itself. It also routes the task onto the priority (`_todo`) twin of its
+queue, same as any other maintainer-triggered run.
+
+The entry is located and its replacement task computed here, client-side (a
+plain LRANGE + local JSON parsing) rather than inside Redis: scanning and
+JSON-decoding the whole (cumulative, potentially large) error_list from
+within a Lua script would block the single-threaded server for everyone else
+using it. The actual remove-from-error_list and push-to-target-queue then
+happen as a single atomic Lua script (`EVAL`) so a failure or a racing
+concurrent invocation can't leave the task duplicated (both still in
+error_list and requeued) or double-enqueued. That script treats the entry
+and task as opaque strings it never decodes — Redis's Lua `cjson` can't tell
+an empty JSON array from an empty object, so decoding and re-encoding the
+task would risk silently corrupting typed list fields (e.g.
+`RebaseData.consolidated_issues`). The (potentially large) entry/task strings
+are staged into temporary Redis keys via `valkey-cli -x` (stdin) rather than
+passed as `oc exec`/subprocess command-line arguments, which have far lower
+size limits than a Redis value.
+
+Usage:
+    make requeue-error ERROR_ID=42                       # from openshift/ (preferred)
+    python3 scripts/requeue_error.py 42                  # same, run directly
+    python3 scripts/requeue_error.py 42 --dry-run         # show the plan, don't mutate anything
+"""
+
+import argparse
+import contextlib
+import json
+import secrets
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from error_list import _try_json, fetch_via_oc, to_elements
+
+
+def run_valkey_cli(deployment: str, args: list[str], stdin: bytes | None = None) -> str:
+    # No command-line logging here: `args`/`stdin` can carry a full task/error
+    # record (traceback, metadata), and the caller already prints a safe,
+    # human-level summary of what's about to happen before invoking this.
+    exec_flags = ["-i"] if stdin is not None else []
+    cmd = ["oc", "exec", *exec_flags, f"deployment/{deployment}", "--", "valkey-cli", *args]
+    try:
+        proc = subprocess.run(cmd, input=stdin, capture_output=True, timeout=60)  # noqa: S603
+    except OSError as e:
+        sys.exit(f"error: failed to run `oc` ({e}).")
+    except subprocess.TimeoutExpired:
+        sys.exit("error: `oc exec` timed out. Check cluster connectivity / VPN.")
+    if proc.returncode != 0:
+        stderr = proc.stderr.decode("utf-8", errors="replace")
+        sys.exit(f"error: valkey-cli command failed (exit {proc.returncode}): {stderr.strip()[:300]}")
+    return proc.stdout.decode("utf-8", errors="replace")
+
+
+def find_entry(blob: str, error_id: int) -> tuple[str, dict] | None:
+    for raw in to_elements(blob):
+        obj = _try_json(raw)
+        if isinstance(obj, dict) and obj.get("error_id") == error_id:
+            return raw, obj
+    return None
+
+
+# Removes the pre-staged raw entry from the source list and, only if that
+# removal actually found and deleted something, pushes the pre-staged task
+# onto the target list. Both values are read via GET (opaque strings — never
+# JSON-decoded, see module docstring) from temporary keys that are always
+# cleaned up before returning, win or lose.
+#
+# LREM has to run before LPUSH so only the invocation that actually removes
+# the entry proceeds to push it (that's what makes concurrent requeues of the
+# same error_id race-safe). But Redis doesn't roll back a script's earlier
+# writes just because a later command errors — so if LPUSH then failed (e.g.
+# the target key exists with the wrong type), the entry would be gone from
+# `source` forever without ever reaching `target`. Guard against that with
+# redis.pcall (catches the error instead of aborting the script) and, on
+# failure, push the entry back onto `source` rather than lose it.
+_ATOMIC_REQUEUE_LUA = """
+local raw = redis.call('GET', KEYS[3])
+local task_json = redis.call('GET', KEYS[4])
+local result = 0
+if raw and task_json then
+    local removed = redis.call('LREM', KEYS[1], 1, raw)
+    if removed == 1 then
+        local reply = redis.pcall('LPUSH', KEYS[2], task_json)
+        if type(reply) == 'table' and reply.err then
+            redis.call('LPUSH', KEYS[1], raw)
+            result = -1
+        else
+            result = 1
+        end
+    end
+end
+redis.call('DEL', KEYS[3], KEYS[4])
+return result
+"""
+
+
+# Safety net for staging keys: the Lua script always DELs them on the happy
+# path, but if a SET or the EVAL itself fails, best-effort cleanup (below)
+# might not run either (e.g. the process gets killed) — a bounded TTL is the
+# backstop that guarantees they can't accumulate in Valkey forever.
+_STAGING_KEY_TTL_SECONDS = 300
+
+
+def _stage_value(deployment: str, key: str, value: str) -> None:
+    """Write `value` to `key` via stdin (avoids argv size limits), with a TTL."""
+    run_valkey_cli(deployment, ["-x", "SET", key], stdin=value.encode())
+    run_valkey_cli(deployment, ["EXPIRE", key, str(_STAGING_KEY_TTL_SECONDS)])
+
+
+def _cleanup_staging_keys(deployment: str, *keys: str) -> None:
+    """Best-effort delete — the TTL above is the real safety net, so a failure
+    here (e.g. the same outage that broke the operation we're cleaning up
+    after) is swallowed rather than masking the original error."""
+    with contextlib.suppress(SystemExit):
+        run_valkey_cli(deployment, ["DEL", *keys])
+
+
+def atomic_requeue(
+    deployment: str, source_queue: str, target_queue: str, raw_entry: str, task_json: str, error_id: int
+) -> int:
+    """Atomically move `raw_entry` off `source_queue` and `task_json` onto `target_queue`.
+
+    `raw_entry`/`task_json` are staged into temporary keys via stdin
+    (`valkey-cli -x`) rather than passed as command-line arguments, since
+    either can be arbitrarily large; the Lua script only ever receives small
+    key names. A random suffix keeps concurrent requeues of the same
+    error_id from sharing staging keys, and a bounded TTL plus best-effort
+    cleanup on failure keep a broken SET/EVAL from leaking them permanently.
+
+    Returns:
+       1 — moved successfully
+       0 — `raw_entry` was no longer in `source_queue` (e.g. another
+           invocation already requeued or removed it first); nothing pushed
+      -1 — the push to `target_queue` itself failed (e.g. wrong type on that
+           key); the entry was put back onto `source_queue`, nothing lost
+    """
+    token = secrets.token_hex(8)
+    entry_key = f"tmp:requeue_error:{error_id}:{token}:entry"
+    task_key = f"tmp:requeue_error:{error_id}:{token}:task"
+    try:
+        _stage_value(deployment, entry_key, raw_entry)
+        _stage_value(deployment, task_key, task_json)
+        out = run_valkey_cli(
+            deployment,
+            ["EVAL", _ATOMIC_REQUEUE_LUA, "4", source_queue, target_queue, entry_key, task_key],
+        )
+    except SystemExit:
+        _cleanup_staging_keys(deployment, entry_key, task_key)
+        raise
+    return int(out.strip())
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "error_id", type=int, help="error_id of the entry to requeue (see `make show-error-list`)"
+    )
+    ap.add_argument("--queue", default="error_list", help="Source Valkey list name (default: error_list)")
+    ap.add_argument(
+        "--deployment", default="valkey", help="OpenShift deployment running valkey (default: valkey)"
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="Print the plan without pushing or removing anything"
+    )
+    args = ap.parse_args()
+
+    blob = fetch_via_oc(args.queue, args.deployment)
+    found = find_entry(blob, args.error_id)
+    if found is None:
+        sys.exit(f"error: no entry with error_id={args.error_id} found in {args.queue}")
+    raw, entry = found
+
+    target_queue = entry.get("queue")
+    task = entry.get("task")
+    jira_issue = (entry.get("error") or {}).get("jira_issue", "unknown")
+    if not target_queue or not task:
+        sys.exit(
+            f"error: entry {args.error_id} ({jira_issue}) has no requeueable task "
+            "(legacy entry, or a payload that never parsed into a Task) — nothing to requeue."
+        )
+
+    old_attempts = task.get("attempts", 0)
+    task["attempts"] = 0
+    task["user_triggered"] = True
+    if not target_queue.endswith("_todo"):
+        target_queue = f"{target_queue}_todo"
+    task_json = json.dumps(task)
+
+    print(
+        f"Requeuing error_id={args.error_id} ({jira_issue}) onto '{target_queue}' "
+        f"(attempts {old_attempts} -> 0, user_triggered -> true)"
+    )
+    if args.dry_run:
+        print(f"[dry-run] Would atomically remove from {args.queue} and LPUSH {target_queue}: {task_json}")
+        return
+
+    result = atomic_requeue(args.deployment, args.queue, target_queue, raw, task_json, args.error_id)
+    if result == 0:
+        sys.exit(
+            f"error: entry {args.error_id} was no longer in {args.queue} "
+            "(already requeued or removed by another invocation) — nothing pushed."
+        )
+    if result == -1:
+        sys.exit(
+            f"error: entry {args.error_id} could not be pushed onto {target_queue} "
+            f"(e.g. wrong type at that key) — it was left in {args.queue}, nothing lost."
+        )
+    print(f"✓ Requeued onto {target_queue} and removed from {args.queue}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -88,6 +88,7 @@ from ymir.common.models import (
     BuildInputSchema,
     BuildOutputSchema,
     ErrorData,
+    ErrorListEntry,
     InheritAdaptationInputSchema,
     InheritAdaptationOutputSchema,
     LogInputSchema,
@@ -1636,7 +1637,7 @@ async def main() -> None:
                 + (" (user-triggered via ymir_todo)" if user_triggered else "")
             )
 
-            async def finalize_failure(error, comment_text=None):
+            async def finalize_failure(error: ErrorData, retry_queue: str, task, comment_text=None):
                 logger.error("Moving failed task to error list: %s", backport_data.jira_issue)
                 await tasks.set_jira_labels(
                     jira_issue=backport_data.jira_issue,
@@ -1666,23 +1667,29 @@ async def main() -> None:
                             backport_data.jira_issue,
                             comment_error,
                         )
-                await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
+                error_id = await fix_await(redis.incr(RedisQueues.ERROR_ID_COUNTER.value))
+                entry = ErrorListEntry(error_id=error_id, queue=retry_queue, task=task, error=error)
+                await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, entry.model_dump_json()))
 
             async def retry(
-                task, error, comment_text=None, backport_data=backport_data, user_triggered=user_triggered
+                task,
+                error: ErrorData,
+                comment_text=None,
+                backport_data=backport_data,
+                user_triggered=user_triggered,
             ):
                 task.attempts += 1
+                retry_queue = backport_queue_todo if task.user_triggered else backport_queue
                 if task.attempts < max_retries:
                     logger.warning(
                         f"Task failed (attempt {task.attempts}/{max_retries}), "
                         f"re-queuing for retry: {backport_data.jira_issue}"
                     )
-                    retry_queue = backport_queue_todo if task.user_triggered else backport_queue
                     await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                     return
 
                 logger.error(f"Task failed after {max_retries} attempts: {backport_data.jira_issue}")
-                await finalize_failure(error, comment_text)
+                await finalize_failure(error, retry_queue, task, comment_text)
 
             try:
                 logger.info(f"Starting backport processing for {backport_data.jira_issue}")
@@ -1723,6 +1730,8 @@ async def main() -> None:
                     dry_run=dry_run,
                     user_triggered=user_triggered,
                     redis_conn=redis,
+                    task=task,
+                    queue=backport_queue_todo if user_triggered else backport_queue,
                 )
             except Exception as e:
                 error = "".join(traceback.format_exception(e))
@@ -1730,7 +1739,7 @@ async def main() -> None:
                 reason = e.explain() if isinstance(e, FrameworkError) else e
                 await retry(
                     task,
-                    ErrorData(details=error, jira_issue=backport_data.jira_issue).model_dump_json(),
+                    ErrorData(details=error, jira_issue=backport_data.jira_issue),
                     comment_text=f"Agent failed to perform a backport: {reason}",
                 )
             else:
@@ -1762,9 +1771,10 @@ async def main() -> None:
                     failure = ErrorData(
                         details=getattr(state.backport_result, "error", None) or "Unknown backport error",
                         jira_issue=backport_data.jira_issue,
-                    ).model_dump_json()
+                    )
                     if not _configure_task_retry(task, state):
-                        await finalize_failure(failure)
+                        retry_queue = backport_queue_todo if task.user_triggered else backport_queue
+                        await finalize_failure(failure, retry_queue, task)
                         return
                     await tasks.set_jira_labels(
                         jira_issue=backport_data.jira_issue,

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -56,6 +56,7 @@ from ymir.common.models import (
     BuildOutputSchema,
     ConsolidatedIssue,
     ErrorData,
+    ErrorListEntry,
     LogInputSchema,
     LogOutputSchema,
     RebaseData,
@@ -680,15 +681,19 @@ async def main() -> None:
             )
 
             async def retry(
-                task, error, comment_text=None, rebase_data=rebase_data, user_triggered=user_triggered
+                task,
+                error: ErrorData,
+                comment_text=None,
+                rebase_data=rebase_data,
+                user_triggered=user_triggered,
             ):
                 task.attempts += 1
+                retry_queue = rebase_queue_todo if task.user_triggered else rebase_queue
                 if task.attempts < max_retries:
                     logger.warning(
                         f"Task failed (attempt {task.attempts}/{max_retries}), "
                         f"re-queuing for retry: {rebase_data.jira_issue}"
                     )
-                    retry_queue = rebase_queue_todo if task.user_triggered else rebase_queue
                     await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
                     # Final attempt exhausted — mark errored and stop retrying.
@@ -745,7 +750,9 @@ async def main() -> None:
                                 f"Failed to post final rebase failure comment for "
                                 f"{rebase_data.jira_issue}: {comment_error}"
                             )
-                    await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
+                    error_id = await fix_await(redis.incr(RedisQueues.ERROR_ID_COUNTER.value))
+                    entry = ErrorListEntry(error_id=error_id, queue=retry_queue, task=task, error=error)
+                    await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, entry.model_dump_json()))
 
             try:
                 logger.info(f"Starting rebase processing for {rebase_data.jira_issue}")
@@ -780,6 +787,8 @@ async def main() -> None:
                     dry_run=dry_run,
                     user_triggered=user_triggered,
                     redis_conn=redis,
+                    task=task,
+                    queue=rebase_queue_todo if user_triggered else rebase_queue,
                 )
             except Exception as e:
                 error = "".join(traceback.format_exception(e))
@@ -787,7 +796,7 @@ async def main() -> None:
                 reason = e.explain() if isinstance(e, FrameworkError) else e
                 await retry(
                     task,
-                    ErrorData(details=error, jira_issue=rebase_data.jira_issue).model_dump_json(),
+                    ErrorData(details=error, jira_issue=rebase_data.jira_issue),
                     comment_text=f"Agent failed to perform a rebase: {reason}",
                 )
             else:
@@ -831,7 +840,7 @@ async def main() -> None:
                         ErrorData(
                             details=getattr(state.rebase_result, "error", None) or "Unknown rebase error",
                             jira_issue=rebase_data.jira_issue,
-                        ).model_dump_json(),
+                        ),
                     )
 
         shutdown_event = asyncio.Event()

--- a/ymir/agents/rebuild_agent.py
+++ b/ymir/agents/rebuild_agent.py
@@ -38,6 +38,7 @@ from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
     ConsolidatedIssue,
     ErrorData,
+    ErrorListEntry,
     LogInputSchema,
     LogOutputSchema,
     RebuildData,
@@ -406,19 +407,35 @@ async def main() -> None:
         async def process_task(payload):
             try:
                 task = Task.model_validate_json(payload)
+            except Exception as e:
+                logger.error(f"Failed to parse task payload, skipping: {e}")
+                error_id = await fix_await(redis.incr(RedisQueues.ERROR_ID_COUNTER.value))
+                entry = ErrorListEntry(
+                    error_id=error_id,
+                    error=ErrorData(details=f"Malformed task payload: {e}", jira_issue="unknown"),
+                )
+                await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, entry.model_dump_json()))
+                return
+
+            try:
                 triage_state = task.metadata
                 rebuild_data = RebuildData.model_validate(triage_state["triage_result"]["data"])
                 current_jira_issue.set(rebuild_data.jira_issue)
             except Exception as e:
-                logger.error(f"Failed to parse task payload, skipping: {e}")
-                await fix_await(
-                    redis.lpush(
-                        RedisQueues.ERROR_LIST.value,
-                        ErrorData(
-                            details=f"Malformed task payload: {e}", jira_issue="unknown"
-                        ).model_dump_json(),
-                    )
+                # Task itself parsed fine — keep it (and its queue) on the error
+                # entry so it can be requeued once the metadata/schema issue is fixed.
+                logger.error(f"Failed to parse task metadata, skipping: {e}")
+                error_id = await fix_await(redis.incr(RedisQueues.ERROR_ID_COUNTER.value))
+                entry = ErrorListEntry(
+                    error_id=error_id,
+                    queue=rebuild_queue_todo if task.user_triggered else rebuild_queue,
+                    task=task,
+                    error=ErrorData(
+                        details=f"Malformed task metadata: {e}",
+                        jira_issue=task.metadata.get("jira_issue", "unknown"),
+                    ),
                 )
+                await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, entry.model_dump_json()))
                 return
 
             async with issue_lock(redis, rebuild_data.jira_issue, prefix="lock:rebuild:") as lock_token:
@@ -443,15 +460,19 @@ async def main() -> None:
             )
 
             async def retry(
-                task, error, comment_text=None, rebuild_data=rebuild_data, user_triggered=user_triggered
+                task,
+                error: ErrorData,
+                comment_text=None,
+                rebuild_data=rebuild_data,
+                user_triggered=user_triggered,
             ):
                 task.attempts += 1
+                retry_queue = rebuild_queue_todo if task.user_triggered else rebuild_queue
                 if task.attempts < max_retries:
                     logger.warning(
                         f"Task failed (attempt {task.attempts}/{max_retries}), "
                         f"re-queuing for retry: {rebuild_data.jira_issue}"
                     )
-                    retry_queue = rebuild_queue_todo if task.user_triggered else rebuild_queue
                     await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
                     # Final attempt exhausted — mark errored and stop retrying.
@@ -501,7 +522,9 @@ async def main() -> None:
                                 f"Failed to connect to MCP gateway for final rebuild failure comment: "
                                 f"{gateway_error}"
                             )
-                    await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
+                    error_id = await fix_await(redis.incr(RedisQueues.ERROR_ID_COUNTER.value))
+                    entry = ErrorListEntry(error_id=error_id, queue=retry_queue, task=task, error=error)
+                    await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, entry.model_dump_json()))
 
             try:
                 with span_processor.start_transaction(rebuild_data.jira_issue, workflow="RebuildWorkflow"):
@@ -537,6 +560,8 @@ async def main() -> None:
                     dry_run=dry_run,
                     user_triggered=user_triggered,
                     redis_conn=redis,
+                    task=task,
+                    queue=rebuild_queue_todo if user_triggered else rebuild_queue,
                 )
             except Exception as e:
                 error = "".join(traceback.format_exception(e))
@@ -544,7 +569,7 @@ async def main() -> None:
                 reason = e.explain() if isinstance(e, FrameworkError) else e
                 await retry(
                     task,
-                    ErrorData(details=error, jira_issue=rebuild_data.jira_issue).model_dump_json(),
+                    ErrorData(details=error, jira_issue=rebuild_data.jira_issue),
                     comment_text=f"Agent failed to perform a rebuild: {reason}",
                 )
             else:
@@ -596,7 +621,7 @@ async def main() -> None:
                         ErrorData(
                             details=state.rebuild_error or "Unknown rebuild error",
                             jira_issue=rebuild_data.jira_issue,
-                        ).model_dump_json(),
+                        ),
                     )
 
         shutdown_event = asyncio.Event()

--- a/ymir/agents/reproducer_agent.py
+++ b/ymir/agents/reproducer_agent.py
@@ -43,6 +43,7 @@ from ymir.common.logging_setup import configure_logging, current_jira_issue
 from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
     ErrorData,
+    ErrorListEntry,
     MergeRequestDetails,
     Task,
 )
@@ -1232,12 +1233,17 @@ async def main() -> None:
 
             async def retry(
                 task,
-                error,
+                error: ErrorData,
                 input_data=input_data,
                 user_triggered=user_triggered,
                 delay_seconds: float | None = None,
             ):
                 task.attempts += 1
+                retry_queue = (
+                    RedisQueues.REPRODUCER_QUEUE_TODO.value
+                    if task.user_triggered
+                    else RedisQueues.REPRODUCER_QUEUE.value
+                )
                 if task.attempts < max_retries:
                     logger.warning(
                         f"Task failed (attempt {task.attempts}/{max_retries}), "
@@ -1253,11 +1259,6 @@ async def main() -> None:
                             delay_seconds,
                         )
                     else:
-                        retry_queue = (
-                            RedisQueues.REPRODUCER_QUEUE_TODO.value
-                            if task.user_triggered
-                            else RedisQueues.REPRODUCER_QUEUE.value
-                        )
                         await fix_await(redis.lpush(retry_queue, payload_json))
                 else:
                     logger.error(
@@ -1276,7 +1277,9 @@ async def main() -> None:
                         logger.warning(
                             f"Failed to set error labels on {input_data.jira_issue}: {label_error}"
                         )
-                    await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
+                    error_id = await fix_await(redis.incr(RedisQueues.ERROR_ID_COUNTER.value))
+                    entry = ErrorListEntry(error_id=error_id, queue=retry_queue, task=task, error=error)
+                    await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, entry.model_dump_json()))
 
             if not input_data.package:
                 logger.error(
@@ -1288,7 +1291,7 @@ async def main() -> None:
                     ErrorData(
                         details="Missing package in reproducer task metadata",
                         jira_issue=input_data.jira_issue,
-                    ).model_dump_json(),
+                    ),
                 )
                 return
 
@@ -1334,7 +1337,7 @@ async def main() -> None:
                         ErrorData(
                             details=f"Failed to set in-progress label while blocked: {e}",
                             jira_issue=input_data.jira_issue,
-                        ).model_dump_json(),
+                        ),
                     )
                     await asyncio.sleep(60)
                     return
@@ -1370,7 +1373,7 @@ async def main() -> None:
                     )
                     error_msg = f"Failed to set in-progress label: {e}"
                     error_data = ErrorData(details=error_msg, jira_issue=input_data.jira_issue)
-                    await retry(task, error_data.model_dump_json())
+                    await retry(task, error_data)
                     await asyncio.sleep(60)
                     return
 
@@ -1396,7 +1399,7 @@ async def main() -> None:
                 logger.error(f"Exception during reproducer processing for {input_data.jira_issue}: {error}")
                 await retry(
                     task,
-                    ErrorData(details=error, jira_issue=input_data.jira_issue).model_dump_json(),
+                    ErrorData(details=error, jira_issue=input_data.jira_issue),
                 )
             else:
                 if output.retryable_error:
@@ -1409,7 +1412,7 @@ async def main() -> None:
                         ErrorData(
                             details=output.summary or "Reproducer deferred: retryable infra error",
                             jira_issue=input_data.jira_issue,
-                        ).model_dump_json(),
+                        ),
                         delay_seconds=retry_delay_seconds,
                     )
                 else:

--- a/ymir/agents/tasks.py
+++ b/ymir/agents/tasks.py
@@ -27,6 +27,7 @@ from ymir.common.merge_queue import (  # noqa: F401 — re-exported for agents a
 from ymir.common.models import (
     CachedMRMetadata,
     ErrorData,
+    ErrorListEntry,
     LogOutputSchema,
     MergeRequestDetails,
     OpenMergeRequestResult,
@@ -120,6 +121,8 @@ async def handle_zstream_branch_stale_error(
     dry_run: bool,
     user_triggered: bool,
     redis_conn,
+    task: Task | None = None,
+    queue: str | None = None,
 ) -> None:
     """Terminal handling for a stale z-stream branch: label, comment, ERROR_LIST.
 
@@ -161,12 +164,14 @@ async def handle_zstream_branch_stale_error(
                         )
         except Exception as gateway_error:
             logger.warning(f"Failed to post stale-branch comment: {gateway_error}")
-    await fix_await(
-        redis_conn.lpush(
-            RedisQueues.ERROR_LIST.value,
-            ErrorData(details=str(exc), jira_issue=primary_jira_issue).model_dump_json(),
-        )
+    error_id = await fix_await(redis_conn.incr(RedisQueues.ERROR_ID_COUNTER.value))
+    entry = ErrorListEntry(
+        error_id=error_id,
+        queue=queue,
+        task=task,
+        error=ErrorData(details=str(exc), jira_issue=primary_jira_issue),
     )
+    await fix_await(redis_conn.lpush(RedisQueues.ERROR_LIST.value, entry.model_dump_json()))
 
 
 async def needs_zstream_target_label(dist_git_branch: str, fix_version: str | None) -> bool:

--- a/ymir/agents/tests/unit/test_tasks.py
+++ b/ymir/agents/tests/unit/test_tasks.py
@@ -20,7 +20,7 @@ from ymir.agents.tasks import (
     request_mr_qe_reviews,
 )
 from ymir.common.constants import JiraLabels, RedisQueues
-from ymir.common.models import Task
+from ymir.common.models import ErrorListEntry, Task
 
 
 @asynccontextmanager
@@ -686,6 +686,8 @@ async def test_handle_zstream_branch_stale_error_labels_comments_and_error_list(
     exc = ZStreamBranchStaleError("golang", "rhel-9.8.0", "build-ref-sha", "branch-head-sha")
     redis = AsyncMock()
     redis.lpush = AsyncMock()
+    redis.incr = AsyncMock(return_value=7)
+    task = _make_task(attempts=2)
 
     with (
         patch("ymir.agents.tasks.set_jira_labels", new_callable=AsyncMock) as mock_labels,
@@ -702,6 +704,8 @@ async def test_handle_zstream_branch_stale_error_labels_comments_and_error_list(
             dry_run=False,
             user_triggered=False,
             redis_conn=redis,
+            task=task,
+            queue=RedisQueues.REBUILD_QUEUE_C9S.value,
         )
 
     assert mock_labels.await_count == 2
@@ -714,8 +718,15 @@ async def test_handle_zstream_branch_stale_error_labels_comments_and_error_list(
         is_error=True,
         user_triggered=True,
     )
+    redis.incr.assert_awaited_once_with(RedisQueues.ERROR_ID_COUNTER.value)
     redis.lpush.assert_awaited_once()
     assert redis.lpush.await_args.args[0] == RedisQueues.ERROR_LIST.value
+    entry = ErrorListEntry.model_validate_json(redis.lpush.await_args.args[1])
+    assert entry.error_id == 7
+    assert entry.queue == RedisQueues.REBUILD_QUEUE_C9S.value
+    assert entry.task == task
+    assert entry.error.jira_issue == "RHEL-1"
+    assert entry.error.details == str(exc)
 
 
 @pytest.mark.asyncio
@@ -723,6 +734,7 @@ async def test_handle_zstream_branch_stale_error_skips_comment_on_dry_run():
     exc = ZStreamBranchStaleError("golang", "rhel-9.8.0", "build-ref-sha", "branch-head-sha")
     redis = AsyncMock()
     redis.lpush = AsyncMock()
+    redis.incr = AsyncMock(return_value=1)
 
     with (
         patch("ymir.agents.tasks.set_jira_labels", new_callable=AsyncMock) as mock_labels,

--- a/ymir/agents/triage_agent.py
+++ b/ymir/agents/triage_agent.py
@@ -52,6 +52,7 @@ from ymir.common.models import (
     ClarificationNeededData,
     CVEEligibilityResult,
     ErrorData,
+    ErrorListEntry,
     IssueStatus,
     NotAffectedData,
     OpenEndedAnalysisData,
@@ -1489,22 +1490,22 @@ async def main() -> None:
                     )
                 return
 
-            async def retry(task, error, input=input, user_triggered=user_triggered):
+            async def retry(task, error: ErrorData, input=input, user_triggered=user_triggered):
                 task.attempts += 1
+                # Preserve priority on retries: ymir_todo tasks go back to
+                # the priority queue, normal tasks to the standard one.
+                # Read from `task.user_triggered` (not the closure-captured
+                # variable) so we're robust to anything that might rebind
+                # the local in a future refactor.
+                retry_queue = (
+                    RedisQueues.TRIAGE_QUEUE_TODO.value
+                    if task.user_triggered
+                    else RedisQueues.TRIAGE_QUEUE.value
+                )
                 if task.attempts < max_retries:
                     logger.warning(
                         f"Task failed (attempt {task.attempts}/{max_retries}), "
                         f"re-queuing for retry: {input.issue}"
-                    )
-                    # Preserve priority on retries: ymir_todo tasks go back to
-                    # the priority queue, normal tasks to the standard one.
-                    # Read from `task.user_triggered` (not the closure-captured
-                    # variable) so we're robust to anything that might rebind
-                    # the local in a future refactor.
-                    retry_queue = (
-                        RedisQueues.TRIAGE_QUEUE_TODO.value
-                        if task.user_triggered
-                        else RedisQueues.TRIAGE_QUEUE.value
                     )
                     await fix_await(redis.lpush(retry_queue, task.model_dump_json()))
                 else:
@@ -1521,7 +1522,9 @@ async def main() -> None:
                         )
                     except Exception as label_error:
                         logger.warning(f"Failed to set error labels on {input.issue}: {label_error}")
-                    await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, error))
+                    error_id = await fix_await(redis.incr(RedisQueues.ERROR_ID_COUNTER.value))
+                    entry = ErrorListEntry(error_id=error_id, queue=retry_queue, task=task, error=error)
+                    await fix_await(redis.lpush(RedisQueues.ERROR_LIST.value, entry.model_dump_json()))
 
             # ymir_triage_in_progress is the dedup anchor for the next fetcher
             # sweep. If we cannot write it, we must not proceed — otherwise the
@@ -1574,7 +1577,7 @@ async def main() -> None:
                     f"{input.issue} after retries: {e}; re-queuing to avoid duplicate triage."
                 )
                 error_msg = f"Failed to set in-progress label: {e}"
-                await retry(task, ErrorData(details=error_msg, jira_issue=input.issue).model_dump_json())
+                await retry(task, ErrorData(details=error_msg, jira_issue=input.issue))
                 # Long sleep on purpose: critical-write retries already burned
                 # ~7s, so we're past transient blips. Typical Jira outages last
                 # minutes; cycling faster just spams the API.
@@ -1607,7 +1610,7 @@ async def main() -> None:
                 logger.error(f"Exception during triage processing for {input.issue}: {error}")
                 await retry(
                     task,
-                    ErrorData(details=error, jira_issue=input.issue).model_dump_json(),
+                    ErrorData(details=error, jira_issue=input.issue),
                 )
             else:
                 logger.info(f"Triage resolved as {output.resolution.value} for {input.issue}")
@@ -1758,7 +1761,23 @@ async def main() -> None:
 
                 # Dispatch to downstream queues
                 if output.resolution == Resolution.ERROR:
-                    await retry(task, output.data.model_dump_json())
+                    # `data` is a plain union independent of `resolution` — nothing
+                    # guarantees the model actually returned ErrorData here. Fall
+                    # back to a synthesized ErrorData rather than let a mismatched
+                    # type blow up ErrorListEntry validation inside retry() and
+                    # lose the task without persisting it to error_list.
+                    error_data = (
+                        output.data
+                        if isinstance(output.data, ErrorData)
+                        else ErrorData(
+                            details=(
+                                f"Triage returned resolution=error with unexpected data type "
+                                f"{type(output.data).__name__}: {output.data!r}"
+                            ),
+                            jira_issue=input.issue,
+                        )
+                    )
+                    await retry(task, error_data)
                 elif output.resolution in POSTPONED_RESOLUTIONS:
                     await fix_await(
                         redis.lpush(

--- a/ymir/common/constants.py
+++ b/ymir/common/constants.py
@@ -63,10 +63,14 @@ class RedisQueues(Enum):
     # Redis ZSET (score = unix ready-time) for delayed reproducer retries.
     # Not a BRPOP list — excluded from all_queues().
     REPRODUCER_DELAYED_QUEUE = "reproducer_queue_delayed"
+    # Redis scalar counter (INCR) assigning unique, stable ids to error_list
+    # entries so a specific failure can be requeued by id. Not a list/hash/zset
+    # — excluded from all_queues().
+    ERROR_ID_COUNTER = "error_list_id_counter"
 
     @classmethod
     def all_queues(cls) -> set[str]:
-        """Return all Redis list queue names (excludes Hash/ZSET keys)."""
+        """Return all Redis list queue names (excludes Hash/ZSET/counter keys)."""
         return {
             q.value
             for q in cls
@@ -74,6 +78,7 @@ class RedisQueues(Enum):
             not in (
                 cls.MERGE_CONSOLIDATION_QUEUE,
                 cls.REPRODUCER_DELAYED_QUEUE,
+                cls.ERROR_ID_COUNTER,
             )
         }
 

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -512,6 +512,22 @@ class ErrorData(BaseModel):
     jira_issue: str = Field(description="Jira issue identifier")
 
 
+class ErrorListEntry(BaseModel):
+    """Persisted error_list entry; carries enough context to requeue the original task.
+
+    `queue`/`task` are None when no task was available at push time (e.g. a
+    payload that failed to parse into a Task in the first place).
+    """
+
+    error_id: int = Field(description="Monotonically increasing id, unique within error_list")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    queue: str | None = Field(
+        default=None, description="Redis queue to LPUSH `task` back onto, if requeueable"
+    )
+    task: Task | None = Field(default=None, description="Original task payload, if one was available")
+    error: ErrorData
+
+
 TRIAGE_DISCLAIMER = (
     "\n\n_By following Ymir suggestions, you agree to comply with the "
     "[Guidelines on Use of AI Generated Content"

--- a/ymir/common/tests/unit/test_models.py
+++ b/ymir/common/tests/unit/test_models.py
@@ -7,6 +7,7 @@ from ymir.common.models import (
     ClarificationNeededData,
     ConsolidatedIssue,
     ErrorData,
+    ErrorListEntry,
     NotAffectedData,
     OpenEndedAnalysisData,
     PostponedData,
@@ -15,6 +16,7 @@ from ymir.common.models import (
     ReproducerInputSchema,
     ReproducerOutputSchema,
     Resolution,
+    Task,
     TriageOutputSchema,
 )
 
@@ -776,3 +778,40 @@ def test_postponed_minimal_fields():
     data = PostponedData.model_validate(payload)
     assert data.blocker_references is None
     assert data.pending_issues == ["RHEL-333"]
+
+
+# --- ErrorListEntry tests ---
+
+
+def test_error_list_entry_requeueable_roundtrip():
+    task = Task(metadata={"issue": "RHEL-1"}, attempts=3, user_triggered=True)
+    entry = ErrorListEntry(
+        error_id=42,
+        queue="rebase_queue_c9s",
+        task=task,
+        error=ErrorData(details="boom", jira_issue="RHEL-1"),
+    )
+
+    roundtripped = ErrorListEntry.model_validate_json(entry.model_dump_json())
+
+    assert roundtripped.error_id == 42
+    assert roundtripped.queue == "rebase_queue_c9s"
+    assert roundtripped.task == task
+    assert roundtripped.error.jira_issue == "RHEL-1"
+    assert roundtripped.timestamp == entry.timestamp
+
+
+def test_error_list_entry_defaults_timestamp():
+    entry = ErrorListEntry(error_id=1, error=ErrorData(details="boom", jira_issue="RHEL-1"))
+    assert entry.timestamp is not None
+    assert entry.queue is None
+    assert entry.task is None
+
+
+def test_error_list_entry_non_requeueable_when_task_missing():
+    """Mirrors the malformed-payload push site, which has no Task to attach."""
+    entry = ErrorListEntry(
+        error_id=2, error=ErrorData(details="Malformed task payload", jira_issue="unknown")
+    )
+    assert entry.queue is None
+    assert entry.task is None

--- a/ymir/jira_issue_fetcher/jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/jira_issue_fetcher.py
@@ -39,6 +39,7 @@ from ymir.common.merge_queue import submit_merge_job
 from ymir.common.models import (
     BackportOutputSchema,
     ErrorData,
+    ErrorListEntry,
     OpenEndedAnalysisData,
     RebaseOutputSchema,
     Task,
@@ -530,8 +531,13 @@ class JiraIssueFetcher:
                                             schema = OpenEndedAnalysisData.model_validate_json(item)
                                             issue_key = schema.jira_issue.upper()
                                         case RedisQueues.ERROR_LIST.value:
-                                            schema = ErrorData.model_validate_json(item)
-                                            issue_key = schema.jira_issue.upper()
+                                            try:
+                                                entry = ErrorListEntry.model_validate_json(item)
+                                                issue_key = entry.error.jira_issue.upper()
+                                            except ValueError:
+                                                # Legacy entry pushed before ErrorListEntry existed.
+                                                schema = ErrorData.model_validate_json(item)
+                                                issue_key = schema.jira_issue.upper()
                                         case _:
                                             continue
                                 except ValueError:

--- a/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
+++ b/ymir/jira_issue_fetcher/tests/unit/test_jira_issue_fetcher.py
@@ -307,6 +307,38 @@ async def test_get_existing_issue_keys_includes_reproducer_queues(fetcher, mock_
 
 
 @pytest.mark.asyncio
+async def test_get_existing_issue_keys_handles_error_list_entry_wrapper(fetcher, mock_redis_context):
+    """error_list entries pushed as ErrorListEntry (queue/task/error_id wrapper)
+
+    must still be deduped by jira_issue, same as legacy bare-ErrorData entries.
+    """
+    wrapped_entry_json = json.dumps(
+        {
+            "error_id": 1,
+            "timestamp": "2026-01-01T00:00:00Z",
+            "queue": "rebase_queue_c9s",
+            "task": {"metadata": {"issue": "RHEL-WRAPPED"}, "attempts": 3, "user_triggered": False},
+            "error": {"details": "boom", "jira_issue": "RHEL-WRAPPED"},
+        }
+    )
+
+    mock_redis, _ = mock_redis_context
+    for queue in RedisQueues.all_queues():
+        if queue == RedisQueues.ERROR_LIST.value:
+            mock_redis.should_receive("lrange").with_args(queue, 0, -1).and_return(
+                create_async_mock_return_value([wrapped_entry_json])
+            )
+        else:
+            mock_redis.should_receive("lrange").with_args(queue, 0, -1).and_return(
+                create_async_mock_return_value([])
+            )
+
+    result = await fetcher._get_existing_issue_keys(mock_redis)
+
+    assert "RHEL-WRAPPED" in result
+
+
+@pytest.mark.asyncio
 async def test_push_issues_to_queue(fetcher, mock_redis_context):
     """Test pushing new issues to the triage queue."""
     mock_redis, _ = mock_redis_context


### PR DESCRIPTION
When a task ends up in error_list, additional metadata are now stored alongside the error details and Jira key - unique ID, timestamp and the original trigger, so it is possible to re-enqueue a task to its original queue in case the error has been analyzed and fixed (or it was transient).

`make show-error-list` now shows error IDs and timestamps and `make requeue-error ERROR_ID=N` moves an errored task from error_list to its original queue and resets the retry counter.