### PR TITLE
sweep: limit history of job runs to 1

### DIFF
--- a/openshift/cronjob-jira-issue-fetcher-todo.yml
+++ b/openshift/cronjob-jira-issue-fetcher-todo.yml
@@ -8,8 +8,8 @@ metadata:
 spec:
   schedule: "*/5 * * * *"  # Every 5 minutes — picks up ymir_todo maintainer requests promptly
   concurrencyPolicy: Forbid  # Prevent overlapping runs
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   suspend: false
   jobTemplate:
     metadata:

--- a/openshift/cronjob-jira-issue-fetcher.yml
+++ b/openshift/cronjob-jira-issue-fetcher.yml
@@ -9,8 +9,8 @@ spec:
   # Every 15 minutes — tops up the triage queue toward QUEUE_DEPTH_THRESHOLD.
   schedule: "*/15 * * * *"
   concurrencyPolicy: Forbid  # Prevent overlapping runs
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   suspend: false
   jobTemplate:
     metadata:

--- a/openshift/cronjob-mr-cleanup.yml
+++ b/openshift/cronjob-mr-cleanup.yml
@@ -8,8 +8,8 @@ metadata:
 spec:
   schedule: "0 4 * * *"  # Daily at 4am UTC
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   suspend: false
   jobTemplate:
     metadata:

--- a/openshift/cronjob-supervisor-collector.yml
+++ b/openshift/cronjob-supervisor-collector.yml
@@ -8,8 +8,8 @@ metadata:
 spec:
   schedule: "*/20 * * * *"  # Every 20 minutes
   concurrencyPolicy: Forbid  # Prevent overlapping runs
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   suspend: false
   jobTemplate:
     metadata:

--- a/openshift/cronjob-sweep-dependency.yml
+++ b/openshift/cronjob-sweep-dependency.yml
@@ -8,8 +8,8 @@ metadata:
 spec:
   schedule: "0 */6 * * *"  # Every 6 hours
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   suspend: false
   jobTemplate:
     metadata:

--- a/openshift/cronjob-sweep-no-patch.yml
+++ b/openshift/cronjob-sweep-no-patch.yml
@@ -8,8 +8,8 @@ metadata:
 spec:
   schedule: "0 4 * * *"  # Daily at 4am UTC
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   suspend: false
   jobTemplate:
     metadata:

--- a/openshift/cronjob-sweep-pr-pending.yml
+++ b/openshift/cronjob-sweep-pr-pending.yml
@@ -8,8 +8,8 @@ metadata:
 spec:
   schedule: "0 */8 * * *"  # Every 8 hours
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   suspend: false
   jobTemplate:
     metadata:

--- a/openshift/cronjob-sweep-y-stream.yml
+++ b/openshift/cronjob-sweep-y-stream.yml
@@ -8,8 +8,8 @@ metadata:
 spec:
   schedule: "0 */12 * * *"  # Every 12 hours
   concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   suspend: false
   jobTemplate:
     metadata:


### PR DESCRIPTION
Our existing limits were a bit too generous.