### PR TITLE
Add explicit instructions to not mess up RPM specs

### DIFF
--- a/ymir/agents/prompts/backport/instructions.j2
+++ b/ymir/agents/prompts/backport/instructions.j2
@@ -295,6 +295,8 @@ General instructions:
 - If necessary, you can run `git checkout -- <FILE>` to revert any changes done to <FILE>.
 - Never change anything in the spec file changelog.
 - Preserve existing formatting and style conventions in spec files and patch headers.
+- Do not simplify, unwrap, or rewrite existing RPM macro definitions or conditional
+  expressions in spec files.
 - Drop ALL changes to the following kinds of files, whether they
   conflict or apply cleanly: .github/ workflows, .gitignore,
   news/changelog files (e.g. Changes, NEWS, ChangeLog), and

--- a/ymir/agents/prompts/backport/instructions_zstream.j2
+++ b/ymir/agents/prompts/backport/instructions_zstream.j2
@@ -291,6 +291,8 @@ General instructions:
 - Never change anything in the spec file changelog.
 - Never change the Release field in the spec file.
 - Preserve existing formatting and style conventions in spec files and patch headers.
+- Do not simplify, unwrap, or rewrite existing RPM macro definitions or conditional
+  expressions in spec files.
 - Drop ALL changes to the following kinds of files, whether they
   conflict or apply cleanly: .github/ workflows, .gitignore,
   news/changelog files (e.g. Changes, NEWS, ChangeLog), and

--- a/ymir/agents/prompts/mr_consolidation/instructions.j2
+++ b/ymir/agents/prompts/mr_consolidation/instructions.j2
@@ -79,6 +79,8 @@ General instructions:
 - Never run `git fetch`, `git pull`, or `git clone`. All branches you need are already
   available locally. If a branch appears empty, work with what is available.
 - Preserve existing formatting and style conventions in spec files and patch headers.
+- Do not simplify, unwrap, or rewrite existing RPM macro definitions or conditional
+  expressions in spec files.
 - If there is a complex conflict, properly resolve it by keeping the functionality of both patches.
 - There is a firewall in place that may block some outgoing network requests
   (e.g. curl, wget, git clone to external hosts). If a shell command fails

--- a/ymir/agents/prompts/rebase/instructions.j2
+++ b/ymir/agents/prompts/rebase/instructions.j2
@@ -89,6 +89,8 @@ General instructions:
 - If necessary, you can run `git checkout -- <FILE>` to revert any changes done to <FILE>.
 - Never change anything in the spec file changelog.
 - Preserve existing formatting and style conventions in spec files and patch headers.
+- Do not simplify, unwrap, or rewrite existing RPM macro definitions or conditional
+  expressions in spec files.
 - Prefer native tools, if available, the `run_shell_command` tool should be the last resort.
 - If the package calls `autoreconf` in `%prep` and the rebase fails
   because of a version constraint,


### PR DESCRIPTION
This patch adds explicit instructions to all spec-editing prompts: don't modify RPM macro definitions or conditional macro constructs.

We ran into issues with consolidation agent that just edited the spec like this for no apparent reason:

-%{?!apply_patch:%define apply_patch(qp:m:) {%__apply_patch %**}}
+%define apply_patch(qp:m:) {%__apply_patch %**}

This can theoretically happen with other spec modifying agents. While its not clear why that happens, perhaps it has tried to "simplify" things or just hallucinated an edit, its best to put some guardrails against it at least at the prompts level for now (it doesnt seem to happen often, could be a one off / rare condition) as atm i cant think of any legit reasons for agents to modify those things.

