### PR TITLE
Avoid git branch collision when fetching branches

### DIFF
--- a/ymir/tools/privileged/gitlab.py
+++ b/ymir/tools/privileged/gitlab.py
@@ -640,7 +640,7 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
         if branch:
             clone_path.mkdir(parents=True, exist_ok=True)
             await _run_git_cmd(
-                ["git", "init"],
+                ["git", "init", "-b", "_ymir_init"],
                 label=f"git init {clone_path}",
                 cwd=clone_path,
                 env=git_env,
@@ -648,7 +648,7 @@ class CloneRepositoryTool(Tool[CloneRepositoryToolInput, ToolRunOptions, StringT
             )
 
             await _run_git_cmd(
-                ["git", *auth_args, "fetch", repository, f"{branch}:refs/heads/{branch}"],
+                ["git", *auth_args, "fetch", repository, f"refs/heads/{branch}:refs/heads/{branch}"],
                 label=f"git fetch {safe_url} branch={branch}",
                 cwd=clone_path,
                 env=git_env,
@@ -757,7 +757,7 @@ class FetchBranchTool(Tool[FetchBranchToolInput, ToolRunOptions, StringToolOutpu
         git_env = _get_mock_git_env()
 
         await _run_git_cmd(
-            ["git", *auth_args, "fetch", repository, f"{branch}:refs/heads/{branch}"],
+            ["git", *auth_args, "fetch", repository, f"refs/heads/{branch}:refs/heads/{branch}"],
             label=f"git fetch {safe_url} branch={branch}",
             cwd=clone_path,
             env=git_env,

--- a/ymir/tools/privileged/tests/unit/test_gitlab.py
+++ b/ymir/tools/privileged/tests/unit/test_gitlab.py
@@ -410,10 +410,10 @@ async def test_clone_repository(mock_git_repo_basepath):
         assert cmd == "git"
         assert kwargs.get("cwd") == clone_path
         if args[0] == "init":
-            assert len(args) == 1
+            assert args[1:] == ("-b", "_ymir_init")
         elif args[0] == "fetch":
             assert args[1].endswith(repository.removeprefix("https://"))
-            assert args[2] == f"{branch}:refs/heads/{branch}"
+            assert args[2] == f"refs/heads/{branch}:refs/heads/{branch}"
         elif args[0] == "checkout":
             assert args[1] == branch
         else:
@@ -1234,7 +1234,7 @@ async def test_clone_repository_removes_existing_dir_with_branch(mock_git_repo_b
     )
 
     assert not (clone_path / "stale").exists()
-    assert any(cmd[:2] == ["git", "init"] for cmd in commands)
+    assert any(cmd[:4] == ["git", "init", "-b", "_ymir_init"] for cmd in commands)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This patch covers 2 collision cases:

1) Tag/branch collision: the fetch refspec with refs/heads/ so git fetches the branch, never the tag.

2) Default branch collision: git init -b _ymir_init so the init's default branch doesn't conflict with the branch being fetched (eg main / master / etc).

Note the _ymir_init branch is just a dummy name to give the init something to work with, since no commits land on that branch it should not be pushed or used anywhere otherwise.
