### PR TITLE
Run Copr builds directly and use LLMs only for diagnosis

### DIFF
--- a/README-agents.md
+++ b/README-agents.md
@@ -41,6 +41,38 @@ fork branch still points at the validated commit before it resumes at MR
 creation. Routing-invariant failures are terminal and are not requeued.
 
 
+### Copr build validation
+
+Backport (including Y-stream inheritance), rebase, MR updates, and MR
+consolidation use a shared `BuildWorkflow`. Its `execute_build` step calls
+`build_package` through the existing MCP gateway; the tool submits and polls
+Copr as before. Shared `run_tool()` validates the response as a `BuildResult`
+using its opt-in `expected_output` schema; other callers' raw results are unchanged.
+Successful validation makes no build-stage LLM calls. Timeouts, tool errors,
+and failures without log artifacts are returned directly to the workflow.
+
+For a failed build with log artifacts, the workflow runs `diagnose_failure`,
+where `BuildFailureAnalyst` explains the existing failure. It cannot invoke
+`build_package` or change the outcome flags; workflow code owns success, timeout,
+and infrastructure-error classification.
+Gateway-based diagnosis requires both `download_artifacts` and
+`extract_log_snippets`. If either is missing, the analyst retrieves and inspects
+the log URLs in its local sandbox instead.
+If diagnosis fails, the original build error is retained. Callers keep their
+existing retry and timeout policies: ordinary backport/rebase/MR-update paths
+may proceed after a timeout, while inheritance and consolidation require success.
+
+Consolidations without Jira footers derive their Copr project name from
+`consolidation-{package}-{branch}`, replacing unsupported characters and limiting
+the name to 100 characters. Changed names include a hash suffix to distinguish
+packages and branches across sanitization or truncation. This fallback is stable
+across retries and is not added to Jira metadata or commit footers.
+
+Standalone rebuild does not have this Copr validation stage. The backport
+incremental repair agent's own edit/build loop is also unchanged. Dry-run mode
+still performs real build validation; it does not turn a build into a success
+without running it.
+
 ## Dry run mode
 
 **Without setting `DRY_RUN=true` env var, agents will make real changes:**

--- a/docs/mr_consolidation_architecture.md
+++ b/docs/mr_consolidation_architecture.md
@@ -168,11 +168,17 @@ If the agent reports failure, the workflow transitions to `handle_failure`.
 
 ### Step 4: `run_build_agent`
 
-A separate build agent verifies the SRPM produced by the consolidation agent actually
-builds in the target build system (Koji/Brew scratch build). If the build fails, the
-workflow loops back to `run_consolidation_agent` with the build error message, up to
-`max_build_attempts` times (default 3). This mirrors the retry pattern used by the
-backport agent.
+The shared `BuildWorkflow` submits the prepared SRPM to Copr deterministically,
+using an LLM only to diagnose failed builds with logs. The Copr project name is
+the first Jira key collected from commit footers, or
+`consolidation-{package}-{branch}` when there are no Jira footers. Unsupported
+characters are replaced and generated names are limited to 100 characters, with
+a hash suffix when changed to distinguish packages and branches. The fallback
+stays stable across retries and does not populate Jira metadata or commit footers.
+
+On failure, the workflow retries the selected consolidation flow with the build
+error, up to `max_build_attempts` times (default 3). Consolidation requires a
+successful build; timeouts do not permit publication.
 
 ### Step 5: `stage_changes`
 

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -22,8 +22,7 @@ from pydantic import BaseModel, Field
 from specfile import Specfile
 
 import ymir.agents.tasks as tasks
