### PR TITLE
Avoid calling unversioned python

### DIFF
--- a/openshift/cronjob-supervisor-collector.yml
+++ b/openshift/cronjob-supervisor-collector.yml
@@ -31,7 +31,7 @@ spec:
             image: 'supervisor:prod'
             imagePullPolicy: IfNotPresent
             command:
-            - /usr/bin/python
+            - /usr/bin/python3
             args:
             - -m
             - supervisor.main

--- a/openshift/deployment-backport-agent-c10s.yml
+++ b/openshift/deployment-backport-agent-c10s.yml
@@ -25,7 +25,7 @@ spec:
         - -m
         - ymir.agents.backport_agent
         command:
-        - /usr/bin/python
+        - /usr/bin/python3
         env:
         - name: CONTAINER_VERSION
           value: "c10s"

--- a/openshift/deployment-mr-consolidation-agent-c10s.yml
+++ b/openshift/deployment-mr-consolidation-agent-c10s.yml
@@ -22,7 +22,7 @@ spec:
         - -m
         - ymir.agents.mr_consolidation_agent
         command:
-        - /usr/bin/python
+        - /usr/bin/python3
         env:
         - name: CONTAINER_VERSION
           value: "c10s"

--- a/openshift/deployment-rebase-agent-c10s.yml
+++ b/openshift/deployment-rebase-agent-c10s.yml
@@ -25,7 +25,7 @@ spec:
         - -m
         - ymir.agents.rebase_agent
         command:
-        - /usr/bin/python
+        - /usr/bin/python3
         env:
         - name: CONTAINER_VERSION
           value: "c10s"

--- a/openshift/deployment-rebuild-agent-c10s.yml
+++ b/openshift/deployment-rebuild-agent-c10s.yml
@@ -25,7 +25,7 @@ spec:
         - -m
         - ymir.agents.rebuild_agent
         command:
-        - /usr/bin/python
+        - /usr/bin/python3
         env:
         - name: CONTAINER_VERSION
           value: "c10s"

--- a/openshift/deployment-reproducer-agent.yml
+++ b/openshift/deployment-reproducer-agent.yml
@@ -23,7 +23,7 @@ spec:
         - -m
         - ymir.agents.reproducer_agent
         command:
-        - /usr/bin/python
+        - /usr/bin/python3
         env:
         - name: REQUESTS_CA_BUNDLE
           value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem

--- a/openshift/deployment-supervisor-processor.yml
+++ b/openshift/deployment-supervisor-processor.yml
@@ -22,7 +22,7 @@ spec:
         image: 'supervisor:prod'
         imagePullPolicy: IfNotPresent
         command:
-        - /usr/bin/python
+        - /usr/bin/python3
         args:
         - -m
         - supervisor.main

--- a/openshift/deployment-triage-agent.yml
+++ b/openshift/deployment-triage-agent.yml
@@ -25,7 +25,7 @@ spec:
         - -m
         - ymir.agents.triage_agent
         command:
-        - /usr/bin/python
+        - /usr/bin/python3
         env:
         - name: REQUESTS_CA_BUNDLE
           value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem


### PR DESCRIPTION
It's installed in c10s images as a weak dependency of python3, which means the dnf transaction can end successfully even without it being installable (due to a network error or similar).