### PR TITLE
Allow egress to gitweb.git.savannah.gnu.org

### DIFF
--- a/openshift/tenant-egress.yml
+++ b/openshift/tenant-egress.yml
@@ -120,6 +120,9 @@ spec:
     - type: Allow
       to:
         dnsName: cgit.git.savannah.gnu.org
+    - type: Allow
+      to:
+        dnsName: gitweb.git.savannah.gnu.org
     # sourceware.org — upstream git for glibc, binutils, elfutils, newlib, etc.
     # Resolves to 38.145.34.32 (Cogent); not covered by existing CIDRs.
     - type: Allow


### PR DESCRIPTION
Savannah patch URLs redirect to gitweb.git.savannah.gnu.org. Explicitly allow this hostname to prevent the egress firewall from blocking redirected patch downloads.