-from ymir.agents.build_agent import create_build_agent
-from ymir.agents.build_agent import get_prompt as get_build_prompt
+from ymir.agents.build_agent import run_build
 from ymir.agents.constants import (
     I_AM_YMIR,
     ZSTREAM_TARGET_LABEL,
@@ -85,7 +84,6 @@ from ymir.common.models import (
     BackportInputSchema,
     BackportOutputSchema,
     BuildInputSchema,
-    BuildOutputSchema,
     ErrorData,
     ErrorListEntry,
     InheritAdaptationInputSchema,
@@ -1124,20 +1122,15 @@ async def run_workflow(
                 )
                 return "comment_in_jira"
 
-            fresh_build_agent = create_build_agent(gateway_tools, local_tool_options)
-            response = await fresh_build_agent.run(
-                render_template(
-                    get_build_prompt(),
-                    BuildInputSchema(
-                        srpm_path=state.backport_result.srpm_path,
-                        dist_git_branch=state.dist_git_branch,
-                        jira_issue=state.jira_issue,
-                    ),
+            build_result = await run_build(
+                build_input=BuildInputSchema(
+                    srpm_path=state.backport_result.srpm_path,
+                    dist_git_branch=state.dist_git_branch,
+                    jira_issue=state.jira_issue,
                 ),
-                expected_output=BuildOutputSchema,
-                **get_agent_execution_config(),
+                available_tools=gateway_tools,
+                local_tool_options=local_tool_options,
             )
-            build_result = BuildOutputSchema.model_validate_json(response.last_message.text)
             if build_result.success:
                 state.incremental_fix_attempts = 0
                 return "update_release"
@@ -1171,20 +1164,15 @@ async def run_workflow(
 
         async def run_inherit_build_agent(state):
             """Require a successful Copr validation before publishing inheritance."""
-            fresh_build_agent = create_build_agent(gateway_tools, local_tool_options)
-            response = await fresh_build_agent.run(
-                render_template(
-                    get_build_prompt(),
-                    BuildInputSchema(
-                        srpm_path=state.backport_result.srpm_path,
-                        dist_git_branch=state.dist_git_branch,
-                        jira_issue=state.jira_issue,
-                    ),
+            build_result = await run_build(
+                build_input=BuildInputSchema(
+                    srpm_path=state.backport_result.srpm_path,
+                    dist_git_branch=state.dist_git_branch,
+                    jira_issue=state.jira_issue,
                 ),
-                expected_output=BuildOutputSchema,
-                **get_agent_execution_config(),
+                available_tools=gateway_tools,
+                local_tool_options=local_tool_options,
             )
-            build_result = BuildOutputSchema.model_validate_json(response.last_message.text)
             if build_result.success:
                 return "stage_changes"
 

--- a/ymir/agents/build_agent.py
+++ b/ymir/agents/build_agent.py
@@ -1,32 +1,146 @@
+import asyncio
+import logging
 from typing import Any
+from urllib.parse import urlsplit
 
 from beeai_framework.agents.requirement.requirements.conditional import (
     ConditionalRequirement,
 )
 from beeai_framework.memory import UnconstrainedMemory
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
-from beeai_framework.tools import Tool
+from beeai_framework.tools import Tool, ToolError
 from beeai_framework.tools.think import ThinkTool
+from beeai_framework.utils.cancellation import AbortController
+from beeai_framework.workflows import Workflow
+from pydantic import BaseModel
 
 from ymir.agents.reasoning_agent import ReasoningAgent
 from ymir.agents.utils import (
+    get_agent_execution_config,
     get_chat_model,
     get_tool_call_checker_config,
     is_reasoning_enabled,
     render_template,
+    run_tool,
 )
 from ymir.common.logging_setup import get_trajectory_writeable
-from ymir.common.models import BuildInstructionsInput
+from ymir.common.models import (
+    BuildFailureAnalysisInput,
+    BuildFailureAnalysisOutput,
+    BuildInputSchema,
+    BuildInstructionsInput,
+    BuildOutputSchema,
+    BuildResult,
+)
 from ymir.tools.unprivileged.commands import RunShellCommandTool
 from ymir.tools.unprivileged.filesystem import GetCWDTool
-from ymir.tools.unprivileged.text import (
-    CreateTool,
-    InsertAfterSubstringTool,
-    InsertTool,
-    SearchTextTool,
-    StrReplaceTool,
-    ViewTool,
-)
+from ymir.tools.unprivileged.text import SearchTextTool, ViewTool
+
+logger = logging.getLogger(__name__)
+
+
+class BuildState(BaseModel):
+    build_input: BuildInputSchema
+    build_result: BuildResult | None = None
+    output: BuildOutputSchema | None = None
+
+
+async def run_build(
+    *,
+    build_input: BuildInputSchema,
+    available_tools: list[Tool],
+    local_tool_options: dict[str, Any],
+) -> BuildOutputSchema:
+    """Submit one build through the gateway, diagnosing only failures with logs.
+
+    Copr submission retries and polling remain inside the existing tool. In
+    particular, neither diagnosis nor a failed diagnosis resubmits the build.
+    Callers retain ownership of timeout policy and workflow-level retries.
+    A missing advertised build tool is reported as an infrastructure failure.
+    """
+    workflow = Workflow(BuildState, name="BuildWorkflow")
+
+    async def execute_build(state: BuildState) -> str:
+        try:
+            result = await run_tool(
+                "build_package",
+                available_tools=available_tools,
+                expected_output=BuildResult,
+                **state.build_input.model_dump(mode="json"),
+            )
+        except ToolError as e:
+            logger.warning("Copr build tool failed for %s: %s", state.build_input.jira_issue, e)
+            state.output = BuildOutputSchema(success=False, error=str(e), is_infra_error=True)
+            return Workflow.END
+
+        state.build_result = result
+        logger.info(
+            "Copr build result for %s: success=%s, is_timeout=%s",
+            state.build_input.jira_issue,
+            result.success,
+            result.is_timeout,
+        )
+        if result.success:
+            state.output = BuildOutputSchema(success=True, error=None)
+            return Workflow.END
+
+        state.output = BuildOutputSchema(
+            success=False,
+            error=result.error_message or "Copr build failed without an error message",
+            is_timeout=result.is_timeout,
+        )
+        if result.is_timeout:
+            return Workflow.END
+
+        if not any(urlsplit(url).path.endswith(".log.gz") for url in result.artifacts_urls or []):
+            return Workflow.END
+
+        return "diagnose_failure"
+
+    async def diagnose_failure(state: BuildState) -> str:
+        if state.build_result is None or state.output is None:
+            raise RuntimeError("Build failure diagnosis requires an existing build result")
+        try:
+            analyst = create_build_failure_agent(available_tools, local_tool_options)
+            response = await analyst.run(
+                render_template(
+                    get_prompt(),
+                    BuildFailureAnalysisInput(
+                        **state.build_input.model_dump(), build_result=state.build_result
+                    ),
+                ),
+                expected_output=BuildFailureAnalysisOutput,
+                **get_agent_execution_config(),
+            )
+            diagnosis = BuildFailureAnalysisOutput.model_validate_json(response.last_message.text)
+            state.output.error = diagnosis.error
+        except asyncio.CancelledError:
+            # BeeAI AbortError also inherits Exception; preserve worker cancellation.
+            raise
+        except Exception:
+            # A model outage or invalid answer cannot erase a known build failure.
+            logger.exception(
+                "Could not analyze failed build for %s; retaining tool error", state.build_input.jira_issue
+            )
+        return Workflow.END
+
+    workflow.add_step("execute_build", execute_build)
+    workflow.add_step("diagnose_failure", diagnose_failure)
+    controller = AbortController()
+    task = asyncio.ensure_future(
+        workflow.run(BuildState(build_input=build_input), options={"signal": controller.signal})
+    )
+    try:
+        response = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # BeeAI runs steps in a child task. Abort and drain that task before
+        # returning cancellation so diagnosis cannot outlive its caller.
+        controller.abort("Build workflow caller cancelled")
+        await asyncio.gather(task, return_exceptions=True)
+        raise
+    if response.state.output is None:
+        raise RuntimeError("Build workflow finished without a result")
+    return response.state.output
 
 
 def get_instructions(*, has_extract_log_snippets: bool = False) -> str:
@@ -40,12 +154,12 @@ def get_prompt() -> str:
     return "build/prompt.j2"
 
 
-def create_build_agent(mcp_tools: list[Tool], local_tool_options: dict[str, Any]) -> ReasoningAgent:
-    filtered_mcp_tools = [
-        t for t in mcp_tools if t.name in ["build_package", "download_artifacts", "extract_log_snippets"]
-    ]
-    available_tool_names = {t.name for t in filtered_mcp_tools}
-    has_extract_log_snippets = "extract_log_snippets" in available_tool_names
+def create_build_failure_agent(mcp_tools: list[Tool], local_tool_options: dict[str, Any]) -> ReasoningAgent:
+    gateway_log_tools = {"download_artifacts", "extract_log_snippets"}
+    has_gateway_log_tools = gateway_log_tools <= {t.name for t in mcp_tools}
+    filtered_mcp_tools = (
+        [t for t in mcp_tools if t.name in gateway_log_tools] if has_gateway_log_tools else []
+    )
 
     requirements = [
         ConditionalRequirement(
@@ -55,34 +169,38 @@ def create_build_agent(mcp_tools: list[Tool], local_tool_options: dict[str, Any]
             consecutive_allowed=False,
             only_success_invocations=False,
         ),
-        ConditionalRequirement("build_package", min_invocations=1),
-        ConditionalRequirement("download_artifacts", only_after=["build_package"]),
     ]
-    if "extract_log_snippets" in available_tool_names:
+    if has_gateway_log_tools:
         requirements.append(
             ConditionalRequirement("extract_log_snippets", only_after=["download_artifacts"]),
         )
 
+    # Gateway-downloaded logs are not in the agent sandbox. Use that path only
+    # when both tools are available; otherwise retrieve logs locally from URLs.
+    local_tools = (
+        []
+        if has_gateway_log_tools
+        else [
+            RunShellCommandTool(options=local_tool_options),
+            ViewTool(options=local_tool_options),
+            SearchTextTool(options=local_tool_options),
+            GetCWDTool(options=local_tool_options),
+        ]
+    )
+
     return ReasoningAgent(
-        name="BuildAgent",
+        name="BuildFailureAnalyst",
         llm=get_chat_model(),
         unconstrained=is_reasoning_enabled(),
         tool_call_checker=get_tool_call_checker_config(),
         tools=[
             ThinkTool(),
-            RunShellCommandTool(options=local_tool_options),
-            CreateTool(options=local_tool_options),
-            ViewTool(options=local_tool_options),
-            InsertTool(options=local_tool_options),
-            InsertAfterSubstringTool(options=local_tool_options),
-            StrReplaceTool(options=local_tool_options),
-            SearchTextTool(options=local_tool_options),
-            GetCWDTool(options=local_tool_options),
+            *local_tools,
             *filtered_mcp_tools,
         ],
         memory=UnconstrainedMemory(),
         requirements=requirements,
         middlewares=[GlobalTrajectoryMiddleware(pretty=True, target=get_trajectory_writeable())],
         role="Red Hat Enterprise Linux developer",
-        instructions=get_instructions(has_extract_log_snippets=has_extract_log_snippets),
+        instructions=get_instructions(has_extract_log_snippets=has_gateway_log_tools),
     )

--- a/ymir/agents/merge_request_agent.py
+++ b/ymir/agents/merge_request_agent.py
@@ -20,8 +20,7 @@ from beeai_framework.workflows import Workflow
 from pydantic import BaseModel, Field
 
 import ymir.agents.tasks as tasks
-from ymir.agents.build_agent import create_build_agent
-from ymir.agents.build_agent import get_prompt as get_build_prompt
+from ymir.agents.build_agent import run_build
 from ymir.agents.constants import I_AM_YMIR
 from ymir.agents.observability import setup_observability
 from ymir.agents.reasoning_agent import ReasoningAgent
@@ -36,7 +35,6 @@ from ymir.agents.utils import (
 from ymir.common.logging_setup import configure_logging, get_trajectory_writeable
 from ymir.common.models import (
     BuildInputSchema,
-    BuildOutputSchema,
     MergeRequestInputSchema,
     MergeRequestOutputSchema,
 )
@@ -242,20 +240,15 @@ async def main() -> None:
                 return "comment_in_mr"
 
             async def run_build_agent(state):
-                build_agent = create_build_agent(gateway_tools, local_tool_options)
-                response = await build_agent.run(
-                    render_template(
-                        get_build_prompt(),
-                        BuildInputSchema(
-                            srpm_path=state.mr_update_result.srpm_path,
-                            dist_git_branch=state.dist_git_branch,
-                            jira_issue=state.jira_issue,
-                        ),
+                build_result = await run_build(
+                    build_input=BuildInputSchema(
+                        srpm_path=state.mr_update_result.srpm_path,
+                        dist_git_branch=state.dist_git_branch,
+                        jira_issue=state.jira_issue,
                     ),
-                    expected_output=BuildOutputSchema,
-                    **get_agent_execution_config(),
+                    available_tools=gateway_tools,
+                    local_tool_options=local_tool_options,
                 )
-                build_result = BuildOutputSchema.model_validate_json(response.last_message.text)
                 if build_result.success:
                     return "stage_changes"
                 if build_result.is_timeout:

--- a/ymir/agents/mr_consolidation_agent.py
+++ b/ymir/agents/mr_consolidation_agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -19,8 +20,7 @@ from pydantic import Field
 from specfile import Specfile
 
 import ymir.agents.tasks as tasks
-from ymir.agents.build_agent import create_build_agent
-from ymir.agents.build_agent import get_prompt as get_build_prompt
+from ymir.agents.build_agent import run_build
 from ymir.agents.constants import (
     I_AM_YMIR,
     ZSTREAM_TARGET_LABEL,
@@ -54,7 +54,6 @@ from ymir.common.logging_setup import configure_logging, current_jira_issue, get
 from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
     BuildInputSchema,
-    BuildOutputSchema,
     LogInputSchema,
     LogOutputSchema,
     MergeConsolidationJob,
@@ -88,6 +87,17 @@ logger = logging.getLogger(__file__)
 redis_logger = logging.getLogger("agent.redis")
 
 _NFS_CACHE_WAIT = 60
+_COPR_PROJECT_NAME_MAX_LENGTH = 100
+
+
+def _build_project_name(package: str, branch: str) -> str:
+    """Generate a stable Copr name, preserving distinct sanitized or truncated inputs."""
+    name = f"consolidation-{package}-{branch}"
+    sanitized = re.sub(r"[^A-Za-z0-9_.-]+", "-", name)
+    if sanitized == name and len(name) <= _COPR_PROJECT_NAME_MAX_LENGTH:
+        return name
+    suffix = "-" + hashlib.sha256(name.encode()).hexdigest()[:12]
+    return sanitized[: _COPR_PROJECT_NAME_MAX_LENGTH - len(suffix)].rstrip("-") + suffix
 
 
 async def create_consolidation_agent(
@@ -771,16 +781,6 @@ async def run_workflow(
                 logger.warning("No SRPM generated, skipping build verification")
                 return "stage_changes"
 
-            build_agent = create_build_agent(gateway_tools, local_tool_options)
-            build_prompt = render_template(
-                get_build_prompt(),
-                BuildInputSchema(
-                    srpm_path=state.consolidation_result.srpm_path,
-                    dist_git_branch=dist_git_branch,
-                    jira_issue=state.jira_issue,
-                ),
-            )
-
             def _retry_step_for_build(state):
                 """Determine which flow to retry on build failure."""
                 has_rebuild_other = any(t == "rebuild" for t in state.mr_types.values())
@@ -791,12 +791,17 @@ async def run_workflow(
                 return "run_consolidation_agent"
 
             try:
-                build_result = await build_agent.run(
-                    build_prompt,
-                    expected_output=BuildOutputSchema,
-                    **get_agent_execution_config(),
+                build_output = await run_build(
+                    build_input=BuildInputSchema(
+                        srpm_path=state.consolidation_result.srpm_path,
+                        dist_git_branch=dist_git_branch,
+                        # Copr requires a project name even without Jira footers.
+                        # Keep the fallback out of the workflow's Jira metadata.
+                        jira_issue=state.jira_issue or _build_project_name(package, dist_git_branch),
+                    ),
+                    available_tools=gateway_tools,
+                    local_tool_options=local_tool_options,
                 )
-                build_output = BuildOutputSchema.model_validate_json(build_result.last_message.text)
                 if not build_output.success:
                     state.build_error = build_output.error
                     state.attempts_remaining -= 1

--- a/ymir/agents/prompts/build/instructions.j2
+++ b/ymir/agents/prompts/build/instructions.j2
@@ -1,32 +1,34 @@
-You are an expert on building packages in RHEL ecosystem and analyzing build failures.
+You are an expert on analyzing package build failures in the RHEL ecosystem.
 
-Build a package using the `build_package` tool. If the build succeeded, your work is done.
-If the build failed, download all *.log.gz files returned in `artifacts_urls`, if any,
-using the `download_artifacts` tool to a temporary directory. If there are no log files,
-just return the error message. Otherwise,
+The workflow has already submitted the build and confirmed that it failed.
+Do not submit or retry a build, regenerate an SRPM, or change package sources or specs.
+Your only task is to explain this existing failure using the supplied result and logs.
+
 {% if has_extract_log_snippets %}
-use the `extract_log_snippets` tool with `log_path` pointing to the location of
+Download the *.log.gz files from the supplied `artifacts_urls` using the
+`download_artifacts` tool to a temporary directory.
+Use the `extract_log_snippets` tool with `log_path` pointing to the location of
 `builder-live.log` and try to identify the build failure. The downloaded files are only
 accessible through `extract_log_snippets` — never use `view`, `search_text`, or shell
 commands to read them, even after a successful `extract_log_snippets` call; those tools
 run in a different sandbox and will always fail with "No such file or directory" on
 these paths, no matter how many times you retry.
 {% else %}
-start with `builder-live.log` and try to identify the build failure. `download_artifacts`
-saves files to a location that `view`, `search_text`, and shell commands cannot reach, so
-you cannot read them directly this way — work from `artifacts_urls` instead.
+Retrieve the *.log.gz files directly from the supplied `artifacts_urls` into a
+temporary directory in your local sandbox using shell commands (for example,
+curl or wget), then decompress and inspect them with the local tools.
+Start with `builder-live.log` and try to identify the build failure.
 {% endif %}
+If there are no accessible logs, return the supplied error message and explain that
+a detailed diagnosis was unavailable.
 If the failure is not found, try the same with `root.log`. Summarize the findings
-and return them as `error`. Set `is_timeout` to the value of the `is_timeout` field
-from the `build_package` tool output. If the build_package tool itself returned an error (e.g. Copr API error,
-project setup failure, or build submission failure) rather than a build failure with logs,
-set `is_infra_error` to `true`.
+and return them as `error`. Build status and retry decisions belong to the workflow,
+not to this analysis.
 
 General instructions:
 
-- Always perform the build, even if you have already built a SRPM with the same name.
-- Your job is to build a package and analyze build failures if necessary, nothing else.
-  Do not run any commands except for those needed to examine the downloaded log files.
+- Only diagnose the supplied failure. Do not fix it or start another build.
+- Do not run any commands except for those needed to retrieve or examine build logs.
 - There is a firewall in place that may block some outgoing network requests
   (e.g. curl, wget, git clone to external hosts). If a shell command fails
   due to a blocked connection and the data it would provide is essential

--- a/ymir/agents/prompts/build/prompt.j2
+++ b/ymir/agents/prompts/build/prompt.j2
@@ -1,1 +1,5 @@
-Build the SRPM {{ srpm_path }}, use {{ dist_git_branch }} dist-git branch and {{ jira_issue }} Jira issue.
+Analyze the existing failed build of SRPM {{ srpm_path }} for dist-git branch
+{{ dist_git_branch }} and Jira issue {{ jira_issue }}. Do not submit another build.
+
+Result from the build tool (including artifact URLs):
+{{ build_result | tojson(indent=2) }}

--- a/ymir/agents/rebase_agent.py
+++ b/ymir/agents/rebase_agent.py
@@ -18,8 +18,7 @@ from beeai_framework.workflows import Workflow
 from pydantic import Field
 
 import ymir.agents.tasks as tasks
-from ymir.agents.build_agent import create_build_agent
-from ymir.agents.build_agent import get_prompt as get_build_prompt
+from ymir.agents.build_agent import run_build
 from ymir.agents.constants import (
     I_AM_YMIR,
     ZSTREAM_TARGET_LABEL,
@@ -52,7 +51,6 @@ from ymir.common.logging_setup import configure_logging, current_jira_issue, get
 from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
     BuildInputSchema,
-    BuildOutputSchema,
     ConsolidatedIssue,
     ErrorData,
     ErrorListEntry,
@@ -397,20 +395,15 @@ async def main() -> None:
                 return "comment_in_jira"
 
             async def run_build_agent(state):
-                build_agent = create_build_agent(gateway_tools, local_tool_options)
-                response = await build_agent.run(
-                    render_template(
-                        get_build_prompt(),
-                        BuildInputSchema(
-                            srpm_path=state.rebase_result.srpm_path,
-                            dist_git_branch=state.dist_git_branch,
-                            jira_issue=state.jira_issue,
-                        ),
+                build_result = await run_build(
+                    build_input=BuildInputSchema(
+                        srpm_path=state.rebase_result.srpm_path,
+                        dist_git_branch=state.dist_git_branch,
+                        jira_issue=state.jira_issue,
                     ),
-                    expected_output=BuildOutputSchema,
-                    **get_agent_execution_config(),
+                    available_tools=gateway_tools,
+                    local_tool_options=local_tool_options,
                 )
-                build_result = BuildOutputSchema.model_validate_json(response.last_message.text)
                 if build_result.success:
                     return "update_release"
                 if build_result.is_timeout:

--- a/ymir/agents/tests/unit/test_build_agent.py
+++ b/ymir/agents/tests/unit/test_build_agent.py
@@ -1,0 +1,439 @@
+"""Build submission is deterministic; only failed-build diagnosis needs an LLM."""
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from beeai_framework.emitter import Emitter
+from beeai_framework.errors import AbortError, FrameworkError
+from beeai_framework.tools import ToolError
+from beeai_framework.tools.mcp import MCPTool
+from mcp.types import CallToolResult, TextContent
+from mcp.types import Tool as MCPToolInfo
+from pydantic import ValidationError
+
+from ymir.agents import build_agent
+from ymir.common.models import BuildFailureAnalysisOutput, BuildInputSchema, BuildResult
+
+
+@pytest.fixture
+def build_input():
+    return BuildInputSchema(
+        srpm_path=Path("/git-repos/package/package-1-1.src.rpm"),
+        dist_git_branch="c10s",
+        jira_issue="RHEL-123",
+    )
+
+
+@pytest.fixture
+def build_mocks(monkeypatch):
+    tool = SimpleNamespace(name="build_package")
+    submit = AsyncMock()
+    analyst = SimpleNamespace(
+        run=AsyncMock(
+            return_value=SimpleNamespace(
+                last_message=SimpleNamespace(text='{"error": "Missing prerequisite function foo"}'),
+            ),
+        ),
+    )
+    factory = MagicMock(return_value=analyst)
+    monkeypatch.setattr(build_agent, "run_tool", submit)
+    monkeypatch.setattr(build_agent, "create_build_failure_agent", factory)
+    # Successful builds must not even require model configuration.
+    monkeypatch.delenv("CHAT_MODEL", raising=False)
+    return SimpleNamespace(tool=tool, submit=submit, analyst=analyst, factory=factory)
+
+
+async def _run(build_input, tools):
+    return await build_agent.run_build(
+        build_input=build_input,
+        available_tools=tools,
+        local_tool_options={"working_directory": Path("/git-repos/package")},
+    )
+
+
+@pytest.mark.asyncio
+async def test_success_submits_once_without_llm(build_input, build_mocks):
+    build_mocks.submit.return_value = BuildResult(success=True, artifacts_urls=["https://copr/log.gz"])
+
+    result = await _run(build_input, [build_mocks.tool])
+
+    assert result.model_dump() == {
+        "success": True,
+        "error": None,
+        "is_timeout": False,
+        "is_infra_error": False,
+    }
+    build_mocks.submit.assert_awaited_once_with(
+        "build_package",
+        available_tools=[build_mocks.tool],
+        expected_output=BuildResult,
+        srpm_path=str(build_input.srpm_path),
+        dist_git_branch="c10s",
+        jira_issue="RHEL-123",
+    )
+    build_mocks.factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_timeout_preserved_without_llm_even_with_logs(build_input, build_mocks):
+    build_mocks.submit.return_value = BuildResult(
+        success=False,
+        is_timeout=True,
+        error_message="Reached timeout for build 123",
+        artifacts_urls=["https://copr/123/builder-live.log.gz"],
+    )
+
+    result = await _run(build_input, [build_mocks.tool])
+
+    assert not result.success
+    assert result.is_timeout
+    assert not result.is_infra_error
+    assert result.error == "Reached timeout for build 123"
+    build_mocks.factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tool_error_is_infrastructure_failure_without_resubmitting(build_input, build_mocks):
+    build_mocks.submit.side_effect = ToolError("Failed to submit Copr build: HTTP 503")
+
+    result = await _run(build_input, [build_mocks.tool])
+
+    assert not result.success
+    assert result.is_infra_error
+    assert not result.is_timeout
+    assert "HTTP 503" in result.error
+    build_mocks.submit.assert_awaited_once()
+    build_mocks.factory.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "tool_names", [[], ["download_artifacts", "extract_log_snippets"]], ids=["empty", "unrelated"]
+)
+@pytest.mark.asyncio
+async def test_missing_build_tool_is_infrastructure_failure(build_input, monkeypatch, tool_names):
+    session = AsyncMock()
+    tools = [MCPTool(session, MCPToolInfo(name=name, inputSchema={})) for name in tool_names]
+    factory = MagicMock()
+    monkeypatch.setattr(build_agent, "create_build_failure_agent", factory)
+    monkeypatch.delenv("CHAT_MODEL", raising=False)
+
+    # Exercise the real lookup rather than mocking run_tool.
+    output = await _run(build_input, tools)
+
+    assert not output.success
+    assert output.is_infra_error
+    assert not output.is_timeout
+    assert "build_package" in output.error
+    session.call_tool.assert_not_awaited()
+    factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_submission_error_propagates(build_input, build_mocks):
+    error = RuntimeError("Unexpected submission error")
+    build_mocks.submit.side_effect = error
+
+    with pytest.raises(FrameworkError) as exc:
+        await _run(build_input, [build_mocks.tool])
+
+    assert exc.value.__cause__ is error
+    build_mocks.submit.assert_awaited_once()
+    build_mocks.factory.assert_not_called()
+
+
+@pytest.mark.parametrize("artifacts", [None, [], ["https://copr/package.rpm"]])
+@pytest.mark.asyncio
+async def test_failure_without_logs_returns_original_error(build_input, build_mocks, artifacts):
+    build_mocks.submit.return_value = BuildResult(
+        success=False,
+        error_message="Build 123 finished with state: failed",
+        artifacts_urls=artifacts,
+    )
+
+    result = await _run(build_input, [build_mocks.tool])
+
+    assert not result.success
+    assert not result.is_infra_error
+    assert result.error == "Build 123 finished with state: failed"
+    build_mocks.factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_failure_analysis_receives_existing_result_and_cannot_resubmit(build_input, build_mocks):
+    log_url = "https://copr/123/builder-live.log.gz?download=1"
+    build_mocks.submit.return_value = BuildResult(
+        success=False,
+        error_message="Build 123 finished with state: failed",
+        artifacts_urls=[log_url],
+    )
+
+    result = await _run(build_input, [build_mocks.tool])
+
+    assert not result.success
+    assert not result.is_timeout
+    assert not result.is_infra_error
+    assert result.error == "Missing prerequisite function foo"
+    build_mocks.submit.assert_awaited_once()
+    build_mocks.factory.assert_called_once()
+    build_mocks.analyst.run.assert_awaited_once()
+    args, kwargs = build_mocks.analyst.run.await_args
+    assert "Build 123 finished with state: failed" in args[0]
+    assert log_url in args[0]
+    assert str(build_input.srpm_path) in args[0]
+    assert kwargs["expected_output"] is BuildFailureAnalysisOutput
+    assert set(BuildFailureAnalysisOutput.model_fields) == {"error"}
+
+
+@pytest.mark.parametrize("analysis_error", [RuntimeError("Model unavailable"), None])
+@pytest.mark.asyncio
+async def test_diagnosis_failure_retains_build_failure(build_input, build_mocks, analysis_error):
+    build_mocks.submit.return_value = BuildResult(
+        success=False,
+        error_message="Build 123 failed",
+        artifacts_urls=["https://copr/123/root.log.gz"],
+    )
+    if analysis_error:
+        build_mocks.analyst.run.side_effect = analysis_error
+    else:
+        build_mocks.analyst.run.return_value.last_message.text = "not json"
+
+    result = await _run(build_input, [build_mocks.tool])
+
+    assert not result.success
+    assert not result.is_infra_error
+    assert "Build 123 failed" in result.error
+    build_mocks.submit.assert_awaited_once()
+
+
+@pytest.mark.parametrize("raw", ["not json", {}, {"success": "unknown"}, []])
+@pytest.mark.asyncio
+async def test_malformed_tool_result_is_not_reported_as_success(build_input, monkeypatch, raw):
+    session = AsyncMock()
+    session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text=raw if isinstance(raw, str) else json.dumps(raw))],
+    )
+    tool = MCPTool(
+        session, MCPToolInfo(name="build_package", inputSchema=BuildInputSchema.model_json_schema())
+    )
+    factory = MagicMock()
+    monkeypatch.setattr(build_agent, "create_build_failure_agent", factory)
+
+    with pytest.raises(FrameworkError) as exc:
+        await _run(build_input, [tool])
+
+    assert isinstance(exc.value.__cause__, ValidationError)
+    factory.assert_not_called()
+    session.call_tool.assert_awaited_once()
+
+
+@pytest.mark.parametrize("during_analysis", [False, True])
+@pytest.mark.parametrize("cancellation", [asyncio.CancelledError, AbortError])
+@pytest.mark.asyncio
+async def test_cancellation_propagates(build_input, build_mocks, during_analysis, cancellation):
+    if during_analysis:
+        build_mocks.submit.return_value = BuildResult(
+            success=False,
+            artifacts_urls=["https://copr/123/root.log.gz"],
+        )
+        build_mocks.analyst.run.side_effect = cancellation
+    else:
+        build_mocks.submit.side_effect = cancellation
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run(build_input, [build_mocks.tool])
+
+    build_mocks.submit.assert_awaited_once()
+
+
+@pytest.mark.parametrize("during_analysis", [False, True])
+@pytest.mark.asyncio
+async def test_cancelling_caller_stops_active_workflow_step(build_input, build_mocks, during_analysis):
+    started = asyncio.Event()
+    stopped = asyncio.Event()
+    active_step = None
+
+    async def blocked_step(*args, **kwargs):
+        nonlocal active_step
+        active_step = asyncio.current_task()
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            stopped.set()
+
+    if during_analysis:
+        build_mocks.submit.return_value = BuildResult(
+            success=False, artifacts_urls=["https://copr/123/root.log.gz"]
+        )
+        build_mocks.analyst.run.side_effect = blocked_step
+    else:
+        build_mocks.submit.side_effect = blocked_step
+
+    task = asyncio.create_task(_run(build_input, [build_mocks.tool]))
+    try:
+        await asyncio.wait_for(started.wait(), timeout=2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=2)
+        await asyncio.wait_for(stopped.wait(), timeout=2)
+        build_mocks.submit.assert_awaited_once()
+        assert build_mocks.factory.call_count == during_analysis
+    finally:
+        task.cancel()
+        if active_step is not None:
+            active_step.cancel()
+            await asyncio.gather(active_step, return_exceptions=True)
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.parametrize("structured", [False, True])
+@pytest.mark.parametrize(
+    "success,is_timeout,error_message",
+    [(True, False, None), (False, True, "Build timed out"), (False, False, "Build failed")],
+)
+@pytest.mark.asyncio
+async def test_actual_gateway_result_decoding(
+    build_input, monkeypatch, structured, success, is_timeout, error_message
+):
+    result = {
+        "success": success,
+        "is_timeout": is_timeout,
+        "error_message": error_message,
+        "artifacts_urls": [],
+    }
+    session = AsyncMock()
+    session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text=json.dumps(result))],
+        structuredContent={"result": result} if structured else None,
+    )
+    tool = MCPTool(
+        session,
+        MCPToolInfo(name="build_package", inputSchema=BuildInputSchema.model_json_schema()),
+    )
+    factory = MagicMock()
+    monkeypatch.setattr(build_agent, "create_build_failure_agent", factory)
+
+    output = await _run(build_input, [tool])
+
+    assert output.success == success
+    assert output.is_timeout == is_timeout
+    assert output.error == error_message
+    assert not output.is_infra_error
+    session.call_tool.assert_awaited_once()
+    assert session.call_tool.await_args.kwargs["arguments"] == build_input.model_dump(mode="json")
+    factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_actual_gateway_error_is_infrastructure_failure(build_input, monkeypatch):
+    session = AsyncMock()
+    session.call_tool.return_value = CallToolResult(
+        isError=True,
+        content=[TextContent(type="text", text="Failed to submit Copr build: HTTP 503")],
+    )
+    tool = MCPTool(
+        session,
+        MCPToolInfo(name="build_package", inputSchema=BuildInputSchema.model_json_schema()),
+    )
+    factory = MagicMock()
+    monkeypatch.setattr(build_agent, "create_build_failure_agent", factory)
+
+    output = await _run(build_input, [tool])
+
+    assert not output.success
+    assert output.is_infra_error
+    assert not output.is_timeout
+    assert "HTTP 503" in output.error
+    session.call_tool.assert_awaited_once()
+    factory.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "build_result,steps",
+    [
+        ({"success": True}, ["execute_build"]),
+        ({"success": False, "is_timeout": True}, ["execute_build"]),
+        ({"success": False}, ["execute_build"]),
+        (
+            {"success": False, "artifacts_urls": ["https://copr/builder-live.log.gz"]},
+            ["execute_build", "diagnose_failure"],
+        ),
+    ],
+    ids=["success", "timeout", "no-logs", "diagnosis"],
+)
+@pytest.mark.asyncio
+async def test_build_workflow_routes_real_steps(build_input, monkeypatch, build_result, steps):
+    session = AsyncMock()
+    session.call_tool.return_value = CallToolResult(
+        content=[TextContent(type="text", text=json.dumps(build_result))]
+    )
+    tool = MCPTool(
+        session, MCPToolInfo(name="build_package", inputSchema=BuildInputSchema.model_json_schema())
+    )
+    analyst = SimpleNamespace(
+        run=AsyncMock(
+            return_value=SimpleNamespace(last_message=SimpleNamespace(text='{"error": "Diagnosis"}'))
+        )
+    )
+    factory = MagicMock(return_value=analyst)
+    monkeypatch.setattr(build_agent, "create_build_failure_agent", factory)
+    visited = []
+
+    def on_step(data, event):
+        if event.name == "start" and getattr(event.creator, "name", None) == "BuildWorkflow":
+            visited.append(data.step)
+
+    cleanup = Emitter.root().on("*.*", on_step)
+    try:
+        output = await _run(build_input, [tool])
+    finally:
+        cleanup()
+
+    assert visited == steps
+    assert output.success == build_result["success"]
+    session.call_tool.assert_awaited_once()
+    assert factory.call_count == ("diagnose_failure" in steps)
+
+
+@pytest.mark.parametrize("has_extractor", [False, True])
+@pytest.mark.parametrize("has_downloader", [False, True])
+def test_failure_agent_has_no_build_or_edit_tools(monkeypatch, has_extractor, has_downloader):
+    names = ["build_package", "unrelated_tool"]
+    if has_downloader:
+        names.append("download_artifacts")
+    if has_extractor:
+        names.append("extract_log_snippets")
+    tools = [SimpleNamespace(name=name) for name in names]
+    factory = MagicMock()
+    monkeypatch.setattr(build_agent, "ReasoningAgent", factory)
+    monkeypatch.setattr(build_agent, "get_chat_model", MagicMock())
+
+    build_agent.create_build_failure_agent(tools, {"working_directory": Path("/tmp")})
+
+    kwargs = factory.call_args.kwargs
+    available = {t.name for t in kwargs["tools"]}
+    has_gateway_log_tools = has_extractor and has_downloader
+    assert ("download_artifacts" in available) == has_gateway_log_tools
+    assert "build_package" not in available
+    assert "unrelated_tool" not in available
+    assert not available.intersection({"create", "insert", "str_replace", "insert_after_substring"})
+    assert ("extract_log_snippets" in available) == has_gateway_log_tools
+    local_tools = {"run_shell_command", "view", "search_text", "get_cwd"}
+    assert available.intersection(local_tools) == (set() if has_gateway_log_tools else local_tools)
+    extractor_requirements = [
+        requirement for requirement in kwargs["requirements"] if requirement.source == "extract_log_snippets"
+    ]
+    assert len(extractor_requirements) == int(has_gateway_log_tools)
+    if has_gateway_log_tools:
+        assert extractor_requirements[0]._after == {"download_artifacts"}
+        assert "accessible through `extract_log_snippets`" in kwargs["instructions"]
+    else:
+        assert "extract_log_snippets" not in kwargs["instructions"]
+        assert "download_artifacts" not in kwargs["instructions"]
+        assert "local sandbox" in kwargs["instructions"]
+        assert "artifacts_urls" in kwargs["instructions"]
+    assert "Do not submit or retry a build" in kwargs["instructions"]

--- a/ymir/agents/tests/unit/test_jinja2_templates.py
+++ b/ymir/agents/tests/unit/test_jinja2_templates.py
@@ -32,8 +32,9 @@ def render_template(template_name: str, input: BaseModel | None = None) -> str:
 try:
     from ymir.common.models import (
         BackportInputSchema,
-        BuildInputSchema,
+        BuildFailureAnalysisInput,
         BuildInstructionsInput,
+        BuildResult,
         InheritAdaptationInputSchema,
         LogInputSchema,
         MergeRequestInputSchema,
@@ -46,10 +47,16 @@ except ImportError:
     class BuildInstructionsInput(BaseModel):  # type: ignore[no-redef]
         has_extract_log_snippets: bool = False
 
-    class BuildInputSchema(BaseModel):  # type: ignore[no-redef]
+    class BuildResult(BaseModel):  # type: ignore[no-redef]
+        success: bool
+        error_message: str | None = None
+        artifacts_urls: list[str] | None = None
+
+    class BuildFailureAnalysisInput(BaseModel):  # type: ignore[no-redef]
         srpm_path: Path
         dist_git_branch: str
         jira_issue: str
+        build_result: BuildResult
 
     class LogInputSchema(BaseModel):  # type: ignore[no-redef]
         jira_issue: str
@@ -120,22 +127,25 @@ class TestBuildInstructions:
             "build/instructions.j2",
             BuildInstructionsInput(has_extract_log_snippets=True),
         )
-        assert "expert on building packages" in result
-        assert "build_package" in result
+        assert "expert on analyzing package build failures" in result
+        assert "Do not submit or retry a build" in result
         assert "builder-live.log" in result
         assert "extract_log_snippets" in result
-        assert "start with" not in result
+        assert "Start with" not in result
 
     def test_loads_without_extract_log_snippets(self):
         result = render_template(
             "build/instructions.j2",
             BuildInstructionsInput(has_extract_log_snippets=False),
         )
-        assert "expert on building packages" in result
-        assert "build_package" in result
+        assert "expert on analyzing package build failures" in result
+        assert "Do not submit or retry a build" in result
         assert "builder-live.log" in result
         assert "extract_log_snippets" not in result
-        assert "start with" in result
+        assert "download_artifacts" not in result
+        assert "local sandbox" in result
+        assert "artifacts_urls" in result
+        assert "Start with" in result
 
 
 class TestLogInstructions:
@@ -212,15 +222,24 @@ class TestBuildTemplate:
     def test_renders_variables(self):
         result = render_template(
             "build/prompt.j2",
-            BuildInputSchema(
+            BuildFailureAnalysisInput(
                 srpm_path=Path("/tmp/pkg-1.0-1.el9.src.rpm"),
                 dist_git_branch="c9s",
                 jira_issue="RHEL-12345",
+                build_result=BuildResult(
+                    success=False,
+                    error_message="Build 123 failed",
+                    artifacts_urls=["https://copr/123/builder-live.log.gz"],
+                ),
             ),
         )
         assert "/tmp/pkg-1.0-1.el9.src.rpm" in result
         assert "c9s" in result
         assert "RHEL-12345" in result
+        assert "Build 123 failed" in result
+        assert "https://copr/123/builder-live.log.gz" in result
+        assert '"success": false' in result
+        assert "Do not submit another build" in result
 
 
 class TestLogTemplate:
@@ -661,10 +680,11 @@ class TestRenderTemplate:
         """Templates with variables are rendered correctly."""
         result = render_template(
             "build/prompt.j2",
-            BuildInputSchema(
+            BuildFailureAnalysisInput(
                 srpm_path=Path("/tmp/test.src.rpm"),
                 dist_git_branch="c10s",
                 jira_issue="RHEL-99999",
+                build_result=BuildResult(success=False),
             ),
         )
         assert "RHEL-99999" in result
@@ -674,10 +694,11 @@ class TestRenderTemplate:
         """Path objects are serialized as strings, not PosixPath repr."""
         result = render_template(
             "build/prompt.j2",
-            BuildInputSchema(
+            BuildFailureAnalysisInput(
                 srpm_path=Path("/tmp/test.src.rpm"),
                 dist_git_branch="c10s",
                 jira_issue="RHEL-1",
+                build_result=BuildResult(success=False),
             ),
         )
         assert "PosixPath" not in result

--- a/ymir/agents/tests/unit/test_mr_consolidation_build.py
+++ b/ymir/agents/tests/unit/test_mr_consolidation_build.py
@@ -1,0 +1,143 @@
+"""Consolidation can validate builds even when commits have no Jira footers."""
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from beeai_framework.tools.mcp import MCPTool
+from beeai_framework.workflows import Workflow
+from mcp.types import CallToolResult, TextContent
+from mcp.types import Tool as MCPToolInfo
+
+from ymir.agents import mr_consolidation_agent
+from ymir.common.models import MRConsolidationOutputSchema
+
+
+@pytest.mark.parametrize(
+    "package,branch",
+    [
+        ("compat-libstdc++-33", "c10s"),
+        ("package", "rhel/10.1"),
+        ("a" * 81, "c10s"),
+        ("a" * 82, "c10s"),
+    ],
+)
+def test_fallback_build_project_is_valid_and_stable(package, branch):
+    project = mr_consolidation_agent._build_project_name(package, branch)
+
+    assert re.fullmatch(r"[A-Za-z0-9_.-]+", project)
+    assert len(project) <= 100
+    assert project == mr_consolidation_agent._build_project_name(package, branch)
+    if package == "a" * 81:
+        assert project == f"consolidation-{package}-{branch}"
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [
+        (("compat-libstdc++-33", "c10s"), ("compat-libstdc--33", "c10s")),
+        (("a" * 100 + "b", "c10s"), ("a" * 100 + "c", "c10s")),
+        (("a" * 100, "c9s"), ("a" * 100, "c10s")),
+    ],
+)
+def test_fallback_build_projects_remain_distinct(first, second):
+    assert mr_consolidation_agent._build_project_name(*first) != mr_consolidation_agent._build_project_name(
+        *second
+    )
+
+
+@pytest.mark.parametrize("jira_issue", [None, "RHEL-12345"])
+@pytest.mark.parametrize("release_strategy", ["per_commit", "merged"])
+@pytest.mark.parametrize("retry_first", [False, True])
+@pytest.mark.parametrize("package", ["package", "compat-libstdc++-33", "package" * 30])
+@pytest.mark.asyncio
+async def test_build_project_identifier_preserves_jira_metadata(
+    monkeypatch, jira_issue, release_strategy, retry_first, package
+):
+    session = AsyncMock()
+    results = [{"success": True}]
+    if retry_first:
+        results.insert(0, {"success": False, "error_message": "Build failed"})
+    session.call_tool.side_effect = [
+        CallToolResult(content=[TextContent(type="text", text=json.dumps(result))]) for result in results
+    ]
+    # The real build_package contract requires a string project identifier,
+    # even though the workflow's Jira metadata is optional.
+    tool = MCPTool(
+        session,
+        MCPToolInfo(
+            name="build_package",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "srpm_path": {"type": "string"},
+                    "dist_git_branch": {"type": "string"},
+                    "jira_issue": {"type": "string"},
+                },
+                "required": ["srpm_path", "dist_git_branch", "jira_issue"],
+            },
+        ),
+    )
+    gateway = MagicMock()
+    gateway.__aenter__.return_value = [tool]
+    monkeypatch.setattr(mr_consolidation_agent, "mcp_tools", MagicMock(return_value=gateway))
+    monkeypatch.setattr(mr_consolidation_agent, "create_log_agent", MagicMock())
+    monkeypatch.setattr(mr_consolidation_agent, "get_mock_local_tool_env", lambda _: None)
+    monkeypatch.setenv("MCP_GATEWAY_URL", "http://gateway.invalid/sse")
+
+    run_workflow = Workflow.run
+    completed = []
+
+    def stop_after_build(state):
+        completed.append(state)
+        return Workflow.END
+
+    def start_at_build(workflow, state, options=None):
+        if workflow.name == "MRConsolidationWorkflow":
+            # Start after SRPM preparation and stop before publication. Run the
+            # real consolidation build step, nested BuildWorkflow and MCPTool.
+            state.jira_issue = jira_issue
+            state.jira_issues_collected = [jira_issue] if jira_issue else []
+            state.consolidation_result = MRConsolidationOutputSchema(
+                success=True,
+                status="Prepared SRPM",
+                srpm_path=Path("/git-repos/package/package-1-1.src.rpm"),
+            )
+            workflow.set_start("run_build_agent")
+            retry_step = "per_commit_flow" if release_strategy == "per_commit" else "run_consolidation_agent"
+            workflow.steps[retry_step].handler = lambda _: "run_build_agent"
+            workflow.steps["push_and_open_mr"].handler = stop_after_build
+            workflow.steps["update_release"].handler = stop_after_build
+        return run_workflow(workflow, state, options)
+
+    monkeypatch.setattr(Workflow, "run", start_at_build)
+    state = await mr_consolidation_agent.run_workflow(
+        package=package,
+        dist_git_branch="c10s",
+        release_strategy=release_strategy,
+        dry_run=True,
+        consolidation_agent_factory=MagicMock(),
+    )
+
+    assert len(completed) == 1, "Build validation did not reach its success route"
+    assert session.call_tool.await_count == len(results)
+    project = session.call_tool.await_args_list[0].kwargs["arguments"]["jira_issue"]
+    assert re.fullmatch(r"[A-Za-z0-9_.-]+", project)
+    assert len(project) <= 100
+    if jira_issue:
+        assert project == jira_issue
+    elif package == "package":
+        assert project == "consolidation-package-c10s"
+    else:
+        assert project.startswith("consolidation-")
+    for call in session.call_tool.await_args_list:
+        assert call.kwargs["arguments"] == {
+            "srpm_path": "/git-repos/package/package-1-1.src.rpm",
+            "dist_git_branch": "c10s",
+            "jira_issue": project,
+        }
+    assert state.jira_issue == jira_issue
+    assert state.jira_issues_collected == ([jira_issue] if jira_issue else [])
+    assert state.attempts_remaining == 3 - int(retry_first)

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -733,20 +733,43 @@ class BuildInstructionsInput(BaseModel):
 
     has_extract_log_snippets: bool = Field(
         default=False,
-        description="Whether the extract_log_snippets tool is available",
+        description="Whether both gateway log download and extraction tools are available",
     )
 
 
 class BuildInputSchema(BaseModel):
-    """Input schema for the build agent."""
+    """Inputs for deterministic Copr build execution."""
 
     srpm_path: Path = Field(description="Path to SRPM to build")
     dist_git_branch: str = Field(description="dist-git branch to update")
     jira_issue: str | None = Field(description="Jira issue to reference as resolved")
 
 
+class BuildResult(BaseModel):
+    """Structured result shared by the Copr tool and its workflow callers."""
+
+    success: bool = Field(description="Whether the build succeeded")
+    is_timeout: bool = Field(default=False, description="Whether the build failed due to a timeout")
+    error_message: str | None = Field(description="Error message in case of failure", default=None)
+    artifacts_urls: list[str] | None = Field(
+        description="URLs to build artifacts (logs and RPM files)", default=None
+    )
+
+
+class BuildFailureAnalysisInput(BuildInputSchema):
+    """Give the analyst an existing failed build, never a request to submit one."""
+
+    build_result: BuildResult
+
+
+class BuildFailureAnalysisOutput(BaseModel):
+    error: str = Field(
+        min_length=1, description="Explanation of the existing build failure based on its logs"
+    )
+
+
 class BuildOutputSchema(BaseModel):
-    """Output schema for the build agent."""
+    """Build outcome for workflow routing, with optional LLM failure diagnosis."""
 
     success: bool = Field(description="Whether the build was successfully completed")
     error: str | None = Field(description="Specific details about an error")

--- a/ymir/common/pyproject.toml
+++ b/ymir/common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-common"
-version = "0.6.0"
+version = "0.7.0"
 description = "Common utilities shared across Ymir AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]

--- a/ymir/common/tests/unit/test_run_tool.py
+++ b/ymir/common/tests/unit/test_run_tool.py
@@ -1,0 +1,123 @@
+"""Shared tool execution preserves raw results unless a schema is requested."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from beeai_framework.tools import Tool, ToolError
+from beeai_framework.tools.types import JSONToolOutput, StringToolOutput
+from mcp.types import TextContent
+from pydantic import BaseModel, ValidationError
+
+from ymir.common.utils import run_tool
+
+
+class ExampleResult(BaseModel):
+    value: int
+
+
+@pytest.fixture
+def tool():
+    tool = MagicMock(spec=Tool)
+    tool.name = "example"
+    tool.run.return_value.middleware = AsyncMock()
+    return tool
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        (StringToolOutput("ordinary text"), "ordinary text"),
+        (StringToolOutput('{"value": 42}'), '{"value": 42}'),
+        (StringToolOutput("42"), "42"),
+        (JSONToolOutput({"value": 42}), {"value": 42}),
+        (JSONToolOutput({"result": {"value": 42}}), {"value": 42}),
+        (JSONToolOutput(TextContent(type="text", text="ordinary text")), "ordinary text"),
+        (
+            JSONToolOutput([TextContent(type="text", text="first"), {"result": {"value": 42}}]),
+            ["first", {"value": 42}],
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_raw_results_are_unchanged(tool, output, expected):
+    tool.run.return_value.middleware.return_value = output
+
+    assert await run_tool(tool, query="hello") == expected
+
+    tool.run.assert_called_once_with(input={"query": "hello"})
+    tool.run.return_value.middleware.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        StringToolOutput('{"value": 42}'),
+        JSONToolOutput({"value": 42}),
+        JSONToolOutput({"result": {"value": 42}}),
+        JSONToolOutput(TextContent(type="text", text='{"value": 42}')),
+    ],
+)
+@pytest.mark.parametrize("by_name", [False, True])
+@pytest.mark.asyncio
+async def test_expected_output_decodes_and_validates(tool, output, by_name):
+    tool.run.return_value.middleware.return_value = output
+
+    result = await run_tool(
+        tool.name if by_name else tool,
+        available_tools=[tool],
+        expected_output=ExampleResult,
+        query="hello",
+    )
+
+    assert isinstance(result, ExampleResult)
+    assert result.value == 42
+    # The output schema is a helper option, never a tool input.
+    tool.run.assert_called_once_with(input={"query": "hello"})
+    tool.run.return_value.middleware.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        StringToolOutput("not json"),
+        JSONToolOutput({}),
+        JSONToolOutput({"value": "not an integer"}),
+        JSONToolOutput([]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_invalid_expected_output_raises_without_retry(tool, output):
+    tool.run.return_value.middleware.return_value = output
+
+    with pytest.raises(ValidationError):
+        await run_tool(tool, expected_output=ExampleResult)
+
+    tool.run.assert_called_once()
+    tool.run.return_value.middleware.assert_awaited_once()
+
+
+@pytest.mark.parametrize("available", ["none", "empty", "unrelated"])
+@pytest.mark.asyncio
+async def test_missing_tool_raises_tool_error(tool, available):
+    tools = {"none": None, "empty": [], "unrelated": [tool]}[available]
+
+    with pytest.raises(ToolError, match="missing_tool"):
+        await run_tool("missing_tool", available_tools=tools)
+
+    tool.run.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "error", [ToolError("tool failed"), RuntimeError("unexpected"), asyncio.CancelledError()]
+)
+@pytest.mark.asyncio
+async def test_execution_errors_propagate_without_retry(tool, error):
+    tool.run.return_value.middleware.side_effect = error
+
+    with pytest.raises(type(error)) as exc:
+        await run_tool(tool, expected_output=ExampleResult)
+
+    assert exc.value is error
+    tool.run.assert_called_once()
+    tool.run.return_value.middleware.assert_awaited_once()

--- a/ymir/common/utils.py
+++ b/ymir/common/utils.py
@@ -9,17 +9,18 @@ from collections.abc import AsyncGenerator, Callable
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar, overload
 
 import httpx
 import koji
 from beeai_framework.middleware.trajectory import GlobalTrajectoryMiddleware
-from beeai_framework.tools import Tool
+from beeai_framework.tools import Tool, ToolError
 from beeai_framework.tools.mcp import MCPTool
 from beeai_framework.tools.types import JSONToolOutput, StringToolOutput
 from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.types import CallToolResult, TextContent
+from pydantic import BaseModel
 from specfile import Specfile
 from specfile.sourcelist import Sourcelist
 from specfile.sources import Patches, Sources
@@ -38,6 +39,8 @@ logger = logging.getLogger(__name__)
 
 FIXED_IN_BUILD_CUSTOM_FIELD = "customfield_10578"
 DOWNSTREAM_COMPONENT_CUSTOM_FIELD = "customfield_10669"  # Downstream Component Name
+
+ToolResultT = TypeVar("ToolResultT", bound=BaseModel)
 
 
 class _MetaInjectingSession:
@@ -82,13 +85,44 @@ def get_absolute_path(path: Path, tool: Tool) -> Path:
     return Path(cwd) / path
 
 
+@overload
 async def run_tool(
     tool: str | Tool,
     available_tools: list[Tool] | None = None,
+    *,
+    expected_output: type[ToolResultT],
     **kwargs: Any,
-) -> str | dict | list:
+) -> ToolResultT: ...
+
+
+@overload
+async def run_tool(
+    tool: str | Tool,
+    available_tools: list[Tool] | None = None,
+    *,
+    expected_output: None = None,
+    **kwargs: Any,
+) -> str | dict | list: ...
+
+
+async def run_tool(
+    tool: str | Tool,
+    available_tools: list[Tool] | None = None,
+    *,
+    expected_output: type[ToolResultT] | None = None,
+    **kwargs: Any,
+) -> ToolResultT | str | dict | list:
+    """Run a tool once, optionally decoding and validating its result as a model.
+
+    Without ``expected_output``, preserve the unwrapped result, including plain
+    text. With a schema, accept either JSON text or structured data and let
+    validation errors propagate to the caller.
+    """
     if isinstance(tool, str):
-        tool = next(t for t in available_tools or [] if t.name == tool)
+        selected_tool = next((t for t in available_tools or [] if t.name == tool), None)
+        if selected_tool is None:
+            raise ToolError(f"Required tool '{tool}' is unavailable")
+        tool = selected_tool
     output = await tool.run(input=kwargs).middleware(
         GlobalTrajectoryMiddleware(pretty=True, target=get_trajectory_writeable())
     )
@@ -100,8 +134,14 @@ async def run_tool(
         case _:
             result = str(output)
     if isinstance(result, list):
-        return [_unpack_tool_result(item) for item in result]
-    return _unpack_tool_result(result)
+        result = [_unpack_tool_result(item) for item in result]
+    else:
+        result = _unpack_tool_result(result)
+    if expected_output is not None:
+        if isinstance(result, str):
+            return expected_output.model_validate_json(result)
+        return expected_output.model_validate(result)
+    return result
 
 
 def _unpack_tool_result(result: Any) -> Any:

--- a/ymir/tools/privileged/copr.py
+++ b/ymir/tools/privileged/copr.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 
 from ymir.common import load_rhel_config
 from ymir.common.base_utils import KerberosError, init_kerberos_ticket
+from ymir.common.models import BuildResult
 from ymir.common.validators import AbsolutePath
 from ymir.common.version_utils import parse_branch_name
 from ymir.tools.base import CloneableTool as Tool
@@ -79,15 +80,6 @@ async def _copr_api_call(func, *args, **kwargs):
             )
             await asyncio.sleep(delay)
     raise RuntimeError("unreachable")
-
-
-class BuildResult(BaseModel):
-    success: bool = Field(description="Whether the build succeeded")
-    is_timeout: bool = Field(default=False, description="Whether the build failed due to a timeout")
-    error_message: str | None = Field(description="Error message in case of failure", default=None)
-    artifacts_urls: list[str] | None = Field(
-        description="URLs to build artifacts (logs and RPM files)", default=None
-    )
 
 
 class BuildPackageToolInput(BaseModel):

--- a/ymir/tools/privileged/tests/unit/test_copr.py
+++ b/ymir/tools/privileged/tests/unit/test_copr.py
@@ -10,6 +10,7 @@ from copr.v3 import BuildProxy, ProjectChrootProxy, ProjectProxy
 from copr.v3.exceptions import CoprException
 from flexmock import flexmock
 
+from ymir.common.models import BuildResult
 from ymir.tools.privileged import copr as copr_tools
 from ymir.tools.privileged.copr import (
     COPR_API_MAX_RETRIES,
@@ -150,6 +151,7 @@ async def test_build_package(build_failure, build_timeout, exclusive_arch, dist_
         }
     )
     result = out.result
+    assert isinstance(result, BuildResult)
     assert result.success == (not build_failure)
     assert result.is_timeout == build_timeout
     assert any(url.endswith("builder-live.log.gz") for url in result.artifacts_urls)

--- a/ymir/tools/pyproject.toml
+++ b/ymir/tools/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ymir-tools"
-version = "0.7.0"
+version = "0.7.1"
 description = "Ymir MCP tools for AI workflows"
 requires-python = ">=3.13"
 dynamic = ["dependencies"]

--- a/ymir/tools/requirements.txt
+++ b/ymir/tools/requirements.txt
@@ -1,5 +1,5 @@
 # Dependencies specific to ymir-tools
-ymir-common>=0.1.0
+ymir-common>=0.7.0
 aiohttp>=3.12.15
 copr>=1.129
 flexmock>=0.12.2


### PR DESCRIPTION
Call the existing build tool deterministically so successful builds no longer require model orchestration. Share the structured Copr result schema and invoke a diagnosis-only agent for failed builds with logs.

Migrate backport, inheritance, rebase, MR updates, and consolidation while preserving their timeout and retry policies. Keep rebuild and the incremental backport repair loop unchanged.

Add regression tests for gateway decoding, zero-LLM success handling, error classification, cancellation, and diagnosis without resubmission. Document the shared build flow and its dry-run behavior.

Validation: 64 focused container tests passed; Ruff lint and format checks passed. Broader container testing found two gateway startup test failures and the same missing-MCP-settings error in the install smoke test. The gateway test failures also reproduce on unchanged commit 00d2ba6. Other component suites passed.

Assisted-by: Codex

I've ran e2e test for build succeeding on first try and build failing on the first time with the need to fix it. No regressions were found. GPT-6 Astra estimates around 8% of token cost savings per backport task.