### PR TITLE
Keep backport repair diagnostics out of generated patches

### DIFF
--- a/README-agents.md
+++ b/README-agents.md
@@ -73,6 +73,14 @@ incremental repair agent's own edit/build loop is also unchanged. Dry-run mode
 still performs real build validation; it does not turn a build into a success
 without running it.
 
+Incremental backport repairs keep `fix-attempts.md` and archived build logs in
+`<local_clone>-build-logs`, beside the dist-git and upstream checkouts. This
+preserves diagnostic history between repair attempts without allowing Git
+staging in either checkout to include those files in generated patches. The
+repair prompt provides the file path for reading previous attempts and
+appending the outcome. The directory is removed with the issue's working
+directory on a fresh run.
+
 ## Dry run mode
 
 **Without setting `DRY_RUN=true` env var, agents will make real changes:**

--- a/ymir/agents/backport_agent.py
+++ b/ymir/agents/backport_agent.py
@@ -81,6 +81,7 @@ from ymir.common.logging_setup import configure_logging, current_jira_issue, get
 from ymir.common.mock_repos import get_mock_local_tool_env
 from ymir.common.models import (
     BackportData,
+    BackportFixBuildInputSchema,
     BackportInputSchema,
     BackportOutputSchema,
     BuildInputSchema,
@@ -283,6 +284,11 @@ async def create_backport_agent(
         role="Red Hat Enterprise Linux developer",
         instructions=await get_instructions(fix_version),
     )
+
+
+def _get_build_logs_dir(local_clone: Path) -> Path:
+    """Keep repair diagnostics outside both dist-git and upstream Git worktrees."""
+    return local_clone.with_name(f"{local_clone.name}-build-logs")
 
 
 def _move_build_logs(source_dir: Path, target_dir: Path) -> None:
@@ -1034,7 +1040,7 @@ async def run_workflow(
                     )
                     return "fork_and_prepare_dist_git"
 
-                log_dir = upstream_repo / "build-logs"
+                log_dir = _get_build_logs_dir(state.local_clone)
                 log_dir.mkdir(parents=True, exist_ok=True)
                 attempt_num = state.incremental_fix_attempts + 1
 
@@ -1055,8 +1061,9 @@ async def run_workflow(
                 response = await fix_agent.run(
                     render_template(
                         await get_fix_build_error_prompt(fix_version=state.fix_version),
-                        BackportInputSchema(
+                        BackportFixBuildInputSchema(
                             local_clone=state.local_clone,
+                            build_logs_dir=log_dir,
                             unpacked_sources=state.unpacked_sources,
                             package=state.package,
                             dist_git_branch=state.dist_git_branch,
@@ -1155,7 +1162,7 @@ async def run_workflow(
                 if upstream_repo.exists():
                     _move_build_logs(
                         state.local_clone,
-                        upstream_repo / "build-logs" / "attempt-0",
+                        _get_build_logs_dir(state.local_clone) / "attempt-0",
                     )
                 logger.info("Cherry-pick workflow was used - starting incremental fix")
                 return "fix_build_error"

--- a/ymir/agents/prompts/backport/prompt_fix_build_error.j2
+++ b/ymir/agents/prompts/backport/prompt_fix_build_error.j2
@@ -64,12 +64,14 @@ CRITICAL CONSTRAINTS:
 
 - DO NOT commit any changes in {{ local_clone }} dist-git repository during the fix attempt.
   Keep all dist-git changes (patch files and spec edits) uncommitted until the build passes.
-  All your work is in {{ local_clone }}-upstream, which you can commit to freely.
+  Commit source fixes in {{ local_clone }}-upstream, staging only the intended source files.
+  Keep build logs and repair notes in {{ build_logs_dir }}, outside both Git repositories.
+  Do not copy these diagnostics into either repository or include them in generated patches.
 
 - Fix BOTH compilation errors AND test failures. NEVER skip or disable tests.
 - Make ONE attempt — you will be called again if the build still fails.
 
-Before you start: Read {{ local_clone }}-upstream/build-logs/fix-attempts.md for a log of
+Before you start: Read {{ build_logs_dir }}/fix-attempts.md for a log of
 previous fix attempts. Do NOT repeat strategies that already failed.
 
 WORKFLOW:
@@ -130,7 +132,7 @@ SPECIAL CONSIDERATIONS FOR TEST FAILURES:
      and identify the new error
 {% endif %}
 
-7. Append a summary to {{ local_clone }}-upstream/build-logs/fix-attempts.md documenting:
+7. Append a summary to {{ build_logs_dir }}/fix-attempts.md documenting:
    - What you identified as the root cause
    - Which commits you cherry-picked or what manual edits you made
    - Any BuildRequires or Requires additions to the spec file (if rules allowed

--- a/ymir/agents/tests/unit/test_backport_build_logs.py
+++ b/ymir/agents/tests/unit/test_backport_build_logs.py
@@ -1,0 +1,135 @@
+"""Build-repair diagnostics must not become part of generated source patches."""
+
+import subprocess
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+from beeai_framework.workflows import Workflow
+from flexmock import flexmock
+
+from ymir.agents import backport_agent
+from ymir.common.models import BackportOutputSchema, BuildOutputSchema
+from ymir.tools.unprivileged.wicked_git import GitPatchCreationTool
+
+
+@pytest.mark.parametrize("branch", ["c9s", "c10s"])
+@pytest.mark.asyncio
+async def test_build_repair_logs_stay_out_of_git(monkeypatch, tmp_path, branch):
+    local_clone = tmp_path / "expat"
+    upstream = tmp_path / "expat-upstream"
+    log_dir = tmp_path / "expat-build-logs"
+
+    def git(repo, *args):
+        return subprocess.run(
+            ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+        ).stdout.strip()
+
+    for repo, filename in ((local_clone, "expat.spec"), (upstream, "source.c")):
+        repo.mkdir()
+        git(repo, "init", "-q")
+        git(repo, "config", "user.name", "Ymir Tests")
+        git(repo, "config", "user.email", "ymir-tests@example.com")
+        (repo / filename).write_text("initial content\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-m", "Initial content")
+
+    base = git(upstream, "rev-parse", "HEAD")
+    patch_file = local_clone / "fix.patch"
+    patch_tool = GitPatchCreationTool(options={"base_head_commit": base})
+    (local_clone / "builder-live.log").write_text("initial build log")
+    (local_clone / "root.log.gz").write_bytes(b"initial compressed log")
+    attempts = []
+
+    async def repair(prompt, **kwargs):
+        attempt = len(attempts) + 1
+        attempts.append(prompt)
+        notes = log_dir / "fix-attempts.md"
+        assert notes.exists(), "Repair notes must be outside both Git checkouts"
+        assert str(notes) in prompt
+        assert notes.read_text() not in prompt, "Saved history should be read from the file as needed"
+        assert str(upstream / "build-logs") not in prompt
+        assert f"## Attempt {attempt}" in notes.read_text()
+        assert (log_dir / "attempt-0" / "builder-live.log").read_text() == "initial build log"
+        assert (log_dir / "attempt-0" / "root.log.gz").read_bytes() == b"initial compressed log"
+        if attempt == 2:
+            assert "First repair summary" in notes.read_text()
+            assert "First repair summary" not in prompt
+            assert "second build failure" in notes.read_text()
+            assert (log_dir / "attempt-1" / "builder-live.log").read_text() == "retry build log"
+
+        # Repeat the blanket staging that included fix-attempts.md in production.
+        (upstream / "source.c").write_text(f"int value = {attempt};\n")
+        git(upstream, "add", "-A")
+        git(upstream, "commit", "-m", f"Repair {attempt}")
+        await patch_tool.run({"repository_path": upstream, "patch_file_path": patch_file})
+        assert git(upstream, "diff", "--name-only", base, "HEAD") == "source.c"
+        assert "fix-attempts.md" not in patch_file.read_text()
+        assert "build-logs" not in patch_file.read_text()
+        assert f"+int value = {attempt};" in patch_file.read_text()
+
+        if attempt == 1:
+            (local_clone / "builder-live.log").write_text("retry build log")
+            with notes.open("a") as stream:
+                stream.write("\nFirst repair summary\n")
+        result = BackportOutputSchema(
+            success=attempt == 2,
+            status=f"Repair {attempt}",
+            srpm_path=local_clone / "expat.src.rpm",
+            error="second build failure" if attempt == 1 else None,
+        )
+        return SimpleNamespace(last_message=SimpleNamespace(text=result.model_dump_json()))
+
+    @asynccontextmanager
+    async def gateway(*args, **kwargs):
+        yield []
+
+    async def create_repair_agent(*args, **kwargs):
+        return flexmock(run=repair)
+
+    async def failed_build(**kwargs):
+        return BuildOutputSchema(success=False, error="initial build failure")
+
+    flexmock(backport_agent).should_receive("mcp_tools").replace_with(gateway).once()
+    flexmock(backport_agent).should_receive("create_log_agent").and_return(None).once()
+    flexmock(backport_agent).should_receive("get_mock_local_tool_env").and_return(None).once()
+    flexmock(backport_agent).should_receive("get_agent_execution_config").and_return({}).twice()
+    flexmock(backport_agent).should_receive("create_backport_agent").replace_with(create_repair_agent).twice()
+    flexmock(backport_agent).should_receive("run_build").replace_with(failed_build).once()
+    monkeypatch.setenv("MCP_GATEWAY_URL", "http://gateway.invalid/sse")
+
+    run_workflow = Workflow.run
+
+    def start_at_build(workflow, state, options=None):
+        state.local_clone = local_clone
+        state.unpacked_sources = upstream
+        state.used_cherry_pick_workflow = True
+        state.backport_result = BackportOutputSchema(
+            success=True,
+            status="Backported",
+            srpm_path=local_clone / "expat.src.rpm",
+            error=None,
+        )
+        workflow.set_start("run_build_agent")
+        # Exercise the real build-failure routing and both repair attempts,
+        # stopping before release bookkeeping or external writes.
+        workflow.steps["update_release"].handler = lambda _: Workflow.END
+        workflow.steps["comment_in_jira"].handler = lambda _: Workflow.END
+        return run_workflow(workflow, state, options)
+
+    monkeypatch.setattr(Workflow, "run", start_at_build)
+    state = await backport_agent.run_workflow(
+        package="expat",
+        dist_git_branch=branch,
+        upstream_patches=[],
+        jira_issue="RHEL-123",
+        cve_id=None,
+        dry_run=True,
+        backport_agent_factory=lambda *_: None,
+    )
+
+    assert state.backport_result.success, state.backport_result.error
+    assert len(attempts) == 2
+    git(local_clone, "add", "-A")
+    assert git(local_clone, "diff", "--cached", "--name-only") == "fix.patch"
+    assert not (upstream / "build-logs").exists()

--- a/ymir/agents/tests/unit/test_jinja2_templates.py
+++ b/ymir/agents/tests/unit/test_jinja2_templates.py
@@ -31,6 +31,7 @@ def render_template(template_name: str, input: BaseModel | None = None) -> str:
 
 try:
     from ymir.common.models import (
+        BackportFixBuildInputSchema,
         BackportInputSchema,
         BuildFailureAnalysisInput,
         BuildInstructionsInput,
@@ -85,6 +86,9 @@ except ImportError:
         build_error: str | None = None
         triage_summary: str | None = None
         has_extract_log_snippets: bool = False
+
+    class BackportFixBuildInputSchema(BackportInputSchema):  # type: ignore[no-redef]
+        build_logs_dir: Path
 
     class RebaseInputSchema(BaseModel):  # type: ignore[no-redef]
         local_clone: Path
@@ -371,8 +375,9 @@ class TestBackportFixBuildErrorTemplate:
     def test_renders_with_extract_log_snippets(self):
         result = render_template(
             "backport/prompt_fix_build_error.j2",
-            BackportInputSchema(
+            BackportFixBuildInputSchema(
                 local_clone=Path("/tmp/clone"),
+                build_logs_dir=Path("/tmp/clone-build-logs"),
                 unpacked_sources=Path("/tmp/sources"),
                 package="libfoo",
                 dist_git_branch="c9s",
@@ -384,15 +389,17 @@ class TestBackportFixBuildErrorTemplate:
         )
         assert "cherry-pick workflow succeeded but the build failed" in result
         assert "undefined reference" in result
-        assert "fix-attempts.md" in result
+        assert "Before you start: Read /tmp/clone-build-logs/fix-attempts.md" in result
+        assert "/tmp/clone-upstream/build-logs" not in result
         assert "extract_log_snippets" in result
         assert "start with" not in result
 
     def test_renders_without_extract_log_snippets(self):
         result = render_template(
             "backport/prompt_fix_build_error.j2",
-            BackportInputSchema(
+            BackportFixBuildInputSchema(
                 local_clone=Path("/tmp/clone"),
+                build_logs_dir=Path("/tmp/clone-build-logs"),
                 unpacked_sources=Path("/tmp/sources"),
                 package="libfoo",
                 dist_git_branch="c9s",
@@ -404,7 +411,8 @@ class TestBackportFixBuildErrorTemplate:
         )
         assert "cherry-pick workflow succeeded but the build failed" in result
         assert "undefined reference" in result
-        assert "fix-attempts.md" in result
+        assert "Before you start: Read /tmp/clone-build-logs/fix-attempts.md" in result
+        assert "/tmp/clone-upstream/build-logs" not in result
         assert "extract_log_snippets" not in result
         assert "get logs and identify the new error" in result
 

--- a/ymir/common/models.py
+++ b/ymir/common/models.py
@@ -189,6 +189,12 @@ class BackportInputSchema(BaseModel):
     )
 
 
+class BackportFixBuildInputSchema(BackportInputSchema):
+    """Build-repair context with a diagnostics directory outside the Git worktrees."""
+
+    build_logs_dir: Path = Field(description="Path to build logs and persistent repair notes")
+
+
 class BackportOutputSchema(BaseModel):
     """Output schema for the backport agent."""
 


### PR DESCRIPTION
Repair notes inside the upstream checkout could be staged by git add -A and exported into RPM patches. Store notes and archived build logs beside both Git checkouts, and pass the log path explicitly to the repair prompt.

Add c9s and c10s regression coverage for repeated repairs, persistent notes, and real Git staging and patch generation. Use flexmock for dependency mocks.

Assisted-by: Codex
